### PR TITLE
Foundation: establish project, documentation and security baseline

### DIFF
--- a/.context/README.md
+++ b/.context/README.md
@@ -1,0 +1,32 @@
+# Yukh MCP context system
+
+`.context/` is the repository-owned, durable operating memory for humans and agents.
+
+## Precedence
+
+When sources conflict:
+
+1. current explicit human instruction;
+2. accepted decisions;
+3. accepted RFCs;
+4. security and quality models;
+5. project charter and architecture;
+6. nearest `AGENTS.md`;
+7. governing Issue and pull request;
+8. latest applicable handoff;
+9. session records;
+10. temporary notes.
+
+Sessions and handoffs preserve continuity and evidence. They do not silently change architecture.
+
+## Records
+
+- `manifest.yaml`: machine-readable loading and write rules.
+- `decisions/`: durable decisions; accepted records are immutable.
+- `rfcs/`: substantial, costly, public-contract, or security proposals.
+- `handoffs/`: transfers of incomplete work.
+- `sessions/`: chronological evidence; non-authoritative.
+- `quality-attributes/`: measurable system requirements.
+- `templates/`: canonical record formats.
+
+Never store secrets, credentials, personal data, sensitive infrastructure details, or private reasoning in this public directory.

--- a/.context/decisions/ADR-0001-repository-context-system.md
+++ b/.context/decisions/ADR-0001-repository-context-system.md
@@ -1,0 +1,22 @@
+# ADR-0001 — Repository-owned context system
+
+- Status: Accepted
+- Date: 2026-08-02
+- Decider: project owner
+- Governing issue: Foundation initiative
+
+## Context
+
+Yukh MCP will be developed publicly by humans and multiple agents across tools and sessions. Chat history and tool-local memory are not durable or portable enough to govern security, architecture, scope, and delivery.
+
+## Decision
+
+Yukh MCP maintains durable operating memory under `.context/`. Accepted ADRs and RFCs are authoritative. Sessions and handoffs preserve continuity and evidence but cannot change architecture. Material acceptance remains a human decision.
+
+## Consequences
+
+The repository remains portable and auditable. Contributors incur a small context-maintenance cost. Accepted records are superseded rather than rewritten.
+
+## Security
+
+The context directory is public. Secrets, credentials, sensitive infrastructure data, personal data, and private reasoning are forbidden.

--- a/.context/manifest.yaml
+++ b/.context/manifest.yaml
@@ -1,0 +1,47 @@
+schema_version: 1
+project: yukh-mcp
+context_root: .context
+
+precedence:
+  - current_human_instruction
+  - accepted_decisions
+  - accepted_rfcs
+  - security_and_quality_models
+  - project_charter_and_architecture
+  - nearest_agents_md
+  - governing_issue_and_pull_request
+  - latest_applicable_handoff
+  - sessions
+  - temporary_notes
+
+records:
+  decisions:
+    path: .context/decisions
+    id_pattern: "ADR-{number:04d}"
+    immutable_after_acceptance: true
+  rfcs:
+    path: .context/rfcs
+    id_pattern: "RFC-{number:04d}"
+    required_for:
+      - public_contract_change
+      - trust_boundary_change
+      - authentication_or_authorization_change
+      - deployment_topology_change
+      - release_or_packaging_change
+  handoffs:
+    path: .context/handoffs
+    id_pattern: "HANDOFF-{date}-{sequence:02d}"
+  sessions:
+    path: .context/sessions
+    id_pattern: "SESSION-{date}-{sequence:02d}"
+    authoritative: false
+
+write_policy:
+  sessions: agents_allowed
+  handoffs: agents_allowed
+  decisions: proposal_allowed_human_acceptance_required
+  rfcs: proposal_allowed_human_acceptance_required
+  architecture_change_without_record: forbidden
+  security_change_without_record: forbidden
+  destructive_operation_without_explicit_approval: forbidden
+  secrets_or_private_reasoning: forbidden

--- a/.context/templates/decision.md
+++ b/.context/templates/decision.md
@@ -1,0 +1,20 @@
+# ADR-NNNN — Title
+
+- Status: Proposed
+- Date: YYYY-MM-DD
+- Deciders:
+- Governing issue:
+- Supersedes:
+- Superseded by:
+
+## Context
+
+## Decision
+
+## Consequences
+
+## Alternatives considered
+
+## Security
+
+## Evidence

