### PR TITLE
Preserve existing Project review status

### DIFF
--- a/.yukh/project.yaml
+++ b/.yukh/project.yaml
@@ -62,6 +62,10 @@ fields:
 defaults:
   execution: hybrid
 
+workflow:
+  in_progress_status: In progress
+  review_status: In review
+
 scheduling:
   automatic_iteration: false
 


### PR DESCRIPTION
Follow-up to #23.

The reviewed bootstrap dry-run showed that the default Yukh workflow vocabulary would add `Review` while Project 5 already contains `In review`. This policy override reuses the existing `In progress` and `In review` options, avoiding duplicate semantic states.

No Project mutation is included. A new bootstrap dry-run will be attached before merge.