### PR TITLE
Replace the repository field with a fine keyline

### DIFF
--- a/docs/assets/repository-mark.svg
+++ b/docs/assets/repository-mark.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="title desc">
   <title id="title">Yukh MCP repository mark</title>
-  <desc id="desc">The canonical violet Yukh MCP mark on its protected dark field</desc>
-  <rect width="96" height="96" fill="#171714"/>
+  <desc id="desc">The canonical violet Yukh MCP mark with a fine dark keyline for light surfaces</desc>
+  <circle cx="47.21" cy="47.50" r="29" fill="#ffffff" stroke="#171714" stroke-width="1.5"/>
   <g transform="translate(16 16)">
     <circle cx="31.21" cy="31.50" r="28.10" fill="#ffffff"/>
     <circle cx="31.29" cy="31.46" r="26.31" fill="#7C3AED"/>


### PR DESCRIPTION
Removes the dark square from the README identity and replaces it with a fine circular keyline around the unchanged canonical component mark.