--- a/.context/templates/handoff.md
+++ b/.context/templates/handoff.md
@@ -1,0 +1,18 @@
+# HANDOFF-YYYY-MM-DD-NN — Title
+
+- Governing issue:
+- From:
+- To:
+- Status:
+
+## Current state
+
+## Completed
+
+## Next actions
+
+## Evidence
+
+## Risks
+
+## Files and commands

--- a/.context/templates/rfc.md
+++ b/.context/templates/rfc.md
@@ -1,0 +1,26 @@
+# RFC-NNNN — Title
+
+- Status: Draft
+- Authors:
+- Created:
+- Governing issue:
+
+## Summary
+
+## Motivation
+
+## Goals
+
+## Non-goals
+
+## Detailed design
+
+## Trust boundaries and threat analysis
+
+## Compatibility
+
+## Rollout and rollback
+
+## Alternatives
+
+## Open questions

--- a/.context/templates/session.md
+++ b/.context/templates/session.md
@@ -1,0 +1,17 @@
+# SESSION-YYYY-MM-DD-NN — Title
+
+- Governing issue:
+- Pull request:
+- Status:
+
+## Objective
+
+## Work completed
+
+## Evidence and validation
+
+## Decisions discovered
+
+## Context impact
+
+## Risks and unresolved work

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,36 @@
+name: Bug report
+description: Report reproducible incorrect behavior that is not a vulnerability.
+title: "[Bug]: "
+labels: ["type:bug", "status:triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Do not disclose vulnerabilities here. Follow SECURITY.md.
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed behavior
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: Remove secrets, credentials, tokens, personal data, and infrastructure identifiers.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Sanitized evidence

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/nomed/yukh-mcp/security
+    about: Report vulnerabilities privately. Do not open a public issue.
+  - name: Questions and ideas
+    url: https://github.com/nomed/yukh-mcp/discussions
+    about: Use Discussions for questions and early ideas once enabled.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,37 @@
+name: Capability or feature
+description: Propose a governed capability or product feature.
+title: "[Feature]: "
+labels: ["type:feature", "status:triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Explain the user outcome before proposing implementation. Security-boundary changes require an RFC.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user or operator problem should Yukh solve?
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe observable success without prescribing internals.
+    validations:
+      required: true
+  - type: textarea
+    id: security
+    attributes:
+      label: Security and trust-boundary impact
+      description: Identify identities, resources, credentials, approvals, mutations, and new boundaries.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Include failure paths and verification evidence.
+    validations:
+      required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      documentation:
+        patterns:
+          - "mkdocs*"
+          - "pymdown*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+## Summary
+
+## Governing issue
+
+Closes #
+
+## Security impact
+
+- [ ] No security-boundary impact
+- [ ] Threat model updated
+- [ ] Security review required
+
+Explain:
+
+## Context impact
+
+- [ ] No context impact
+- [ ] Session/handoff updated
+- [ ] ADR/RFC proposed or superseded
+
+Explain:
+
+## Validation
+
+List exact checks and evidence.
+
+## Checklist
+
+- [ ] Change is narrowly scoped.
+- [ ] Public behavior and documentation agree.
+- [ ] Negative and failure paths are covered.
+- [ ] No secrets or sensitive infrastructure data are included.
+- [ ] Dependencies and workflow actions are intentionally pinned.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,46 @@
+name: Documentation
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+      - ".github/workflows/docs.yml"
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+      - ".github/workflows/docs.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out source
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+
+      - name: Install documentation dependencies
+        run: python -m pip install --requirement requirements-docs.txt
+
+      - name: Build documentation strictly
+        run: mkdocs build --strict

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,66 @@
+name: Publish documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Check out source
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+
+      - name: Install documentation dependencies
+        run: python -m pip install --requirement requirements-docs.txt
+
+      - name: Build documentation strictly
+        run: mkdocs build --strict
+
+      - name: Configure Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@decdde0ac072f6c095aec75db5a0d1acd028b1ee # v4

--- a/.github/workflows/yukh-bootstrap.yml
+++ b/.github/workflows/yukh-bootstrap.yml
@@ -1,0 +1,43 @@
+name: Bootstrap Yukh Project
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Bootstrap mode
+        type: choice
+        options: [dry-run, apply]
+        required: true
+        default: dry-run
+      confirm_apply:
+        description: Explicitly authorize schema apply
+        type: boolean
+        required: true
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: yukh-project-bootstrap
+  cancel-in-progress: false
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out policy
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Bootstrap Project schema
+        uses: nomed/yukh@e862f109bb038f8ec0699e42ac2da11c9ef42549 # v0.7.0
+        with:
+          operation: bootstrap-project
+          project-number: ${{ vars.YUKH_PROJECT_NUMBER }}
+          policy-path: .yukh/project.yaml
+          mode: ${{ inputs.mode }}
+          apply-enabled: ${{ inputs.confirm_apply }}
+          github-token: ${{ secrets.YUKH_PROJECT_TOKEN }}

--- a/.github/workflows/yukh-reconcile.yml
+++ b/.github/workflows/yukh-reconcile.yml
@@ -1,0 +1,50 @@
+name: Yukh reconciliation
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to reconcile
+        type: number
+        required: true
+      mode:
+        description: Reconciliation mode
+        type: choice
+        options: [dry-run, apply]
+        required: true
+        default: dry-run
+      confirm_apply:
+        description: Explicitly authorize apply
+        type: boolean
+        required: true
+        default: false
+
+permissions:
+  contents: read
+  issues: read
+
+concurrency:
+  group: yukh-${{ github.repository }}-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out policy
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Reconcile issue
+        uses: nomed/yukh@e862f109bb038f8ec0699e42ac2da11c9ef42549 # v0.7.0
+        with:
+          issue-number: ${{ github.event.issue.number || inputs.issue_number }}
+          project-number: ${{ vars.YUKH_PROJECT_NUMBER }}
+          policy-path: .yukh/project.yaml
+          mode: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'dry-run' }}
+          apply-enabled: ${{ github.event_name == 'workflow_dispatch' && inputs.confirm_apply || false }}
+          github-token: ${{ secrets.YUKH_PROJECT_TOKEN }}

