### PR TITLE
Implement the capability contract v1

### DIFF
--- a/.context/sessions/SESSION-2026-08-03-02-capability-contract-implementation.md
+++ b/.context/sessions/SESSION-2026-08-03-02-capability-contract-implementation.md
@@ -1,0 +1,59 @@
+# SESSION-2026-08-03-02 — Capability contract implementation
+
+- Governing issue: #5
+- Pull request: pending
+- Status: implementation ready for review
+
+## Objective
+
+Implement the machine-readable, network-free portion of accepted RFC-0001
+without introducing an MCP listener, provider, authorization engine, credential,
+deployment, or target mutation.
+
+## Work completed
+
+- Added JSON Schema 2020-12 records for capability definitions, requests, plans,
+  results, structured errors, and shared types.
+- Added structural and semantic validation for scope, mutation, approval,
+  idempotency, retry, verification, rollback, and implementation identity.
+- Added a restricted embedded-schema profile with finite limits and rejection of
+  remote/cyclic references, unsafe regex constructs, credential channels, and
+  unrestricted execution semantics.
+- Added synthetic read and mutation examples and negative conformance fixtures.
+- Added exact request/definition, output/definition, and result/definition
+  binding tests.
+
+## Evidence and validation
+
+- `npm test`: 16 tests passed, 0 failed.
+- `npm audit --omit=dev`: 0 vulnerabilities.
+- Valid examples cover all five record kinds and both read and mutation
+  definitions.
+- Negative fixtures cover unknown fields, unsupported versions, unbounded
+  schema, credential-shaped input, unsafe regex, cyclic references,
+  unrestricted execution identity, missing mutation verification, unsafe retry,
+  unavailable rollback controls, and subject injection.
+
+## Decisions discovered
+
+- A language-neutral JSON/JavaScript package avoids anticipating the TypeScript
+  MCP runtime and monorepo governed by #6.
+- Machine-readable shape validation is insufficient for provider safety;
+  semantic checks, provider qualification, and human review remain mandatory.
+- Plan canonicalization and lifecycle details remain deferred to #4 rather than
+  being invented in #5 implementation.
+
+## Context impact
+
+- Implemented accepted RFC-0001 without modifying it.
+- Updated the living threat model with the contract-package impact review.
+- Added no trust boundary and authorized no operational capability.
+
+## Risks and unresolved work
+
+- CI execution of contract tests remains governed by #10.
+- Authorization semantics remain governed by #3.
+- Full plan, approval, apply, verification, and rollback lifecycle remains
+  governed by #4.
+- Provider implementation and sandboxing remain governed by #8 and future
+  provider-specific review.

--- a/.context/sessions/SESSION-2026-08-03-02-capability-contract-implementation.md
+++ b/.context/sessions/SESSION-2026-08-03-02-capability-contract-implementation.md
@@ -1,7 +1,7 @@
 # SESSION-2026-08-03-02 — Capability contract implementation
 
 - Governing issue: #5
-- Pull request: pending
+- Pull request: #31
 - Status: implementation ready for review
 
 ## Objective

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+coverage/
+*.log

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Yukh MCP does not aim to be an unrestricted remote shell broker. It exposes type
 
 Yukh MCP is in its foundation phase. Public contracts and security boundaries are being designed in the open before operational capabilities are implemented.
 
+The versioned capability contract is governed by accepted
+[RFC-0001](.context/rfcs/RFC-0001-versioned-capability-contract.md). Its
+[network-free reference package](contracts/capability/v1/README.md) validates
+synthetic contract records without exposing a provider or MCP runtime.
+
 ## Principles
 
 - Capability, not custody.

--- a/contracts/capability/v1/README.md
+++ b/contracts/capability/v1/README.md
@@ -1,0 +1,67 @@
+# Capability contract v1
+
+This directory is the network-free reference implementation of accepted
+[RFC-0001](../../../.context/rfcs/RFC-0001-versioned-capability-contract.md).
+It does not expose an MCP listener, invoke a provider, hold credentials, or
+authorize an operation.
+
+## Contents
+
+- `schemas/`: JSON Schema 2020-12 records for definitions, requests, plans,
+  results, errors, and shared types;
+- `examples/`: entirely synthetic valid records;
+- `fixtures/`: synthetic negative conformance cases;
+- `validator.mjs`: deterministic structural and semantic validation.
+
+## Validation API
+
+`validateRecord(kind, value)` validates one public record. Supported kinds are
+`definition`, `request`, `plan`, `result`, and `error`.
+
+`validateRequestAgainstDefinition(request, definition)` additionally binds an
+exact capability version, resource kind, idempotency requirement, and input
+schema.
+
+`validateOutputAgainstDefinition(output, definition)` prevents invalid provider
+output from crossing the public boundary.
+
+`validateResultAgainstDefinition(result, definition)` binds result identity,
+attempt bounds, output, and mutation-verification requirements.
+
+All functions return:
+
+```json
+{
+  "valid": false,
+  "diagnostics": [
+    {
+      "code": "schema_required",
+      "path": "/input/include",
+      "message": "required field is missing"
+    }
+  ]
+}
+```
+
+Diagnostics are sorted by JSON Pointer path and stable code, capped at 64, and
+contain no input values, provider bodies, credentials, or stack traces.
+
+## Run tests
+
+```text
+npm ci --ignore-scripts
+npm test
+```
+
+The schema profile rejects open objects, unbounded strings and arrays, unbounded
+numbers, remote or cyclic references, unsupported keywords, credential or
+execution-shaped fields, and unsafe regular-expression constructs. Schema
+checks remain defense in depth: provider qualification and human security review
+are still mandatory.
+
+## Boundary
+
+This implementation is experimental and unreleased. Plan canonicalization and
+the full approval/apply lifecycle remain governed by #4; authorization remains
+governed by #3; audit envelopes and retention remain governed by #9. Do not use
+these schemas to claim that an operation is authorized or production-ready.

--- a/contracts/capability/v1/examples/error.json
+++ b/contracts/capability/v1/examples/error.json
@@ -1,0 +1,10 @@
+{
+  "error_version": 1,
+  "code": "schema_validation_failed",
+  "phase": "validate",
+  "retry": "after_correction",
+  "message": "request validation failed",
+  "diagnostics": [
+    { "code": "schema_required", "path": "/input/include", "message": "required field is missing" }
+  ]
+}

--- a/contracts/capability/v1/examples/mutation-definition.json
+++ b/contracts/capability/v1/examples/mutation-definition.json
@@ -1,0 +1,49 @@
+{
+  "contract_version": 1,
+  "capability": {
+    "id": "example.setting.update",
+    "version": "1.0.0",
+    "summary": "Update one bounded synthetic setting",
+    "stability": "experimental"
+  },
+  "resource": { "kinds": ["example_setting"], "cardinality": "one" },
+  "environment": { "required": true },
+  "operation": { "model": "typed", "class": "mutate", "effects": ["update"] },
+  "input": {
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "value"],
+      "properties": {
+        "name": { "type": "string", "pattern": "^[a-z][a-z0-9_]{0,31}$", "maxLength": 32 },
+        "value": { "type": "string", "minLength": 1, "maxLength": 128 }
+      }
+    }
+  },
+  "output": {
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["changed", "version"],
+      "properties": {
+        "changed": { "type": "boolean" },
+        "version": { "type": "integer", "minimum": 1, "maximum": 2147483647 }
+      }
+    }
+  },
+  "risk": { "level": "high", "data_classes": ["synthetic_configuration"] },
+  "mutation": { "mode": "planned", "destructive": false },
+  "approval": { "mode": "explicit" },
+  "execution": {
+    "timeout_ms": 10000,
+    "max_attempts": 1,
+    "concurrency": "per_resource",
+    "max_input_bytes": 4096,
+    "max_output_bytes": 8192
+  },
+  "idempotency": { "classification": "keyed", "key": "required" },
+  "retry": { "policy": "never" },
+  "verification": { "mode": "required", "postconditions": ["setting_value_matches"] },
+  "rollback": { "mode": "restore" },
+  "errors": { "taxonomy_version": 1 }
+}

