### PR TITLE
Fix Yukh Foundation contract policy

### DIFF
--- a/.github/workflows/yukh-bootstrap.yml
+++ b/.github/workflows/yukh-bootstrap.yml
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
 
       - name: Bootstrap Project schema
-        uses: nomed/yukh@e862f109bb038f8ec0699e42ac2da11c9ef42549 # v0.7.0
+        uses: nomed/yukh@adea7e08dee4a882cc4cf7a1061437295b3c04eb # v0.9.1
         with:
           operation: bootstrap-project
           project-number: 5

--- a/.github/workflows/yukh-reconcile.yml
+++ b/.github/workflows/yukh-reconcile.yml
@@ -40,7 +40,7 @@ jobs:
           persist-credentials: false
 
       - name: Reconcile issue
-        uses: nomed/yukh@e862f109bb038f8ec0699e42ac2da11c9ef42549 # v0.7.0
+        uses: nomed/yukh@adea7e08dee4a882cc4cf7a1061437295b3c04eb # v0.9.1
         with:
           issue-number: ${{ github.event.issue.number || inputs.issue_number }}
           project-number: 5

--- a/.yukh/project.yaml
+++ b/.yukh/project.yaml
@@ -10,6 +10,30 @@ contract:
   schema: 1
 
 fields:
+  kind:
+    project_field: Work Type
+    required: true
+    values:
+      gate: Gate
+      epic: Epic
+      feature: Feature
+      task: Task
+      bug: Bug
+      technical_debt: Technical Debt
+  area:
+    project_field: Area
+    ownership: extension
+    required: true
+    values:
+      governance: Governance
+      security: Security
+      architecture: Architecture
+      runtime: Runtime
+      provider: Provider
+      audit: Audit
+      delivery: Delivery
+      documentation: Documentation
+      release: Release
   priority:
     project_field: Priority
     required: true


### PR DESCRIPTION
Closes the consumer-policy portion of #1.

## What changed

- pin bootstrap and reconciliation to the verified immutable Yukh v0.9.1 release commit
- declare the mandatory contract dimensions `kind` and `area`
- map `kind` to canonical Project field `Work Type`
- map repository-owned `area` to Project field `Area` with an explicit Foundation vocabulary

## Why

Yukh contract schema v1 requires `kind`, `area`, and `priority` at the parser boundary. The original consumer policy and issues declared only `priority`, so reconciliation failed before policy mapping or Project discovery.

## Validation

- policy parsed successfully with Yukh v0.9.1
- Yukh v0.9.1 CI: typecheck, 131 tests, package verification
- clean consumer bootstrap dry-run: https://github.com/nomed/yukh-mcp/actions/runs/30746438922
- no Project mutation performed

## Follow-up

After this PR is reviewed and merged, issues #1-#13 will receive explicit `kind` and `area` values. Bootstrap and issue reconciliation will then be run in dry-run only, with the exact mutation plan reviewed before any apply request.