--- a/.yukh/project.yaml
+++ b/.yukh/project.yaml
@@ -1,0 +1,47 @@
+version: 1
+
+project:
+  owner: nomed
+  repository: yukh-mcp
+  name: Yukh
+
+contract:
+  marker: yukh
+  schema: 1
+
+fields:
+  priority:
+    project_field: Priority
+    required: true
+    values:
+      P0: P0
+      P1: P1
+      P2: P2
+      P3: P3
+  size:
+    project_field: Size
+    values:
+      XS: XS
+      S: S
+      M: M
+      L: L
+      XL: XL
+  estimate:
+    project_field: Estimate
+    type: number
+  iteration:
+    project_field: Iteration
+  status:
+    project_field: Status
+    derived: true
+
+defaults:
+  execution: hybrid
+
+scheduling:
+  automatic_iteration: false
+
+safety:
+  overwrite_human_values: false
+  fail_on_unknown_values: true
+  comment_on_validation_error: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# Agent instructions
+
+## Mission
+
+Build Yukh MCP as a secure, vendor-neutral capability gateway for policy-governed, auditable, and verifiable agent operations.
+
+## Required reading
+
+Before meaningful work, read:
+
+1. `.context/manifest.yaml`;
+2. `.context/README.md`;
+3. this file and any nearer `AGENTS.md`;
+4. accepted decisions and relevant RFCs;
+5. `docs/security/threat-model.md`;
+6. the governing GitHub Issue and latest applicable handoff.
+
+## Non-negotiable security rules
+
+- Deny by default.
+- Never expose unrestricted shell execution as a public capability.
+- Never commit secrets, credentials, private keys, tokens, sensitive infrastructure identifiers, personal data, or private reasoning.
+- Authentication never implies authorization.
+- Every protected operation declares subject, resource, action, environment, and policy decision.
+- Every mutation supports plan and verification semantics.
+- Destructive actions require explicit human approval and must not be silently retried.
+- Logs and errors redact secrets by construction.
+- Security-boundary changes require an RFC and threat-model update.
+
+## Context discipline
+
+- `.context/` is durable operating memory.
+- Sessions and handoffs preserve evidence but cannot change architecture.
+- Accepted ADRs and RFCs are immutable; supersede them with a new record.
+- Every substantive PR references a governing Issue and declares context impact.
+- Architecture and security changes without an accepted record are forbidden.
+
+## Delivery
+
+- Work through a GitHub Issue.
+- Keep changes narrowly scoped.
+- Add negative and failure-path tests with behavior changes.
+- Treat documentation and examples as product interfaces.
+- Record validation evidence in the PR.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,11 @@
+# Code of Conduct
+
+Yukh MCP is committed to a welcoming, professional, and harassment-free community.
+
+We adopt the Contributor Covenant Code of Conduct, version 2.1:
+
+https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+
+Project maintainers are responsible for clarifying and enforcing standards of acceptable behavior. Enforcement contact details will be published before opening broad community contribution channels. Until then, contact the repository owner privately for conduct reports.
+
+Reports must be handled confidentially, promptly, fairly, and without retaliation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+Thank you for helping build Yukh MCP.
+
+## Before contributing
+
+1. Read the project principles and security policy.
+2. Find or open a governing GitHub Issue.
+3. Discuss substantial public-contract, architecture, or security changes before implementation.
+4. Read `.context/manifest.yaml`, `.context/README.md`, and `AGENTS.md`.
+
+## Pull requests
+
+A pull request should:
+
+- address one coherent concern;
+- reference its governing Issue;
+- explain security and context impact;
+- include tests and failure-path evidence where applicable;
+- update documentation with public behavior;
+- avoid unrelated formatting or dependency changes.
+
+## Decisions
+
+Use an ADR for durable decisions and an RFC for substantial or costly proposals. Agents may draft records; human acceptance is required.
+
+## Security
+
+Do not submit secrets or real infrastructure details. Report vulnerabilities privately according to `SECURITY.md`.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,21 @@
+# Governance
+
+Yukh MCP uses transparent, repository-based governance.
+
+## Principles
+
+- Technical reasoning is public by default.
+- Security-sensitive disclosure remains private until coordinated.
+- Maintainers optimize for user safety, interoperability, simplicity, and long-term stewardship.
+- Influence is earned through sustained, constructive contribution.
+- No contributor may merge their own security-boundary change without independent review.
+
+## Decision process
+
+Routine changes use Issues and pull requests. Durable architecture decisions use ADRs. Substantial, costly, compatibility-sensitive, authentication, authorization, or trust-boundary changes require an RFC.
+
+The project owner currently acts as lead maintainer. Governance will evolve before the first stable release and as a diverse maintainer group emerges.
+
+## Conduct
+
+Participation requires respectful, good-faith collaboration and compliance with the Code of Conduct.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,17 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+Copyright 2026 Yukh MCP contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# yukh-mcp
+# Yukh MCP
+
+> **Give agents capability, not custody.**
+
+Yukh MCP is an open-source, policy-governed capability gateway for safe, auditable, and verifiable AI operations.
+
+It is designed around a strict lifecycle:
+
+```text
+intent → capability → policy → plan → approval → execution → verification → audit
+```
+
+Yukh MCP does not aim to be an unrestricted remote shell broker. It exposes typed capabilities, evaluates explicit policy, plans mutations before execution, verifies outcomes, and produces structured evidence.
+
+## Status
+
+Yukh MCP is in its foundation phase. Public contracts and security boundaries are being designed in the open before operational capabilities are implemented.
+
+## Principles
+
+- Capability, not custody.
+- Deny by default.
+- No mutation without a plan.
+- No success without verification.
+- Structured evidence over opaque output.
+- Security decisions are public and reviewable.
+- Vendor-neutral MCP interoperability.
+
+## Project
+
+Work is coordinated through [GitHub Issues](https://github.com/nomed/yukh-mcp/issues) and the [Yukh project](https://github.com/users/nomed/projects/5).
+
+Documentation source lives under `docs/` and will be published with GitHub Pages.
+
+## Security
+
+Do not report vulnerabilities in public issues. Follow [SECURITY.md](SECURITY.md).
+
+## License
+
+Licensed under the [Apache License 2.0](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security policy
+
+Security is a product boundary in Yukh MCP, not an afterthought.
+
+## Reporting a vulnerability
+
+Do not disclose suspected vulnerabilities in public Issues, Discussions, pull requests, or chat transcripts.
+
+Until a dedicated security contact and private reporting workflow are published, use GitHub's private vulnerability reporting for this repository. If private reporting is not available, do not publish exploit details; contact the repository owner through a private channel and provide only enough public information to request a secure channel.
+
+## Scope
+
+Reports involving authentication, authorization, policy bypass, command injection, credential exposure, cross-node or cross-tenant access, approval bypass, audit tampering, unsafe retries, or supply-chain integrity are especially important.
+
+## Supported versions
+
+Yukh MCP is pre-release software. Only the latest released version receives security fixes until a stable support policy is published.
+
+## Response principles
+
+- acknowledge privately;
+- minimize disclosure;
+- reproduce safely;
+- assess affected boundaries;
+- prepare regression evidence;
+- coordinate remediation and disclosure;
+- credit reporters unless anonymity is requested.
+
+Never include real credentials, production data, or sensitive infrastructure details in a report.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,26 @@
+# Architecture
+
+Yukh MCP separates reasoning, authorization, execution, and evidence.
+
+```mermaid
+flowchart TD
+    A["MCP client"] --> B["Yukh gateway"]
+    B --> C["Identity and policy"]
+    C --> D["Capability planner"]
+    D --> E["Approval boundary"]
+    E --> F["Capability provider"]
+    F --> G["Target node"]
+    F --> H["Verification"]
+    H --> I["Audit evidence"]
+```
+
+## Boundaries
+
+- The MCP client proposes intent; it is not an authorization authority.
+- The gateway authenticates the caller and evaluates policy.
+- Providers translate typed capabilities into target-specific operations.
+- Credentials remain behind the execution boundary.
+- Verification evaluates declared postconditions.
+- Audit records are structured, redacted, and tamper-evident by design.
+
+The architecture remains under public RFC review during foundation.

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="256" height="256" role="img" aria-labelledby="title desc">
+  <title id="title">Yukh MCP</title>
+  <desc id="desc">Yukh family circular mark in violet</desc>
+  <circle cx="31.21" cy="31.50" r="28.10" fill="#ffffff"/>
+  <circle cx="31.29" cy="31.46" r="26.31" fill="#7C3AED"/>
+  <circle cx="36.09" cy="21.55" r="9.76" fill="#ffffff"/>
+  <circle cx="36.95" cy="40.81" r="5.94" fill="#ffffff"/>
+  <circle cx="25.61" cy="34.52" r="2.71" fill="#ffffff"/>
+  <circle cx="25.50" cy="47.50" r="3.19" fill="#ffffff"/>
+</svg>

--- a/docs/community/brand.md
+++ b/docs/community/brand.md
@@ -1,0 +1,15 @@
+# Brand assets
+
+Yukh components share one geometric mark. Each component selects a distinct base color while preserving the mark proportions and white internal circles.
+
+## Yukh MCP
+
+- Brand: `#7C3AED`
+- Light: `#A78BFA`
+- Dark: `#5B21B6`
+- Dark surface: `#09090B`
+- Light surface: `#FAFAFA`
+
+The canonical mark is derived from the Yukh family master asset. Do not alter its geometry, add shadows, or introduce gradients into the canonical logo.
+
+Use accessible UI tokens rather than assuming the brand fill is valid for text in every context.

--- a/docs/community/roadmap.md
+++ b/docs/community/roadmap.md
@@ -1,0 +1,34 @@
+# Roadmap
+
+## Foundation
+
+- charter, principles, governance, and security baseline;
+- public documentation and brand system;
+- capability contract and policy model;
+- MCP Streamable HTTP walking skeleton;
+- local read-only provider;
+- reproducible demonstration.
+
+## Governed execution
+
+- plan, approval, apply, verification, and audit lifecycle;
+- first bounded mutating capability;
+- failure semantics and rollback;
+- structured compatibility tests.
+
+## Remote nodes
+
+- secure enrollment and identity;
+- SSH provider behind typed capabilities;
+- fleet discovery and health;
+- threat-model review.
+
+## Ecosystem
+
+- provider SDK;
+- provider compatibility kit;
+- Docker and system service providers;
+- ChatGPT plugin packaging;
+- release signing, SBOM, and provenance.
+
+The roadmap is directional. GitHub Issues and accepted RFCs govern committed work.

--- a/docs/concepts/why-yukh.md
+++ b/docs/concepts/why-yukh.md
@@ -1,0 +1,19 @@
+# Why Yukh
+
+Most remote-operation MCP servers expose command execution. That approach gives a model syntax-level power while leaving policy, intent, verification, and evidence to prompts.
+
+Yukh MCP takes a different position:
+
+> An agent receives a governed capability, not custody of credentials or infrastructure.
+
+A capability is typed, versioned, scoped to resources and environments, evaluated by policy, and paired with evidence. Mutations follow plan, approval, apply, verification, and rollback semantics.
+
+## Non-goals
+
+Yukh MCP is not:
+
+- an unrestricted remote shell broker;
+- a replacement for configuration management or orchestration systems;
+- a credential vault exposed to models;
+- an approval mechanism implemented only in prompts;
+- a system that treats successful process termination as verified intent.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,43 @@
+---
+title: Yukh MCP
+description: A zero-trust capability gateway for safe agent operations.
+---
+
+# Give agents capability, not custody.
+
+**Yukh MCP is a policy-governed gateway for safe, auditable, and verifiable AI operations.**
+
+Agents should not need custody of infrastructure credentials or unrestricted shell access. Yukh exposes typed capabilities, evaluates explicit policy, produces a deterministic plan, requires the appropriate approval, verifies the outcome, and records structured evidence.
+
+[Explore the concepts](concepts/why-yukh.md){ .md-button .md-button--primary }
+[Read the security model](security/security-model.md){ .md-button }
+
+## The operating contract
+
+```text
+intent → capability → policy → plan → approval → execution → verification → audit
+```
+
+<div class="grid cards" markdown>
+
+-   :material-shield-lock-outline:{ .lg .middle } **Deny by default**
+
+    Authorization is explicit, scoped, contextual, and independently enforced.
+
+-   :material-file-tree-outline:{ .lg .middle } **Plan first**
+
+    Mutations become inspectable plans before they become effects.
+
+-   :material-check-decagram-outline:{ .lg .middle } **Verify outcomes**
+
+    Exit code zero is not proof that the intended state exists.
+
+-   :material-text-box-search-outline:{ .lg .middle } **Produce evidence**
+
+    Decisions, approvals, execution, verification, and rollback remain auditable.
+
+</div>
+
+## Status
+
+Yukh MCP is in foundation. Security boundaries and public contracts are being designed openly before operational capabilities are implemented.

--- a/docs/security/security-model.md
+++ b/docs/security/security-model.md
@@ -1,0 +1,18 @@
+# Security model
+
+Yukh MCP is deny-by-default.
+
+Authentication establishes an identity. It does not grant capability. Authorization evaluates subject, action, resource, environment, constraints, and current policy for every protected operation.
+
+## Core invariants
+
+1. Models never receive infrastructure private keys.
+2. Public capabilities do not accept unrestricted shell strings.
+3. Every mutation has an inspectable plan.
+4. Destructive operations require explicit approval.
+5. Verification is distinct from execution.
+6. Logs and errors redact credentials and sensitive values.
+7. Policy failure, uncertainty, or dependency failure resolves to deny.
+8. Audit evidence identifies the decision and result without retaining secrets.
+
+See the [threat model](threat-model.md) for initial trust boundaries and threats.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,0 +1,54 @@
+# Threat model
+
+- Status: Initial
+- Last reviewed: 2026-08-02
+- Scope: Foundation architecture
+
+## Assets
+
+- node and workload identities;
+- authorization policy;
+- infrastructure credentials;
+- capability definitions;
+- approval decisions;
+- execution and verification evidence;
+- software supply chain.
+
+## Trust boundaries
+
+1. MCP client to gateway.
+2. Gateway to identity and policy services.
+3. Gateway to capability provider.
+4. Provider to target node.
+5. Runtime to audit storage.
+6. Source repository to released artifact.
+
+## Primary threats
+
+- prompt injection causing unauthorized tool use;
+- authentication or authorization bypass;
+- confused-deputy and cross-resource access;
+- command or argument injection;
+- credential or sensitive-output disclosure;
+- approval replay or substitution;
+- unsafe retries of non-idempotent operations;
+- provider compromise;
+- audit deletion or tampering;
+- malicious dependency or workflow compromise;
+- denial of service and resource exhaustion.
+
+## Baseline controls
+
+- deny-by-default authorization;
+- typed input schemas and server-side validation;
+- capability allowlists;
+- credentials isolated from model context;
+- explicit approval binding;
+- idempotency keys and bounded retries;
+- time, output, and resource limits;
+- structured redaction;
+- tamper-evident audit design;
+- pinned and reviewed build dependencies;
+- negative and abuse-case tests.
+
+This model must evolve with every new trust boundary or mutating capability.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,26 @@
+:root {
+  --yukh-brand: #7c3aed;
+  --yukh-brand-light: #a78bfa;
+  --yukh-brand-dark: #5b21b6;
+  --yukh-surface-dark: #09090b;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: var(--yukh-surface-dark);
+  --md-accent-fg-color: var(--yukh-brand-light);
+}
+
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color: var(--yukh-brand-dark);
+  --md-accent-fg-color: var(--yukh-brand);
+}
+
+.md-header,
+.md-tabs {
+  background: var(--yukh-surface-dark);
+}
+
+.md-typeset .md-button--primary {
+  background-color: var(--yukh-brand);
+  border-color: var(--yukh-brand);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,68 @@
+site_name: Yukh MCP
+site_description: A zero-trust capability gateway for safe agent operations.
+site_url: https://nomed.github.io/yukh-mcp/
+repo_url: https://github.com/nomed/yukh-mcp
+repo_name: nomed/yukh-mcp
+copyright: Copyright &copy; 2026 Yukh MCP contributors
+
+theme:
+  name: material
+  logo: assets/logo.svg
+  favicon: assets/logo.svg
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep purple
+      accent: deep purple
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: black
+      accent: deep purple
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.tabs.link
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+
+extra_css:
+  - stylesheets/extra.css
+
+nav:
+  - Home: index.md
+  - Concepts:
+      - Why Yukh: concepts/why-yukh.md
+  - Architecture:
+      - Overview: architecture/overview.md
+  - Security:
+      - Security model: security/security-model.md
+      - Threat model: security/threat-model.md
+  - Community:
+      - Roadmap: community/roadmap.md
+      - Brand: community/brand.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,1 @@
+mkdocs-material>=9.6,<10


### PR DESCRIPTION
## What changed

- establishes Yukh MCP's public product thesis and non-negotiable principles;
- adds repository-owned `.context/` memory and ADR-0001;
- adds agent instructions, governance, contribution, conduct, and security policies;
- publishes the initial security model and threat model;
- introduces the violet Yukh MCP brand derived from the Yukh family mark;
- creates a professional MkDocs Material documentation structure;
- adds strict documentation CI and GitHub Pages deployment;
- adopts Yukh policy and controlled Project 5 reconciliation workflows;
- adds security-aware Issue and pull request templates;
- pins consumer GitHub Actions to commit SHAs and grants minimum workflow permissions.

## Why

The project needs an explicit security and governance foundation before operational capabilities or remote execution are implemented. This PR makes the boundaries reviewable in public and makes `yukh-mcp` a dogfooding consumer of Yukh Project reconciliation.

## Governing work

- Initiative: #1
- Charter: #2
- Security model: #7
- Supply chain: #10
- Documentation: #12
- Upstream Yukh hardening: nomed/yukh#94

## Security impact

This PR defines boundaries but introduces no runtime server, credentials, SSH connectivity, or operational mutation. Static Pages publishing and Yukh workflows use scoped permissions. The dedicated Project token is referenced only as an Actions secret.

Automatic issue-event reconciliation remains `dry-run`. Apply is available only through explicit workflow dispatch with `confirm_apply=true`.

## Context impact

Creates the context system and accepts ADR-0001 under explicit project-owner direction. Future security, public-contract, and architecture changes require ADR/RFC governance.

## Validation

The Documentation workflow completed successfully with `mkdocs build --strict`. The first Yukh Project dry-run must be executed after merge because repository event and dispatch workflows run from the default branch.

## Administrative follow-up

After review and merge:

- configure `YUKH_PROJECT_NUMBER=5` and the `YUKH_PROJECT_TOKEN` secret;
- run Project bootstrap in dry-run, review, then controlled apply if needed;
- reconcile issues #1–#13 in dry-run, review, then controlled apply;
- prove idempotency with a second apply reporting zero operations;
- configure Pages to use GitHub Actions;
- restrict the `github-pages` environment to `main`;
- protect `main` with required pull request and status checks;
- enable private vulnerability reporting, secret scanning, and push protection where available.