--- a/contracts/capability/v1/examples/mutation-request.json
+++ b/contracts/capability/v1/examples/mutation-request.json
@@ -1,0 +1,9 @@
+{
+  "request_version": 1,
+  "request_id": "req_example8d4b",
+  "capability": { "id": "example.setting.update", "version": "1.0.0" },
+  "resource": { "kind": "example_setting", "ref": "setting-example-01" },
+  "environment": "development",
+  "input": { "name": "display_mode", "value": "compact" },
+  "idempotency_key": "idem-example-0001"
+}

--- a/contracts/capability/v1/examples/plan.json
+++ b/contracts/capability/v1/examples/plan.json
@@ -1,0 +1,17 @@
+{
+  "plan_version": 1,
+  "plan_id": "plan_example91c2",
+  "plan_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "request_id": "req_example8d4b",
+  "capability": { "id": "example.setting.update", "version": "1.0.0" },
+  "subject_ref": "sub_example001",
+  "resource_ref": "setting-example-01",
+  "environment": "development",
+  "policy_decision_ref": "decision_example001",
+  "created_at": "2026-08-03T00:00:00Z",
+  "expires_at": "2026-08-03T00:05:00Z",
+  "preconditions": [{ "kind": "version_equals", "value": 7 }],
+  "effects": [{ "kind": "update", "field": "display_mode" }],
+  "verification": [{ "kind": "setting_value_matches" }],
+  "rollback": "restore"
+}

--- a/contracts/capability/v1/examples/read-definition.json
+++ b/contracts/capability/v1/examples/read-definition.json
@@ -1,0 +1,61 @@
+{
+  "contract_version": 1,
+  "capability": {
+    "id": "node.inspect",
+    "version": "1.0.0",
+    "summary": "Inspect bounded metadata for one configured node",
+    "stability": "experimental"
+  },
+  "resource": { "kinds": ["node"], "cardinality": "one" },
+  "environment": { "required": true },
+  "operation": { "model": "typed", "class": "read", "effects": ["observe"] },
+  "input": {
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["include"],
+      "properties": {
+        "include": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 4,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": ["health", "platform", "uptime"],
+            "maxLength": 16
+          }
+        }
+      }
+    }
+  },
+  "output": {
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["health", "freshness_seconds"],
+      "properties": {
+        "health": { "type": "string", "enum": ["healthy", "degraded", "unknown"], "maxLength": 16 },
+        "freshness_seconds": { "type": "integer", "minimum": 0, "maximum": 300 }
+      }
+    }
+  },
+  "risk": { "level": "low", "data_classes": ["operational_metadata"] },
+  "mutation": { "mode": "none", "destructive": false },
+  "approval": { "mode": "never" },
+  "execution": {
+    "timeout_ms": 5000,
+    "max_attempts": 1,
+    "concurrency": "per_resource",
+    "max_input_bytes": 2048,
+    "max_output_bytes": 16384
+  },
+  "idempotency": { "classification": "naturally_idempotent", "key": "forbidden" },
+  "retry": { "policy": "safe_before_start_only" },
+  "verification": {
+    "mode": "required",
+    "postconditions": ["resource_identity_matches", "output_schema_valid"]
+  },
+  "rollback": { "mode": "not_applicable" },
+  "errors": { "taxonomy_version": 1 }
+}

--- a/contracts/capability/v1/examples/read-request.json
+++ b/contracts/capability/v1/examples/read-request.json
@@ -1,0 +1,9 @@
+{
+  "request_version": 1,
+  "request_id": "req_example7f3a",
+  "capability": { "id": "node.inspect", "version": "1.0.0" },
+  "resource": { "kind": "node", "ref": "node-example-01" },
+  "environment": "development",
+  "input": { "include": ["health", "platform"] },
+  "idempotency_key": null
+}

--- a/contracts/capability/v1/examples/result.json
+++ b/contracts/capability/v1/examples/result.json
@@ -1,0 +1,15 @@
+{
+  "result_version": 1,
+  "request_id": "req_example7f3a",
+  "capability": { "id": "node.inspect", "version": "1.0.0" },
+  "status": "succeeded",
+  "resource_ref": "node-example-01",
+  "environment": "development",
+  "attempts": 1,
+  "implementation_ref": "impl_sha256_example2f90",
+  "started_at": "2026-08-03T00:00:00Z",
+  "finished_at": "2026-08-03T00:00:01Z",
+  "output": { "health": "healthy", "freshness_seconds": 1 },
+  "verification": { "status": "verified", "evidence_refs": ["evidence_example2ad4"] },
+  "error": null
+}

--- a/contracts/capability/v1/fixtures/negative-cases.json
+++ b/contracts/capability/v1/fixtures/negative-cases.json
@@ -1,0 +1,99 @@
+[
+  {
+    "name": "unknown definition field",
+    "record": "definition",
+    "base": "read-definition.json",
+    "set": { "/unexpected": true },
+    "expected_code": "schema_additionalProperties"
+  },
+  {
+    "name": "unsupported contract version",
+    "record": "definition",
+    "base": "read-definition.json",
+    "set": { "/contract_version": 2 },
+    "expected_code": "schema_const"
+  },
+  {
+    "name": "unbounded input string",
+    "record": "definition",
+    "base": "read-definition.json",
+    "delete": ["/input/schema/properties/include/maxItems"],
+    "expected_code": "schema_profile_unbounded_array"
+  },
+  {
+    "name": "input schema without object root",
+    "record": "definition",
+    "base": "read-definition.json",
+    "set": { "/input/schema": {} },
+    "expected_code": "schema_profile_root_object"
+  },
+  {
+    "name": "credential-shaped input",
+    "record": "definition",
+    "base": "read-definition.json",
+    "set": {
+      "/input/schema/properties/token": { "type": "string", "maxLength": 64 }
+    },
+    "expected_code": "schema_profile_forbidden_input"
+  },
+  {
+    "name": "unsafe input pattern",
+    "record": "definition",
+    "base": "read-definition.json",
+    "set": {
+      "/input/schema/properties/include/items/pattern": "^(a+)+$"
+    },
+    "expected_code": "schema_profile_unsafe_pattern"
+  },
+  {
+    "name": "cyclic local schema reference",
+    "record": "definition",
+    "base": "read-definition.json",
+    "set": {
+      "/input/schema/$defs": {
+        "loop": { "$ref": "#/$defs/loop" }
+      }
+    },
+    "expected_code": "schema_profile_cyclic_ref"
+  },
+  {
+    "name": "unrestricted execution identity",
+    "record": "definition",
+    "base": "read-definition.json",
+    "set": { "/capability/id": "system.shell" },
+    "expected_code": "definition_unrestricted_execution_identity"
+  },
+  {
+    "name": "mutating capability without verification",
+    "record": "definition",
+    "base": "mutation-definition.json",
+    "set": { "/verification/mode": "not_applicable", "/verification/postconditions": [] },
+    "expected_code": "definition_mutation_verification"
+  },
+  {
+    "name": "non-idempotent automatic retry",
+    "record": "definition",
+    "base": "mutation-definition.json",
+    "set": {
+      "/idempotency/classification": "non_idempotent",
+      "/idempotency/key": "forbidden",
+      "/execution/max_attempts": 2,
+      "/retry/policy": "provider_verified_idempotent"
+    },
+    "expected_code": "definition_non_idempotent_retry"
+  },
+  {
+    "name": "unavailable rollback without elevated controls",
+    "record": "definition",
+    "base": "mutation-definition.json",
+    "set": { "/rollback/mode": "unavailable", "/risk/level": "medium" },
+    "expected_code": "definition_unavailable_rollback_controls"
+  },
+  {
+    "name": "request subject injection",
+    "record": "request",
+    "base": "read-request.json",
+    "set": { "/subject_ref": "sub_attacker001" },
+    "expected_code": "schema_additionalProperties"
+  }
+]

