### PR TITLE
CI: bind Yukh workflows to Project 5

### DIFF
--- a/.github/workflows/yukh-bootstrap.yml
+++ b/.github/workflows/yukh-bootstrap.yml
@@ -36,7 +36,7 @@ jobs:
         uses: nomed/yukh@e862f109bb038f8ec0699e42ac2da11c9ef42549 # v0.7.0
         with:
           operation: bootstrap-project
-          project-number: ${{ vars.YUKH_PROJECT_NUMBER }}
+          project-number: 5
           policy-path: .yukh/project.yaml
           mode: ${{ inputs.mode }}
           apply-enabled: ${{ inputs.confirm_apply }}

--- a/.github/workflows/yukh-reconcile.yml
+++ b/.github/workflows/yukh-reconcile.yml
@@ -43,7 +43,7 @@ jobs:
         uses: nomed/yukh@e862f109bb038f8ec0699e42ac2da11c9ef42549 # v0.7.0
         with:
           issue-number: ${{ github.event.issue.number || inputs.issue_number }}
-          project-number: ${{ vars.YUKH_PROJECT_NUMBER }}
+          project-number: 5
           policy-path: .yukh/project.yaml
           mode: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'dry-run' }}
           apply-enabled: ${{ github.event_name == 'workflow_dispatch' && inputs.confirm_apply || false }}


### PR DESCRIPTION
## Summary

Replace the optional repository variable `YUKH_PROJECT_NUMBER` with the explicit public Project number `5` in both Yukh workflows.

## Why

The Project target is a versioned, non-sensitive repository decision. Keeping it in workflow source removes unnecessary manual setup and makes reconciliation reproducible from the repository alone.

## Security

No secret is added. `YUKH_PROJECT_TOKEN` remains an Actions secret and is still required for Project access.

## Validation

Both workflow call sites now pass the same explicit Project number. No runtime or permission behavior changes.
