### PR TITLE
Add the component identity to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Yukh MCP
+<p align="center">
+  <a href="https://nomed.github.io/system/mcp/"><img src="docs/assets/repository-mark.svg" width="96" alt="Yukh MCP"></a>
+</p>
+
+<h1 align="center">Yukh MCP</h1>
+
+<p align="center"><a href="https://nomed.github.io/system/mcp/">Role in the Yukh system</a></p>
 
 > **Give agents capability, not custody.**
 

--- a/docs/assets/repository-mark.svg
+++ b/docs/assets/repository-mark.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="title desc">
+  <title id="title">Yukh MCP repository mark</title>
+  <desc id="desc">The canonical violet Yukh MCP mark on its protected dark field</desc>
+  <rect width="96" height="96" fill="#171714"/>
+  <g transform="translate(16 16)">
+    <circle cx="31.21" cy="31.50" r="28.10" fill="#ffffff"/>
+    <circle cx="31.29" cy="31.46" r="26.31" fill="#7C3AED"/>
+    <circle cx="36.09" cy="21.55" r="9.76" fill="#ffffff"/>
+    <circle cx="36.95" cy="40.81" r="5.94" fill="#ffffff"/>
+    <circle cx="25.61" cy="34.52" r="2.71" fill="#ffffff"/>
+    <circle cx="25.50" cy="47.50" r="3.19" fill="#ffffff"/>
+  </g>
+</svg>


### PR DESCRIPTION
## What changed

- adds the canonical component mark at the top of the README
- preserves the original component color on a protected dark field
- links the identity header to the component role in the Yukh system

## Why

The repository should communicate its identity and its place in Yukh immediately, without changing the logo to compensate for an uncontrolled GitHub surface.

## Validation

- clean diff validation
- SVG structure validation