--- a/contracts/capability/v1/schemas/common.schema.json
+++ b/contracts/capability/v1/schemas/common.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yukh.example/schemas/capability/v1/common.schema.json",
+  "$defs": {
+    "capabilityId": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$",
+      "minLength": 3,
+      "maxLength": 128
+    },
+    "semver": {
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$",
+      "maxLength": 128
+    },
+    "capabilityRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version"],
+      "properties": {
+        "id": { "$ref": "#/$defs/capabilityId" },
+        "version": { "$ref": "#/$defs/semver" }
+      }
+    },
+    "opaqueId": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]{2,127}$",
+      "maxLength": 128
+    },
+    "resourceRef": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$",
+      "maxLength": 256
+    },
+    "environment": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9._-]{0,63}$",
+      "maxLength": 64
+    },
+    "timestamp": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](?:\\.[0-9]+)?Z$",
+      "maxLength": 64
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$",
+      "maxLength": 71
+    },
+    "implementationRef": {
+      "type": "string",
+      "pattern": "^impl_[a-z0-9_]{8,122}$",
+      "maxLength": 128
+    },
+    "diagnostic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "path", "message"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]{1,63}$",
+          "maxLength": 64
+        },
+        "path": { "type": "string", "maxLength": 512 },
+        "message": { "type": "string", "minLength": 1, "maxLength": 512 }
+      }
+    },
+    "verificationSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "evidence_refs"],
+      "properties": {
+        "status": {
+          "enum": ["verified", "failed", "inconclusive", "not_applicable"]
+        },
+        "evidence_refs": {
+          "type": "array",
+          "maxItems": 32,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/opaqueId" }
+        }
+      }
+    }
+  }
+}

--- a/contracts/capability/v1/schemas/definition.schema.json
+++ b/contracts/capability/v1/schemas/definition.schema.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yukh.example/schemas/capability/v1/definition.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract_version", "capability", "resource", "environment", "operation",
+    "input", "output", "risk", "mutation", "approval", "execution",
+    "idempotency", "retry", "verification", "rollback", "errors"
+  ],
+  "properties": {
+    "contract_version": { "const": 1 },
+    "capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version", "summary", "stability"],
+      "properties": {
+        "id": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/capabilityId" },
+        "version": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/semver" },
+        "summary": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "stability": { "enum": ["experimental", "preview", "stable", "deprecated"] }
+      }
+    },
+    "resource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kinds", "cardinality"],
+      "properties": {
+        "kinds": {
+          "type": "array", "minItems": 1, "maxItems": 16, "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9._-]{0,63}$", "maxLength": 64 }
+        },
+        "cardinality": { "enum": ["one", "many"] },
+        "max_items": { "type": "integer", "minimum": 1, "maximum": 1000 }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "cardinality": { "const": "many" } }, "required": ["cardinality"] },
+          "then": { "required": ["max_items"], "properties": { "max_items": true } },
+          "else": { "not": { "required": ["max_items"] } }
+        }
+      ]
+    },
+    "environment": {
+      "type": "object", "additionalProperties": false, "required": ["required"],
+      "properties": { "required": { "const": true } }
+    },
+    "operation": {
+      "type": "object", "additionalProperties": false,
+      "required": ["model", "class", "effects"],
+      "properties": {
+        "model": { "const": "typed" },
+        "class": { "enum": ["read", "mutate"] },
+        "effects": {
+          "type": "array", "minItems": 1, "maxItems": 5, "uniqueItems": true,
+          "items": { "enum": ["observe", "create", "update", "delete", "emit"] }
+        }
+      }
+    },
+    "input": {
+      "type": "object", "additionalProperties": false, "required": ["schema"],
+      "properties": { "schema": { "type": "object" } }
+    },
+    "output": {
+      "type": "object", "additionalProperties": false, "required": ["schema"],
+      "properties": { "schema": { "type": "object" } }
+    },
+    "risk": {
+      "type": "object", "additionalProperties": false,
+      "required": ["level", "data_classes"],
+      "properties": {
+        "level": { "enum": ["low", "medium", "high", "critical"] },
+        "data_classes": {
+          "type": "array", "maxItems": 16, "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_]{0,63}$", "maxLength": 64 }
+        }
+      }
+    },
+    "mutation": {
+      "type": "object", "additionalProperties": false,
+      "required": ["mode", "destructive"],
+      "properties": {
+        "mode": { "enum": ["none", "planned", "transactional"] },
+        "destructive": { "type": "boolean" }
+      }
+    },
+    "approval": {
+      "type": "object", "additionalProperties": false, "required": ["mode"],
+      "properties": { "mode": { "enum": ["never", "policy", "explicit"] } }
+    },
+    "execution": {
+      "type": "object", "additionalProperties": false,
+      "required": ["timeout_ms", "max_attempts", "concurrency", "max_input_bytes", "max_output_bytes"],
+      "properties": {
+        "timeout_ms": { "type": "integer", "minimum": 1, "maximum": 300000 },
+        "max_attempts": { "type": "integer", "minimum": 1, "maximum": 5 },
+        "concurrency": { "enum": ["unrestricted_read", "per_subject", "per_resource", "exclusive_scope"] },
+        "max_input_bytes": { "type": "integer", "minimum": 2, "maximum": 1048576 },
+        "max_output_bytes": { "type": "integer", "minimum": 2, "maximum": 4194304 }
+      }
+    },
+    "idempotency": {
+      "type": "object", "additionalProperties": false,
+      "required": ["classification", "key"],
+      "properties": {
+        "classification": { "enum": ["naturally_idempotent", "keyed", "non_idempotent"] },
+        "key": { "enum": ["required", "optional", "forbidden"] }
+      }
+    },
+    "retry": {
+      "type": "object", "additionalProperties": false, "required": ["policy"],
+      "properties": {
+        "policy": { "enum": ["never", "safe_before_start_only", "safe_on_declared_transient_before_effect", "provider_verified_idempotent"] }
+      }
+    },
+    "verification": {
+      "type": "object", "additionalProperties": false,
+      "required": ["mode", "postconditions"],
+      "properties": {
+        "mode": { "enum": ["required", "not_applicable"] },
+        "postconditions": {
+          "type": "array", "maxItems": 32, "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_]{1,63}$", "maxLength": 64 }
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "mode": { "const": "required" } }, "required": ["mode"] },
+          "then": { "properties": { "postconditions": { "type": "array", "minItems": 1 } } },
+          "else": { "properties": { "postconditions": { "type": "array", "maxItems": 0 } } }
+        }
+      ]
+    },
+    "rollback": {
+      "type": "object", "additionalProperties": false, "required": ["mode"],
+      "properties": {
+        "mode": { "enum": ["not_applicable", "compensating", "restore", "unavailable"] },
+        "rationale": { "type": "string", "minLength": 1, "maxLength": 512 },
+        "recovery": { "type": "string", "minLength": 1, "maxLength": 512 },
+        "stop_conditions": {
+          "type": "array", "minItems": 1, "maxItems": 16, "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1, "maxLength": 256 }
+        }
+      }
+    },
+    "errors": {
+      "type": "object", "additionalProperties": false, "required": ["taxonomy_version"],
+      "properties": { "taxonomy_version": { "const": 1 } }
+    }
+  }
+}

--- a/contracts/capability/v1/schemas/error.schema.json
+++ b/contracts/capability/v1/schemas/error.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yukh.example/schemas/capability/v1/error.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["error_version", "code", "phase", "retry", "message", "diagnostics"],
+  "properties": {
+    "error_version": { "const": 1 },
+    "code": {
+      "enum": [
+        "unsupported_contract_version", "capability_not_found", "invalid_request",
+        "schema_validation_failed", "scope_resolution_failed", "authorization_denied",
+        "authorization_unavailable", "plan_invalidated", "approval_required",
+        "approval_invalid", "execution_timeout", "provider_unavailable",
+        "provider_protocol_error", "verification_failed", "verification_inconclusive",
+        "partial_failure", "outcome_indeterminate", "rollback_failed",
+        "audit_unavailable", "rate_limited", "internal_error"
+      ]
+    },
+    "phase": { "enum": ["resolve", "validate", "authorize", "plan", "approve", "execute", "verify", "rollback", "audit"] },
+    "retry": { "enum": ["never", "after_correction", "after_policy_change", "caller_must_replan", "after_approval", "policy_declared", "operator_review", "indeterminate"] },
+    "message": { "type": "string", "minLength": 1, "maxLength": 512 },
+    "diagnostics": {
+      "type": "array", "maxItems": 64,
+      "items": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/diagnostic" }
+    }
+  }
+}

--- a/contracts/capability/v1/schemas/plan.schema.json
+++ b/contracts/capability/v1/schemas/plan.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yukh.example/schemas/capability/v1/plan.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "plan_version", "plan_id", "plan_digest", "request_id", "capability",
+    "subject_ref", "resource_ref", "environment", "policy_decision_ref",
+    "created_at", "expires_at", "preconditions", "effects", "verification", "rollback"
+  ],
+  "properties": {
+    "plan_version": { "const": 1 },
+    "plan_id": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+    "plan_digest": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/digest" },
+    "request_id": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+    "capability": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/capabilityRef" },
+    "subject_ref": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+    "resource_ref": {
+      "oneOf": [
+        { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/resourceRef" },
+        {
+          "type": "array", "minItems": 1, "maxItems": 1000, "uniqueItems": true,
+          "items": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/resourceRef" }
+        }
+      ]
+    },
+    "environment": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/environment" },
+    "policy_decision_ref": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+    "created_at": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/timestamp" },
+    "expires_at": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/timestamp" },
+    "preconditions": { "type": "array", "maxItems": 64, "items": { "type": "object", "maxProperties": 16 } },
+    "effects": { "type": "array", "maxItems": 64, "items": { "type": "object", "maxProperties": 16 } },
+    "verification": { "type": "array", "maxItems": 64, "items": { "type": "object", "maxProperties": 16 } },
+    "rollback": { "enum": ["not_applicable", "compensating", "restore", "unavailable"] }
+  }
+}

--- a/contracts/capability/v1/schemas/request.schema.json
+++ b/contracts/capability/v1/schemas/request.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yukh.example/schemas/capability/v1/request.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["request_version", "request_id", "capability", "resource", "environment", "input"],
+  "properties": {
+    "request_version": { "const": 1 },
+    "request_id": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+    "capability": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/capabilityRef" },
+    "resource": {
+      "oneOf": [
+        {
+          "type": "object", "additionalProperties": false, "required": ["kind", "ref"],
+          "properties": {
+            "kind": { "type": "string", "pattern": "^[a-z][a-z0-9._-]{0,63}$", "maxLength": 64 },
+            "ref": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/resourceRef" }
+          }
+        },
+        {
+          "type": "object", "additionalProperties": false, "required": ["kind", "refs"],
+          "properties": {
+            "kind": { "type": "string", "pattern": "^[a-z][a-z0-9._-]{0,63}$", "maxLength": 64 },
+            "refs": {
+              "type": "array", "minItems": 1, "maxItems": 1000, "uniqueItems": true,
+              "items": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/resourceRef" }
+            }
+          }
+        }
+      ]
+    },
+    "environment": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/environment" },
+    "input": { "type": "object", "maxProperties": 128 },
+    "idempotency_key": {
+      "type": ["string", "null"], "pattern": "^[A-Za-z0-9._:-]{8,128}$", "maxLength": 128
+    }
+  }
+}

--- a/contracts/capability/v1/schemas/result.schema.json
+++ b/contracts/capability/v1/schemas/result.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yukh.example/schemas/capability/v1/result.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "result_version", "request_id", "capability", "status", "resource_ref",
+    "environment", "attempts", "implementation_ref", "started_at", "finished_at",
+    "output", "verification", "error"
+  ],
+  "properties": {
+    "result_version": { "const": 1 },
+    "request_id": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+    "capability": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/capabilityRef" },
+    "status": { "enum": ["succeeded", "denied", "failed", "partial", "indeterminate"] },
+    "resource_ref": {
+      "oneOf": [
+        { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/resourceRef" },
+        {
+          "type": "array", "minItems": 1, "maxItems": 1000, "uniqueItems": true,
+          "items": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/resourceRef" }
+        }
+      ]
+    },
+    "environment": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/environment" },
+    "attempts": { "type": "integer", "minimum": 0, "maximum": 5 },
+    "implementation_ref": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/implementationRef" },
+    "started_at": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/timestamp" },
+    "finished_at": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/timestamp" },
+    "output": { "type": ["object", "null"], "maxProperties": 128 },
+    "verification": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/verificationSummary" },
+    "error": {
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "https://yukh.example/schemas/capability/v1/error.schema.json" }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "status": { "const": "succeeded" } }, "required": ["status"] },
+      "then": {
+        "properties": {
+          "error": { "type": "null" },
+          "verification": {
+            "type": "object",
+            "properties": { "status": { "enum": ["verified", "not_applicable"] } }
+          }
+        }
+      },
+      "else": { "properties": { "error": { "$ref": "https://yukh.example/schemas/capability/v1/error.schema.json" } } }
+    }
+  ]
+}

--- a/contracts/capability/v1/validator.mjs
+++ b/contracts/capability/v1/validator.mjs
@@ -1,0 +1,467 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import Ajv2020 from "ajv/dist/2020.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const schemaDirectory = join(here, "schemas");
+const recordNames = ["definition", "request", "plan", "error", "result"];
+const schemas = new Map(
+  ["common", ...recordNames].map((name) => [
+    name,
+    JSON.parse(readFileSync(join(schemaDirectory, `${name}.schema.json`), "utf8")),
+  ]),
+);
+
+const ajv = new Ajv2020({
+  allErrors: true,
+  strict: true,
+  validateFormats: false,
+});
+
+for (const schema of schemas.values()) {
+  ajv.addSchema(schema);
+}
+
+const validators = new Map(
+  recordNames.map((name) => [name, ajv.getSchema(schemas.get(name).$id)]),
+);
+
+const forbiddenPropertyNames = new Set([
+  "argv",
+  "bearertoken",
+  "command",
+  "credential",
+  "credentials",
+  "executable",
+  "interpreter",
+  "password",
+  "privatekey",
+  "prototype",
+  "constructor",
+  "proto",
+  "providermethod",
+  "rawrequest",
+  "script",
+  "secret",
+  "sessionsecret",
+  "shell",
+  "token",
+]);
+
+const allowedSchemaKeywords = new Set([
+  "$defs",
+  "$ref",
+  "$schema",
+  "additionalProperties",
+  "allOf",
+  "anyOf",
+  "const",
+  "description",
+  "enum",
+  "items",
+  "maxItems",
+  "maxLength",
+  "maxProperties",
+  "maximum",
+  "minItems",
+  "minLength",
+  "minProperties",
+  "minimum",
+  "not",
+  "oneOf",
+  "pattern",
+  "properties",
+  "required",
+  "title",
+  "type",
+  "uniqueItems",
+]);
+
+const diagnosticMessages = {
+  additionalProperties: "unknown field",
+  const: "value does not match the required constant",
+  enum: "value is not in the allowed set",
+  maxItems: "array exceeds its item bound",
+  maxLength: "string exceeds its length bound",
+  maxProperties: "object exceeds its property bound",
+  maximum: "number exceeds its upper bound",
+  minItems: "array does not meet its item bound",
+  minLength: "string does not meet its length bound",
+  minProperties: "object does not meet its property bound",
+  minimum: "number is below its lower bound",
+  not: "value matches a forbidden shape",
+  oneOf: "value does not match exactly one allowed shape",
+  pattern: "string does not match the required pattern",
+  required: "required field is missing",
+  type: "value has the wrong type",
+  uniqueItems: "array items must be unique",
+};
+
+function pointerToken(value) {
+  return String(value).replaceAll("~", "~0").replaceAll("/", "~1");
+}
+
+function errorPath(error) {
+  if (error.keyword === "required") {
+    return `${error.instancePath}/${pointerToken(error.params.missingProperty)}`;
+  }
+  if (error.keyword === "additionalProperties") {
+    return `${error.instancePath}/${pointerToken(error.params.additionalProperty)}`;
+  }
+  return error.instancePath || "";
+}
+
+function ajvDiagnostics(errors) {
+  return (errors ?? []).map((error) => ({
+    code: `schema_${error.keyword}`,
+    path: errorPath(error),
+    message: diagnosticMessages[error.keyword] ?? "schema constraint failed",
+  }));
+}
+
+function add(diagnostics, code, path, message) {
+  diagnostics.push({ code, path, message });
+}
+
+function normalizePropertyName(name) {
+  return name.toLowerCase().replaceAll(/[^a-z0-9]/g, "");
+}
+
+function inspectEmbeddedSchema(schema, basePath, diagnostics) {
+  const seen = new Set();
+  let nodes = 0;
+
+  if (schema?.type !== "object") {
+    add(diagnostics, "schema_profile_root_object", `${basePath}/type`, "embedded schema root must be an object");
+  }
+
+  function visit(node, path, depth) {
+    nodes += 1;
+    if (nodes > 512) {
+      add(diagnostics, "schema_profile_node_limit", basePath, "schema exceeds the node limit");
+      return;
+    }
+    if (depth > 16) {
+      add(diagnostics, "schema_profile_depth_limit", path, "schema exceeds the nesting limit");
+      return;
+    }
+    if (node === true || node === false) {
+      add(diagnostics, "schema_profile_boolean_schema", path, "boolean schemas are not supported");
+      return;
+    }
+    if (node === null || typeof node !== "object" || Array.isArray(node)) {
+      add(diagnostics, "schema_profile_invalid_node", path, "schema node must be an object");
+      return;
+    }
+    if (seen.has(node)) return;
+    seen.add(node);
+
+    for (const keyword of Object.keys(node)) {
+      if (!allowedSchemaKeywords.has(keyword)) {
+        add(diagnostics, "schema_profile_unknown_keyword", `${path}/${pointerToken(keyword)}`, "schema keyword is not supported");
+      }
+    }
+
+    if (typeof node.$ref === "string" && !node.$ref.startsWith("#/$defs/")) {
+      add(diagnostics, "schema_profile_remote_ref", `${path}/$ref`, "only local $defs references are supported");
+    }
+    if (typeof node.pattern === "string" && (
+      node.pattern.length > 128 ||
+      node.pattern.includes("(?") ||
+      /\\[1-9]/.test(node.pattern) ||
+      /\.(?:\*|\+)/.test(node.pattern) ||
+      /\([^)]*(?:\*|\+|\{[0-9]+(?:,[0-9]*)?\})[^)]*\)(?:\*|\+|\{)/.test(node.pattern) ||
+      /(?:\*|\+|\{[0-9]+(?:,[0-9]*)?\})(?:\*|\+|\{)/.test(node.pattern)
+    )) {
+      add(diagnostics, "schema_profile_unsafe_pattern", `${path}/pattern`, "pattern is outside the bounded regular-expression profile");
+    }
+
+    const types = Array.isArray(node.type) ? node.type : [node.type];
+    if (types.includes("object") || node.properties) {
+      if (node.additionalProperties !== false) {
+        add(diagnostics, "schema_profile_open_object", `${path}/additionalProperties`, "object schemas must deny unknown fields");
+      }
+      if (node.properties && Object.keys(node.properties).length > 128) {
+        add(diagnostics, "schema_profile_property_limit", `${path}/properties`, "object schema exceeds the property limit");
+      }
+      for (const [name, child] of Object.entries(node.properties ?? {})) {
+        if (forbiddenPropertyNames.has(normalizePropertyName(name))) {
+          add(diagnostics, "schema_profile_forbidden_input", `${path}/properties/${pointerToken(name)}`, "field name can carry executable or credential authority");
+        }
+        visit(child, `${path}/properties/${pointerToken(name)}`, depth + 1);
+      }
+    }
+
+    if (types.includes("string") && !Number.isInteger(node.maxLength)) {
+      add(diagnostics, "schema_profile_unbounded_string", `${path}/maxLength`, "string schemas require maxLength");
+    }
+    if (types.includes("array")) {
+      if (!Number.isInteger(node.maxItems)) {
+        add(diagnostics, "schema_profile_unbounded_array", `${path}/maxItems`, "array schemas require maxItems");
+      }
+      if (!node.items) {
+        add(diagnostics, "schema_profile_missing_items", `${path}/items`, "array schemas require an item schema");
+      } else {
+        visit(node.items, `${path}/items`, depth + 1);
+      }
+    }
+    if (types.includes("number") || types.includes("integer")) {
+      if (typeof node.minimum !== "number" || typeof node.maximum !== "number") {
+        add(diagnostics, "schema_profile_unbounded_number", path, "numeric schemas require minimum and maximum");
+      }
+    }
+
+    for (const keyword of ["allOf", "anyOf", "oneOf"]) {
+      if (Array.isArray(node[keyword])) {
+        node[keyword].forEach((child, index) => visit(child, `${path}/${keyword}/${index}`, depth + 1));
+      }
+    }
+    if (node.not) visit(node.not, `${path}/not`, depth + 1);
+    for (const [name, child] of Object.entries(node.$defs ?? {})) {
+      visit(child, `${path}/$defs/${pointerToken(name)}`, depth + 1);
+    }
+  }
+
+  visit(schema, basePath, 0);
+
+  const definitions = schema?.$defs ?? {};
+  const graph = new Map(Object.keys(definitions).map((name) => [name, new Set()]));
+  function collectReferences(node, references) {
+    if (!node || typeof node !== "object") return;
+    if (typeof node.$ref === "string" && node.$ref.startsWith("#/$defs/")) {
+      references.add(node.$ref.slice("#/$defs/".length).split("/")[0]);
+    }
+    for (const value of Object.values(node)) collectReferences(value, references);
+  }
+  for (const [name, definition] of Object.entries(definitions)) {
+    collectReferences(definition, graph.get(name));
+  }
+  const visiting = new Set();
+  const visited = new Set();
+  function hasCycle(name) {
+    if (visiting.has(name)) return true;
+    if (visited.has(name) || !graph.has(name)) return false;
+    visiting.add(name);
+    for (const target of graph.get(name)) if (hasCycle(target)) return true;
+    visiting.delete(name);
+    visited.add(name);
+    return false;
+  }
+  for (const name of graph.keys()) {
+    if (hasCycle(name)) {
+      add(diagnostics, "schema_profile_cyclic_ref", `${basePath}/$defs/${pointerToken(name)}`, "schema references must be acyclic");
+      break;
+    }
+  }
+}
+
+function definitionDiagnostics(definition) {
+  const diagnostics = [];
+  const operation = definition.operation;
+  const mutation = definition.mutation;
+  const approval = definition.approval;
+  const execution = definition.execution;
+  const idempotency = definition.idempotency;
+  const retry = definition.retry;
+  const verification = definition.verification;
+  const rollback = definition.rollback;
+  const risk = definition.risk;
+
+  if (!operation || !mutation || !approval || !execution || !idempotency || !retry || !verification || !rollback || !risk) {
+    return diagnostics;
+  }
+
+  const reservedSegments = new Set(["command", "exec", "interpreter", "proxy", "script", "shell"]);
+  for (const segment of definition.capability?.id?.split(/[._-]/) ?? []) {
+    if (reservedSegments.has(segment)) {
+      add(diagnostics, "definition_unrestricted_execution_identity", "/capability/id", "capability identity names execution machinery");
+      break;
+    }
+  }
+
+  if (operation.class === "read") {
+    if (operation.effects.some((effect) => effect !== "observe")) {
+      add(diagnostics, "definition_read_effect", "/operation/effects", "read capabilities may declare only observe effects");
+    }
+    if (mutation.mode !== "none" || mutation.destructive) {
+      add(diagnostics, "definition_read_mutation", "/mutation", "read capabilities cannot declare mutation");
+    }
+    if (rollback.mode !== "not_applicable") {
+      add(diagnostics, "definition_read_rollback", "/rollback/mode", "read capabilities use not_applicable rollback");
+    }
+  }
+
+  if (operation.class === "mutate") {
+    if (mutation.mode === "none") {
+      add(diagnostics, "definition_mutation_mode", "/mutation/mode", "mutating capabilities require a mutation mode");
+    }
+    if (!operation.effects.some((effect) => effect !== "observe")) {
+      add(diagnostics, "definition_mutation_effect", "/operation/effects", "mutating capabilities require a mutating effect");
+    }
+    if (verification.mode !== "required") {
+      add(diagnostics, "definition_mutation_verification", "/verification/mode", "mutating capabilities require verification");
+    }
+    if (rollback.mode === "not_applicable") {
+      add(diagnostics, "definition_mutation_rollback", "/rollback/mode", "mutating capabilities must declare rollback behavior");
+    }
+  }
+
+  if (approval.mode === "never" && (operation.class !== "read" || mutation.destructive)) {
+    add(diagnostics, "definition_approval_never", "/approval/mode", "approval never is limited to non-destructive reads");
+  }
+  if (mutation.destructive && (
+    operation.class !== "mutate" || approval.mode !== "explicit" ||
+    execution.max_attempts !== 1 || retry.policy !== "never"
+  )) {
+    add(diagnostics, "definition_destructive_controls", "/mutation/destructive", "destructive mutation requires explicit approval, one attempt, and no retry");
+  }
+  if (rollback.mode === "unavailable") {
+    if (!new Set(["high", "critical"]).has(risk.level) || approval.mode !== "explicit" || execution.max_attempts !== 1 || retry.policy !== "never") {
+      add(diagnostics, "definition_unavailable_rollback_controls", "/rollback/mode", "unavailable rollback requires elevated risk controls");
+    }
+    for (const field of ["rationale", "recovery", "stop_conditions"]) {
+      if (rollback[field] === undefined) {
+        add(diagnostics, "definition_unavailable_rollback_field", `/rollback/${field}`, "unavailable rollback requires recovery metadata");
+      }
+    }
+  }
+  if (idempotency.classification === "keyed" && idempotency.key === "forbidden") {
+    add(diagnostics, "definition_idempotency_key", "/idempotency/key", "keyed idempotency requires a key");
+  }
+  if (idempotency.classification !== "keyed" && idempotency.key !== "forbidden") {
+    add(diagnostics, "definition_idempotency_key", "/idempotency/key", "only keyed idempotency accepts a key");
+  }
+  if (idempotency.classification === "non_idempotent" && (execution.max_attempts !== 1 || retry.policy !== "never")) {
+    add(diagnostics, "definition_non_idempotent_retry", "/retry/policy", "non-idempotent capabilities allow one attempt and no retry");
+  }
+  if (execution.concurrency === "unrestricted_read" && operation.class !== "read") {
+    add(diagnostics, "definition_concurrency", "/execution/concurrency", "unrestricted_read concurrency is limited to read capabilities");
+  }
+
+  for (const [field, schema] of [["input", definition.input?.schema], ["output", definition.output?.schema]]) {
+    const before = diagnostics.length;
+    inspectEmbeddedSchema(schema, `/${field}/schema`, diagnostics);
+    if (diagnostics.length === before) {
+      try {
+        new Ajv2020({ allErrors: true, strict: true }).compile(schema);
+      } catch {
+        add(diagnostics, "schema_profile_compile_error", `/${field}/schema`, "schema does not compile under the supported profile");
+      }
+    }
+  }
+  return diagnostics;
+}
+
+function sortDiagnostics(diagnostics) {
+  return diagnostics
+    .map((diagnostic, index) => ({ ...diagnostic, index }))
+    .sort((left, right) =>
+      left.path.localeCompare(right.path) ||
+      left.code.localeCompare(right.code) ||
+      left.index - right.index,
+    )
+    .slice(0, 64)
+    .map(({ index: _index, ...diagnostic }) => diagnostic);
+}
+
+export function validateRecord(kind, value) {
+  const validator = validators.get(kind);
+  if (!validator) {
+    throw new TypeError(`unsupported record kind: ${kind}`);
+  }
+  const valid = validator(value);
+  const diagnostics = ajvDiagnostics(validator.errors);
+  if (valid && kind === "definition") {
+    diagnostics.push(...definitionDiagnostics(value));
+  }
+  const ordered = sortDiagnostics(diagnostics);
+  return { valid: ordered.length === 0, diagnostics: ordered };
+}
+
+export function validateRequestAgainstDefinition(request, definition) {
+  const diagnostics = [];
+  const requestResult = validateRecord("request", request);
+  const definitionResult = validateRecord("definition", definition);
+  diagnostics.push(...requestResult.diagnostics, ...definitionResult.diagnostics);
+  if (diagnostics.length > 0) return { valid: false, diagnostics: sortDiagnostics(diagnostics) };
+
+  if (request.capability.id !== definition.capability.id || request.capability.version !== definition.capability.version) {
+    add(diagnostics, "request_capability_mismatch", "/capability", "request does not select the exact definition");
+  }
+  if (!definition.resource.kinds.includes(request.resource.kind)) {
+    add(diagnostics, "request_resource_kind", "/resource/kind", "resource kind is outside the capability scope");
+  }
+  if (definition.resource.cardinality === "one" && !request.resource.ref) {
+    add(diagnostics, "request_resource_cardinality", "/resource", "capability requires exactly one resource");
+  }
+  if (definition.resource.cardinality === "many") {
+    if (!request.resource.refs) {
+      add(diagnostics, "request_resource_cardinality", "/resource", "capability requires a bounded resource set");
+    } else if (request.resource.refs.length > definition.resource.max_items) {
+      add(diagnostics, "request_resource_limit", "/resource/refs", "resource set exceeds the capability limit");
+    }
+  }
+  if (Buffer.byteLength(JSON.stringify(request.input), "utf8") > definition.execution.max_input_bytes) {
+    add(diagnostics, "request_input_byte_limit", "/input", "input exceeds the capability byte limit");
+  }
+  const keyMode = definition.idempotency.key;
+  if (keyMode === "required" && !request.idempotency_key) {
+    add(diagnostics, "request_idempotency_key_required", "/idempotency_key", "idempotency key is required");
+  }
+  if (keyMode === "forbidden" && request.idempotency_key != null) {
+    add(diagnostics, "request_idempotency_key_forbidden", "/idempotency_key", "idempotency key is forbidden");
+  }
+
+  const inputValidator = new Ajv2020({ allErrors: true, strict: true }).compile(definition.input.schema);
+  if (!inputValidator(request.input)) {
+    diagnostics.push(...ajvDiagnostics(inputValidator.errors).map((diagnostic) => ({
+      ...diagnostic,
+      path: `/input${diagnostic.path}`,
+    })));
+  }
+  return { valid: diagnostics.length === 0, diagnostics: sortDiagnostics(diagnostics) };
+}
+
+export function validateOutputAgainstDefinition(output, definition) {
+  const definitionResult = validateRecord("definition", definition);
+  if (!definitionResult.valid) return definitionResult;
+
+  if (Buffer.byteLength(JSON.stringify(output), "utf8") > definition.execution.max_output_bytes) {
+    return {
+      valid: false,
+      diagnostics: [{ code: "output_byte_limit", path: "/output", message: "output exceeds the capability byte limit" }],
+    };
+  }
+  const outputValidator = new Ajv2020({ allErrors: true, strict: true }).compile(definition.output.schema);
+  if (outputValidator(output)) return { valid: true, diagnostics: [] };
+  return {
+    valid: false,
+    diagnostics: sortDiagnostics(ajvDiagnostics(outputValidator.errors).map((diagnostic) => ({
+      ...diagnostic,
+      path: `/output${diagnostic.path}`,
+    }))),
+  };
+}
+
+export function validateResultAgainstDefinition(result, definition) {
+  const diagnostics = [];
+  const resultResult = validateRecord("result", result);
+  const definitionResult = validateRecord("definition", definition);
+  diagnostics.push(...resultResult.diagnostics, ...definitionResult.diagnostics);
+  if (diagnostics.length > 0) return { valid: false, diagnostics: sortDiagnostics(diagnostics) };
+
+  if (result.capability.id !== definition.capability.id || result.capability.version !== definition.capability.version) {
+    add(diagnostics, "result_capability_mismatch", "/capability", "result does not identify the exact definition");
+  }
+  if (result.attempts > definition.execution.max_attempts) {
+    add(diagnostics, "result_attempt_limit", "/attempts", "result exceeds the definition attempt limit");
+  }
+  if (result.status === "succeeded" && definition.operation.class === "mutate" && result.verification.status !== "verified") {
+    add(diagnostics, "result_mutation_unverified", "/verification/status", "mutating success requires verified postconditions");
+  }
+  if (result.output !== null) {
+    diagnostics.push(...validateOutputAgainstDefinition(result.output, definition).diagnostics);
+  }
+  return { valid: diagnostics.length === 0, diagnostics: sortDiagnostics(diagnostics) };
+}

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -151,3 +151,29 @@ RFCs are superseded rather than edited.
 
 Until those records are accepted, this model establishes constraints and stop
 conditions; it does not authorize operational capabilities or production use.
+
+## Capability contract implementation review — 2026-08-03
+
+- Governing issue: #5
+- Accepted architecture: RFC-0001
+- Scope: network-free schemas, validator, synthetic fixtures, and tests
+- New trust boundary: none
+
+The contract package processes untrusted record and embedded-schema data but
+does not accept network traffic, resolve identity or policy, invoke a provider,
+hold credentials, persist audit events, or mutate a target.
+
+Implementation-specific threats and controls are:
+
+| Threat | Control | Residual risk |
+| --- | --- | --- |
+| schema bombs or recursive references | node/depth/property limits; remote and cyclic references rejected before compilation | complex but acyclic schemas still consume bounded local CPU |
+| regular-expression denial of service | pattern length and construct restrictions; provider schema review remains mandatory | the conservative filter is not a formal regex complexity proof |
+| prototype or credential channel through property names | closed objects; dangerous and credential-shaped names rejected; input values excluded from diagnostics | semantic intent still requires human provider review |
+| diagnostic disclosure or nondeterminism | allowlisted messages without values; stable path/code ordering; 64-item cap; repeatability tests | paths reveal only submitted field names |
+| malicious or incompatible dependency | exact Ajv version and lockfile; install scripts disabled in validation; dependency audit evidence | registry and build-environment integrity remain governed by #10 |
+| invalid provider output represented as success | result and output validation; mutating success requires verified postconditions | real verification semantics remain governed by #4 and #9 |
+
+No operational capability is authorized by this review. A first provider,
+listener, authentication profile, policy adapter, plan executor, or audit store
+requires another threat-model impact review under its governing issue and RFC.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,72 @@
+{
+  "name": "yukh-mcp",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "yukh-mcp",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "8.20.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "yukh-mcp",
+  "version": "0.0.0",
+  "description": "Policy-governed capability gateway for safe agent operations",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "test": "node --test",
+    "test:contracts": "node --test test/contracts/*.test.mjs"
+  },
+  "dependencies": {
+    "ajv": "8.20.0"
+  }
+}

--- a/test/contracts/capability-contract.test.mjs
+++ b/test/contracts/capability-contract.test.mjs
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  validateOutputAgainstDefinition,
+  validateRecord,
+  validateResultAgainstDefinition,
+  validateRequestAgainstDefinition,
+} from "../../contracts/capability/v1/validator.mjs";
+
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const contractRoot = join(repositoryRoot, "contracts/capability/v1");
+const examples = join(contractRoot, "examples");
+
+function load(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function pointerParts(pointer) {
+  return pointer.slice(1).split("/").map((part) => part.replaceAll("~1", "/").replaceAll("~0", "~"));
+}
+
+function setPointer(document, pointer, value) {
+  const parts = pointerParts(pointer);
+  const key = parts.pop();
+  let parent = document;
+  for (const part of parts) parent = parent[part];
+  parent[key] = value;
+}
+
+function deletePointer(document, pointer) {
+  const parts = pointerParts(pointer);
+  const key = parts.pop();
+  let parent = document;
+  for (const part of parts) parent = parent[part];
+  delete parent[key];
+}
+
+const validRecords = [
+  ["definition", "read-definition.json"],
+  ["definition", "mutation-definition.json"],
+  ["request", "read-request.json"],
+  ["request", "mutation-request.json"],
+  ["plan", "plan.json"],
+  ["result", "result.json"],
+  ["error", "error.json"],
+];
+
+for (const [kind, filename] of validRecords) {
+  test(`${filename} validates as ${kind}`, () => {
+    assert.deepEqual(validateRecord(kind, load(join(examples, filename))), {
+      valid: true,
+      diagnostics: [],
+    });
+  });
+}
+
+test("read request validates against its exact definition", () => {
+  const result = validateRequestAgainstDefinition(
+    load(join(examples, "read-request.json")),
+    load(join(examples, "read-definition.json")),
+  );
+  assert.deepEqual(result, { valid: true, diagnostics: [] });
+});
+
+test("mutation request requires its idempotency key", () => {
+  const request = load(join(examples, "mutation-request.json"));
+  delete request.idempotency_key;
+  const result = validateRequestAgainstDefinition(
+    request,
+    load(join(examples, "mutation-definition.json")),
+  );
+  assert.equal(result.valid, false);
+  assert(result.diagnostics.some(({ code }) => code === "request_idempotency_key_required"));
+});
+
+test("many-resource requests enforce the definition bound", () => {
+  const definition = load(join(examples, "read-definition.json"));
+  definition.resource = { kinds: ["node"], cardinality: "many", max_items: 2 };
+  const request = load(join(examples, "read-request.json"));
+  request.resource = { kind: "node", refs: ["node-example-01", "node-example-02"] };
+  assert.equal(validateRequestAgainstDefinition(request, definition).valid, true);
+
+  request.resource.refs.push("node-example-03");
+  const invalid = validateRequestAgainstDefinition(request, definition);
+  assert.equal(invalid.valid, false);
+  assert(invalid.diagnostics.some(({ code }) => code === "request_resource_limit"));
+});
+
+test("request and output bytes remain within definition bounds", () => {
+  const definition = load(join(examples, "read-definition.json"));
+  const request = load(join(examples, "read-request.json"));
+  definition.execution.max_input_bytes = 2;
+  assert(validateRequestAgainstDefinition(request, definition).diagnostics.some(
+    ({ code }) => code === "request_input_byte_limit",
+  ));
+
+  definition.execution.max_input_bytes = 2048;
+  definition.execution.max_output_bytes = 2;
+  assert.deepEqual(validateOutputAgainstDefinition(
+    { health: "healthy", freshness_seconds: 2 },
+    definition,
+  ), {
+    valid: false,
+    diagnostics: [{ code: "output_byte_limit", path: "/output", message: "output exceeds the capability byte limit" }],
+  });
+});
+
+test("provider output is validated before release", () => {
+  const definition = load(join(examples, "read-definition.json"));
+  assert.deepEqual(validateOutputAgainstDefinition(
+    { health: "healthy", freshness_seconds: 2 },
+    definition,
+  ), { valid: true, diagnostics: [] });
+
+  const invalid = validateOutputAgainstDefinition(
+    { health: "healthy", freshness_seconds: 2, provider_body: "not allowed" },
+    definition,
+  );
+  assert.equal(invalid.valid, false);
+  assert.deepEqual(invalid.diagnostics, [{
+    code: "schema_additionalProperties",
+    path: "/output/provider_body",
+    message: "unknown field",
+  }]);
+});
+
+test("mutating success requires verified postconditions", () => {
+  const definition = load(join(examples, "mutation-definition.json"));
+  const result = load(join(examples, "result.json"));
+  result.capability = clone(definition.capability);
+  delete result.capability.summary;
+  delete result.capability.stability;
+  result.resource_ref = "setting-example-01";
+  result.output = { changed: true, version: 8 };
+  result.verification = { status: "inconclusive", evidence_refs: ["evidence_example2ad4"] };
+  result.error = {
+    error_version: 1,
+    code: "verification_inconclusive",
+    phase: "verify",
+    retry: "operator_review",
+    message: "verification is inconclusive",
+    diagnostics: [],
+  };
+  result.status = "failed";
+  assert.equal(validateResultAgainstDefinition(result, definition).valid, true);
+
+  result.status = "succeeded";
+  result.error = null;
+  const invalid = validateResultAgainstDefinition(result, definition);
+  assert.equal(invalid.valid, false);
+  assert(invalid.diagnostics.some(({ code }) => code === "schema_enum"));
+});
+
+test("negative fixtures fail with their stable expected code", () => {
+  const cases = load(join(contractRoot, "fixtures/negative-cases.json"));
+  for (const fixture of cases) {
+    const value = clone(load(join(examples, fixture.base)));
+    for (const [pointer, replacement] of Object.entries(fixture.set ?? {})) {
+      setPointer(value, pointer, replacement);
+    }
+    for (const pointer of fixture.delete ?? []) deletePointer(value, pointer);
+
+    const first = validateRecord(fixture.record, value);
+    const second = validateRecord(fixture.record, clone(value));
+    assert.equal(first.valid, false, fixture.name);
+    assert(first.diagnostics.some(({ code }) => code === fixture.expected_code), fixture.name);
+    assert.equal(JSON.stringify(first), JSON.stringify(second), `${fixture.name}: diagnostics changed`);
+  }
+});
+
+test("diagnostic ordering is independent of object property order", () => {
+  const left = { request_version: 2, unexpected: true };
+  const right = { unexpected: true, request_version: 2 };
+  assert.deepEqual(validateRecord("request", left), validateRecord("request", right));
+});
+
+test("unknown record kinds fail without exposing input", () => {
+  assert.throws(() => validateRecord("provider", { secret: "example" }), {
+    name: "TypeError",
+    message: "unsupported record kind: provider",
+  });
+});


### PR DESCRIPTION
Closes #5

## Summary

Implements the network-free portion of accepted RFC-0001:

- JSON Schema 2020-12 records for definitions, requests, plans, results, errors, and common types;
- deterministic structural and semantic validation;
- exact request/definition, output/definition, and result/definition binding;
- finite resource, byte, time, attempt, diagnostic, and embedded-schema limits;
- read/mutation, approval, idempotency, retry, verification, rollback, and implementation-reference consistency;
- synthetic read and mutation examples plus negative conformance fixtures;
- package documentation and repository positioning updates.

## Security impact

The living threat model now records the implementation review for schema bombs, cyclic/remote references, regex denial of service, prototype/credential channels, diagnostic disclosure, dependency risk, and invalid provider output.

The package has no network listener, identity or policy adapter, provider invocation, credentials, audit persistence, deployment, or target mutation. It authorizes no operational capability.

## Context impact

- Implements accepted RFC-0001 without modifying it.
- Adds `SESSION-2026-08-03-02` with scope and evidence.
- Adds no trust boundary.

## Validation

- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm test`: 16 passed, 0 failed
- `npm audit --omit=dev`: 0 vulnerabilities
- `git diff --check`
- 14 JSON artifacts parsed
- 10 Markdown files checked; all local links resolve
- exact dependency tree reviewed: Ajv 8.20.0 plus four locked transitive packages

## Remaining boundaries

Contract-test CI remains governed by #10. Authorization remains #3; the full plan/apply lifecycle remains #4; provider implementation remains #8. This PR does not begin #6.