### PR TITLE
Implement deny-by-default authorization contract v1

### DIFF
--- a/.context/sessions/SESSION-2026-08-03-03-authorization-implementation.md
+++ b/.context/sessions/SESSION-2026-08-03-03-authorization-implementation.md
@@ -1,0 +1,26 @@
+# Session — authorization contract implementation
+
+- Date: 2026-08-03
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/3
+- Branch: `agent/issue-3-authorization-implementation`
+- Status: implementation complete locally; draft PR pending
+
+## Outcome
+
+Implemented the network-free authorization v1 reference package governed by
+accepted RFC-0002: JSON Schemas, canonical request and decision digests,
+deny-override and all-or-nothing combining, typed constraint intersection,
+strongest-obligation accumulation, one-shot exact-binding enforcement, and
+sanitized evidence candidates.
+
+The test suite covers explicit, default, error, and indeterminate deny bases;
+cross-binding and replay rejection; multi-resource behavior; conflicting
+constraints; obligation blocking; ordering independence; and generated deny
+monotonicity cases.
+
+## Boundary
+
+No listener, provider, evaluator client, identity adapter, credential,
+deployment, or production runtime was introduced. Approval receipts remain
+unacceptable until issue #4 defines and implements their verification. Durable
+replay state and the complete audit envelope remain future integration work.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ The versioned capability contract is governed by accepted
 [network-free reference package](contracts/capability/v1/README.md) validates
 synthetic contract records without exposing a provider or MCP runtime.
 
+The deny-by-default authorization contract is governed by accepted
+[RFC-0002](.context/rfcs/RFC-0002-deny-by-default-authorization.md). Its
+[network-free reference package](contracts/authorization/v1/README.md) binds
+policy evaluation to the exact request, combines deny-overrides deterministically,
+and rejects decision replay without implementing identity, policy, or provider
+integrations.
+
 ## Principles
 
 - Capability, not custody.

--- a/contracts/authorization/v1/README.md
+++ b/contracts/authorization/v1/README.md
@@ -1,0 +1,34 @@
+# Authorization contract v1
+
+This network-free reference package implements the deny-by-default contract in
+[RFC-0002](../../../.context/rfcs/RFC-0002-deny-by-default-authorization.md).
+It does not authenticate identities, contact a policy evaluator, invoke a
+provider, expose an MCP listener, or hold credentials.
+
+`authorization.mjs` exports pure builders and validators, a deterministic
+deny-override combiner, sanitized evidence construction, and a process-local
+one-shot enforcement reference. The JSON Schemas define request, evaluation,
+decision, constraint, obligation, and evidence records.
+
+Only `effect: allow` with `basis: explicit` can authorize. Invalid or mismatched
+evaluation is error-deny, no applicable allow is default-deny, and an empty or
+unenforceable intersection is indeterminate-deny. Multi-resource requests are
+all-or-nothing.
+
+The reference enforcer consumes a decision on its first attempt. It validates
+the exact request and decision digests, subject and authentication context,
+capability definition, resource set, environment, policy, attribute snapshot,
+time bounds, constraint handlers, and decision-bound obligation receipts.
+`approval_required` always remains pending here: issue #4 must define the
+verifiable approval receipt before this package may accept one.
+
+Run all contract checks with:
+
+```sh
+npm test
+```
+
+The package is reference logic, not a production security boundary. A durable
+gateway must replace process-local consumption state, provide registered
+constraint enforcers, re-evaluate every invocation, and emit the complete audit
+envelope governed by issue #9.

--- a/contracts/authorization/v1/authorization.mjs
+++ b/contracts/authorization/v1/authorization.mjs
@@ -1,0 +1,245 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import Ajv2020 from "ajv/dist/2020.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const capabilitySchemas = join(here, "../../capability/v1/schemas");
+const recordNames = ["request", "evaluation", "decision", "evidence"];
+const schemas = new Map();
+for (const [name, path] of [
+  ["capability-common", join(capabilitySchemas, "common.schema.json")],
+  ["common", join(here, "schemas/common.schema.json")],
+  ...recordNames.map((name) => [name, join(here, `schemas/${name}.schema.json`)]),
+]) schemas.set(name, JSON.parse(readFileSync(path, "utf8")));
+
+const ajv = new Ajv2020({ allErrors: true, strict: true, validateFormats: false });
+for (const schema of schemas.values()) ajv.addSchema(schema);
+const validators = new Map(recordNames.map((name) => [name, ajv.getSchema(schemas.get(name).$id)]));
+
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value && typeof value === "object") return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`).join(",")}}`;
+  return JSON.stringify(value);
+}
+
+export function digest(value) {
+  return `sha256:${createHash("sha256").update(canonical(value)).digest("hex")}`;
+}
+
+function without(value, field) {
+  const copy = structuredClone(value);
+  delete copy[field];
+  return copy;
+}
+
+function diagnosticPath(error) {
+  if (error.keyword === "required") return `${error.instancePath}/${error.params.missingProperty}`;
+  if (error.keyword === "additionalProperties") return `${error.instancePath}/${error.params.additionalProperty}`;
+  return error.instancePath;
+}
+
+export function validateAuthorizationRecord(kind, value) {
+  const validator = validators.get(kind);
+  if (!validator) throw new TypeError(`unsupported authorization record kind: ${kind}`);
+  const schemaValid = validator(value);
+  const diagnostics = (validator.errors ?? []).map((error) => ({
+    code: `schema_${error.keyword}`,
+    path: diagnosticPath(error),
+    message: "authorization schema constraint failed",
+  }));
+  if (schemaValid && kind === "request" && digest(without(value, "request_digest")) !== value.request_digest) {
+    diagnostics.push({ code: "request_digest_mismatch", path: "/request_digest", message: "request digest does not match canonical content" });
+  }
+  if (schemaValid && kind === "decision") {
+    if (digest(without(value, "decision_digest")) !== value.decision_digest) diagnostics.push({ code: "decision_digest_mismatch", path: "/decision_digest", message: "decision digest does not match canonical content" });
+    if (value.effect === "allow" && value.basis !== "explicit") diagnostics.push({ code: "decision_effect_basis", path: "/basis", message: "only an explicit decision may allow" });
+  }
+  diagnostics.sort((a, b) => a.path.localeCompare(b.path) || a.code.localeCompare(b.code));
+  return { valid: diagnostics.length === 0, diagnostics: diagnostics.slice(0, 64) };
+}
+
+export function buildAuthorizationRequest({ authorization_request_id, subject, definition, resource, environment, normalized_input, risk, requested_at, policy, attributes }) {
+  const request = {
+    authorization_request_version: 1,
+    authorization_request_id,
+    subject: structuredClone(subject),
+    action: {
+      capability: { id: definition.capability.id, version: definition.capability.version },
+      definition_digest: digest(definition),
+      operation_class: definition.operation.class,
+      effects: [...definition.operation.effects].sort(),
+      approval_mode: definition.approval.mode,
+    },
+    resource: { kind: resource.kind, refs: [...new Set(resource.refs)].sort(), attributes_digest: resource.attributes_digest },
+    environment: structuredClone(environment),
+    request_context: { normalized_input_digest: digest(normalized_input), risk, requested_at },
+    policy: structuredClone(policy),
+    attributes: structuredClone(attributes),
+  };
+  request.request_digest = digest(request);
+  const result = validateAuthorizationRecord("request", request);
+  if (!result.valid) throw new TypeError(`invalid authorization request: ${result.diagnostics.map(({ code }) => code).join(",")}`);
+  return request;
+}
+
+const obligationRanks = {
+  approval_required: ["standard", "elevated", "destructive"],
+  evidence_profile: ["standard_read", "standard_mutation", "enhanced"],
+  verification_profile: ["schema_only", "declared_postconditions", "independent"],
+  redaction_profile: ["standard", "strict", "metadata_only"],
+  concurrency_profile: ["per_subject", "per_resource", "exclusive_scope"],
+};
+const dataRanks = ["public", "operational_metadata", "internal", "restricted"];
+
+function intersectValues(groups) {
+  return groups.reduce((left, right) => left.filter((value) => right.some((candidate) => canonical(candidate) === canonical(value))));
+}
+
+function combineConstraints(items) {
+  const grouped = Map.groupBy(items, (item) => item.type === "input_value_set" ? `${item.type}:${item.value.path}` : item.type);
+  const result = [];
+  for (const group of grouped.values()) {
+    const type = group[0].type;
+    let value;
+    if (["max_result_items", "max_output_bytes", "decision_ttl_ms", "concurrency_limit"].includes(type)) value = Math.min(...group.map((item) => item.value));
+    else if (type === "output_data_class") value = dataRanks[Math.max(...group.map((item) => dataRanks.indexOf(item.value)))];
+    else if (["output_fields", "allowed_resource_refs"].includes(type)) value = intersectValues(group.map((item) => item.value));
+    else if (type === "time_window") value = { not_before: group.map((item) => item.value.not_before).sort().at(-1), not_after: group.map((item) => item.value.not_after).sort()[0] };
+    else if (type === "input_value_set") value = { path: group[0].value.path, values: intersectValues(group.map((item) => item.value.values)) };
+    else return null;
+    if ((Array.isArray(value) && value.length === 0) || (type === "input_value_set" && value.values.length === 0) || (type === "time_window" && value.not_before >= value.not_after)) return null;
+    result.push({ type, value });
+  }
+  return result.sort((a, b) => a.type.localeCompare(b.type) || canonical(a.value).localeCompare(canonical(b.value)));
+}
+
+function combineObligations(items) {
+  const grouped = Map.groupBy(items, (item) => item.type);
+  const result = [];
+  for (const [type, group] of grouped) {
+    const ranks = obligationRanks[type];
+    if (!ranks) return null;
+    const index = Math.max(...group.map((item) => ranks.indexOf(item.value)));
+    if (index < 0) return null;
+    result.push({ type, value: ranks[index] });
+  }
+  return result.sort((a, b) => a.type.localeCompare(b.type));
+}
+
+function same(left, right) { return canonical(left) === canonical(right); }
+
+export function combineAuthorization({ request, evaluation, decision_id, issued_at, expires_at }) {
+  const requestResult = validateAuthorizationRecord("request", request);
+  const evaluationResult = validateAuthorizationRecord("evaluation", evaluation);
+  let basis = "default";
+  let reasons = ["no_applicable_allow"];
+  let constraints = [];
+  let obligations = [];
+  let allow = false;
+  const bindingValid = evaluationResult.valid && requestResult.valid &&
+    evaluation.authorization_request_id === request.authorization_request_id &&
+    evaluation.request_digest === request.request_digest && same(evaluation.policy, request.policy);
+
+  if (!bindingValid) {
+    basis = "error"; reasons = ["evaluation_invalid_or_mismatched"];
+  } else {
+    const requested = new Set(request.resource.refs);
+    const semanticInvalid = evaluation.statements.some((statement) =>
+      (request.resource.refs.length > 1 && !statement.resource_refs) ||
+      statement.resource_refs?.some((ref) => !requested.has(ref)),
+    );
+    const applicable = (resourceRef) => evaluation.statements.filter((statement) => !statement.resource_refs || statement.resource_refs.includes(resourceRef));
+    const resourceGroups = request.resource.refs.map(applicable);
+    if (semanticInvalid) {
+      basis = "error"; reasons = ["evaluation_invalid_or_mismatched"];
+    } else if (resourceGroups.some((group) => group.some((statement) => statement.effect === "deny"))) {
+      basis = "explicit";
+      reasons = evaluation.statements.filter((statement) => statement.effect === "deny").map((statement) => statement.reason_code).sort().filter((v, i, a) => i === 0 || v !== a[i - 1]);
+    } else if (resourceGroups.some((group) => !group.some((statement) => statement.effect === "allow"))) {
+      basis = "default"; reasons = ["no_applicable_allow"];
+    } else {
+      const allows = resourceGroups.flatMap((group) => group.filter((statement) => statement.effect === "allow"));
+      constraints = combineConstraints(allows.flatMap((statement) => statement.constraints));
+      obligations = combineObligations(allows.flatMap((statement) => statement.obligations));
+      if (!constraints || !obligations) {
+        basis = "indeterminate"; reasons = ["policy_result_unenforceable"]; constraints = []; obligations = [];
+      } else {
+        allow = true; basis = "explicit";
+        reasons = [...new Set(allows.map((statement) => statement.reason_code))].sort();
+      }
+    }
+  }
+
+  if (allow && request.action.approval_mode === "explicit") {
+    obligations = combineObligations([...obligations, { type: "approval_required", value: request.request_context.risk === "critical" ? "destructive" : "elevated" }]);
+  }
+  const ttl = constraints?.find(({ type }) => type === "decision_ttl_ms")?.value;
+  if (allow && (!Number.isFinite(Date.parse(issued_at)) || !Number.isFinite(Date.parse(expires_at)) || Date.parse(expires_at) <= Date.parse(issued_at) || (ttl && Date.parse(expires_at) - Date.parse(issued_at) > ttl))) {
+    allow = false; basis = "indeterminate"; reasons = ["decision_lifetime_invalid"]; constraints = []; obligations = [];
+  }
+  const decision = {
+    authorization_decision_version: 1, decision_id,
+    authorization_request_id: request.authorization_request_id, request_digest: request.request_digest,
+    effect: allow ? "allow" : "deny", basis, reason_codes: reasons,
+    subject_ref: request.subject.ref, authentication_context_ref: request.subject.authentication_context_ref,
+    action: structuredClone(request.action), resource: { kind: request.resource.kind, refs: [...request.resource.refs] },
+    environment_ref: request.environment.ref, policy: structuredClone(request.policy),
+    attribute_snapshot_ref: request.attributes.snapshot_ref,
+    constraints, obligations, issued_at, expires_at,
+    evaluator_ref: evaluation?.evaluator_ref ?? "impl_unavailable",
+  };
+  decision.decision_digest = digest(decision);
+  return decision;
+}
+
+function decisionMatchesRequest(decision, request) {
+  return decision.authorization_request_id === request.authorization_request_id && decision.request_digest === request.request_digest &&
+    decision.subject_ref === request.subject.ref && decision.authentication_context_ref === request.subject.authentication_context_ref &&
+    same(decision.action, request.action) && same(decision.resource, { kind: request.resource.kind, refs: request.resource.refs }) &&
+    decision.environment_ref === request.environment.ref && same(decision.policy, request.policy) && decision.attribute_snapshot_ref === request.attributes.snapshot_ref;
+}
+
+export function createDecisionEnforcer() {
+  const consumed = new Set();
+  return function enforce({ decision, request, now, obligation_receipts = [], constraint_handlers = {} }) {
+    if (consumed.has(decision.decision_id)) return { allowed: false, code: "decision_already_consumed" };
+    consumed.add(decision.decision_id);
+    if (!validateAuthorizationRecord("request", request).valid || !validateAuthorizationRecord("decision", decision).valid || !decisionMatchesRequest(decision, request)) return { allowed: false, code: "decision_binding_mismatch" };
+    if (decision.effect !== "allow") return { allowed: false, code: "authorization_denied" };
+    if (Date.parse(now) < Date.parse(decision.issued_at) || Date.parse(now) >= Date.parse(decision.expires_at)) return { allowed: false, code: "decision_stale" };
+    const window = decision.constraints.find(({ type }) => type === "time_window")?.value;
+    if (window && (now < window.not_before || now >= window.not_after)) return { allowed: false, code: "constraint_failed" };
+    for (const constraint of decision.constraints) {
+      if (constraint.type === "time_window") continue;
+      if (typeof constraint_handlers[constraint.type] !== "function" || constraint_handlers[constraint.type](structuredClone(constraint.value)) !== true) {
+        return { allowed: false, code: "constraint_unenforceable" };
+      }
+    }
+    const receipts = new Map(obligation_receipts.map((receipt) => [receipt.type, receipt]));
+    for (const obligation of decision.obligations) {
+      // RFC-0002 deliberately leaves approval receipt verification to issue #4.
+      if (obligation.type === "approval_required") return { allowed: false, code: "obligation_pending" };
+      const receipt = receipts.get(obligation.type);
+      if (!receipt || receipt.decision_id !== decision.decision_id || receipt.value !== obligation.value) return { allowed: false, code: "obligation_pending" };
+    }
+    return { allowed: true, code: "authorized" };
+  };
+}
+
+export function buildAuthorizationEvidence({ evidence_id, request, decision, evaluation, enforcement, obligation_receipt_refs = [] }) {
+  return {
+    authorization_evidence_version: 1, evidence_id,
+    authorization_request_id: request.authorization_request_id, request_digest: request.request_digest,
+    decision_id: decision.decision_id, decision_digest: decision.decision_digest,
+    effect: decision.effect, basis: decision.basis, reason_codes: [...decision.reason_codes],
+    subject_ref: request.subject.ref, authentication_context_ref: request.subject.authentication_context_ref,
+    action: structuredClone(request.action), resource: { kind: request.resource.kind, refs: [...request.resource.refs] },
+    environment_ref: request.environment.ref, policy: structuredClone(request.policy),
+    attribute_snapshot_ref: request.attributes.snapshot_ref, attribute_snapshot_digest: request.attributes.digest,
+    constraints_digest: digest(decision.constraints), obligations: structuredClone(decision.obligations),
+    evaluator_ref: decision.evaluator_ref, evaluated_at: evaluation.evaluated_at,
+    enforcement, obligation_receipt_refs: [...obligation_receipt_refs].sort(),
+  };
+}

--- a/contracts/authorization/v1/schemas/common.schema.json
+++ b/contracts/authorization/v1/schemas/common.schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yukh.example/schemas/authorization/v1/common.schema.json",
+  "$defs": {
+    "reasonCode": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]{2,63}$",
+      "maxLength": 64
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["bundle_ref", "revision", "digest"],
+      "properties": {
+        "bundle_ref": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+        "revision": { "type": "integer", "minimum": 1, "maximum": 2147483647 },
+        "digest": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/digest" }
+      }
+    },
+    "action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["capability", "definition_digest", "operation_class", "effects", "approval_mode"],
+      "properties": {
+        "capability": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/capabilityRef" },
+        "definition_digest": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/digest" },
+        "operation_class": { "enum": ["read", "mutate"] },
+        "effects": {
+          "type": "array", "minItems": 1, "maxItems": 5, "uniqueItems": true,
+          "items": { "enum": ["observe", "create", "update", "delete", "emit"] }
+        },
+        "approval_mode": { "enum": ["never", "policy", "explicit"] }
+      }
+    },
+    "constraint": {
+      "oneOf": [
+        {
+          "type": "object", "additionalProperties": false, "required": ["type", "value"],
+          "properties": {
+            "type": { "const": "output_data_class" },
+            "value": { "enum": ["public", "operational_metadata", "internal", "restricted"] }
+          }
+        },
+        {
+          "type": "object", "additionalProperties": false, "required": ["type", "value"],
+          "properties": {
+            "type": { "const": "output_fields" },
+            "value": {
+              "type": "array", "minItems": 1, "maxItems": 64, "uniqueItems": true,
+              "items": { "type": "string", "pattern": "^[a-z][a-z0-9_]{0,63}$", "maxLength": 64 }
+            }
+          }
+        },
+        {
+          "type": "object", "additionalProperties": false, "required": ["type", "value"],
+          "properties": {
+            "type": { "enum": ["max_result_items", "max_output_bytes", "decision_ttl_ms", "concurrency_limit"] },
+            "value": { "type": "integer", "minimum": 1, "maximum": 4194304 }
+          }
+        },
+        {
+          "type": "object", "additionalProperties": false, "required": ["type", "value"],
+          "properties": {
+            "type": { "const": "allowed_resource_refs" },
+            "value": {
+              "type": "array", "minItems": 1, "maxItems": 1000, "uniqueItems": true,
+              "items": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/resourceRef" }
+            }
+          }
+        },
+        {
+          "type": "object", "additionalProperties": false, "required": ["type", "value"],
+          "properties": {
+            "type": { "const": "time_window" },
+            "value": {
+              "type": "object", "additionalProperties": false, "required": ["not_before", "not_after"],
+              "properties": {
+                "not_before": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/timestamp" },
+                "not_after": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/timestamp" }
+              }
+            }
+          }
+        },
+        {
+          "type": "object", "additionalProperties": false, "required": ["type", "value"],
+          "properties": {
+            "type": { "const": "input_value_set" },
+            "value": {
+              "type": "object", "additionalProperties": false, "required": ["path", "values"],
+              "properties": {
+                "path": { "type": "string", "pattern": "^/(?:[^~/]|~0|~1)+(?:/(?:[^~/]|~0|~1)+)*$", "maxLength": 256 },
+                "values": {
+                  "type": "array", "minItems": 1, "maxItems": 64, "uniqueItems": true,
+                  "items": {
+                    "anyOf": [
+                      { "type": "string", "maxLength": 256 },
+                      { "type": "number", "minimum": -9007199254740991, "maximum": 9007199254740991 },
+                      { "type": "boolean" },
+                      { "type": "null" }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "obligation": {
+      "oneOf": [
+        {
+          "type": "object", "additionalProperties": false, "required": ["type", "value"],
+          "properties": {
+            "type": { "const": "approval_required" },
+            "value": { "enum": ["standard", "elevated", "destructive"] }
+          }
+        },
+        {
+          "type": "object", "additionalProperties": false, "required": ["type", "value"],
+          "properties": {
+            "type": { "const": "evidence_profile" },
+            "value": { "enum": ["standard_read", "standard_mutation", "enhanced"] }
+          }
+        },
+        {
+          "type": "object", "additionalProperties": false, "required": ["type", "value"],
+          "properties": {
+            "type": { "const": "verification_profile" },
+            "value": { "enum": ["schema_only", "declared_postconditions", "independent"] }
+          }
+        },
+        {
+          "type": "object", "additionalProperties": false, "required": ["type", "value"],
+          "properties": {
+            "type": { "const": "redaction_profile" },
+            "value": { "enum": ["standard", "strict", "metadata_only"] }
+          }
+        },
+        {
+          "type": "object", "additionalProperties": false, "required": ["type", "value"],
+          "properties": {
+            "type": { "const": "concurrency_profile" },
+            "value": { "enum": ["per_subject", "per_resource", "exclusive_scope"] }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contracts/authorization/v1/schemas/decision.schema.json
+++ b/contracts/authorization/v1/schemas/decision.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yukh.example/schemas/authorization/v1/decision.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["authorization_decision_version", "decision_id", "decision_digest", "authorization_request_id", "request_digest", "effect", "basis", "reason_codes", "subject_ref", "authentication_context_ref", "action", "resource", "environment_ref", "policy", "attribute_snapshot_ref", "constraints", "obligations", "issued_at", "expires_at", "evaluator_ref"],
+  "properties": {
+    "authorization_decision_version": { "const": 1 },
+    "decision_id": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+    "decision_digest": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/digest" },
+    "authorization_request_id": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+    "request_digest": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/digest" },
+    "effect": { "enum": ["allow", "deny"] },
+    "basis": { "enum": ["explicit", "default", "error", "indeterminate"] },
+    "reason_codes": { "type": "array", "minItems": 1, "maxItems": 64, "uniqueItems": true, "items": { "$ref": "https://yukh.example/schemas/authorization/v1/common.schema.json#/$defs/reasonCode" } },
+    "subject_ref": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+    "authentication_context_ref": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+    "action": { "$ref": "https://yukh.example/schemas/authorization/v1/common.schema.json#/$defs/action" },
+    "resource": {
+      "type": "object", "additionalProperties": false, "required": ["kind", "refs"],
+      "properties": {
+        "kind": { "type": "string", "pattern": "^[a-z][a-z0-9._-]{0,63}$", "maxLength": 64 },
+        "refs": { "type": "array", "minItems": 1, "maxItems": 1000, "uniqueItems": true, "items": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/resourceRef" } }
+      }
+    },
+    "environment_ref": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/environment" },
+    "policy": { "$ref": "https://yukh.example/schemas/authorization/v1/common.schema.json#/$defs/policy" },
+    "attribute_snapshot_ref": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+    "constraints": { "type": "array", "maxItems": 64, "items": { "$ref": "https://yukh.example/schemas/authorization/v1/common.schema.json#/$defs/constraint" } },
+    "obligations": { "type": "array", "maxItems": 32, "items": { "$ref": "https://yukh.example/schemas/authorization/v1/common.schema.json#/$defs/obligation" } },
+    "issued_at": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/timestamp" },
+    "expires_at": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/timestamp" },
+    "evaluator_ref": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/implementationRef" }
+  }
+}

--- a/contracts/authorization/v1/schemas/evaluation.schema.json
+++ b/contracts/authorization/v1/schemas/evaluation.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yukh.example/schemas/authorization/v1/evaluation.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["evaluation_version", "authorization_request_id", "request_digest", "policy", "evaluator_ref", "evaluated_at", "statements"],
+  "properties": {
+    "evaluation_version": { "const": 1 },
+    "authorization_request_id": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+    "request_digest": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/digest" },
+    "policy": { "$ref": "https://yukh.example/schemas/authorization/v1/common.schema.json#/$defs/policy" },
+    "evaluator_ref": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/implementationRef" },
+    "evaluated_at": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/timestamp" },
+    "statements": {
+      "type": "array", "maxItems": 256,
+      "items": {
+        "type": "object", "additionalProperties": false,
+        "required": ["statement_ref", "effect", "reason_code", "constraints", "obligations"],
+        "properties": {
+          "statement_ref": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+          "effect": { "enum": ["allow", "deny"] },
+          "reason_code": { "$ref": "https://yukh.example/schemas/authorization/v1/common.schema.json#/$defs/reasonCode" },
+          "resource_refs": {
+            "type": "array", "minItems": 1, "maxItems": 1000, "uniqueItems": true,
+            "items": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/resourceRef" }
+          },
+          "constraints": {
+            "type": "array", "maxItems": 64,
+            "items": { "$ref": "https://yukh.example/schemas/authorization/v1/common.schema.json#/$defs/constraint" }
+          },
+          "obligations": {
+            "type": "array", "maxItems": 32,
+            "items": { "$ref": "https://yukh.example/schemas/authorization/v1/common.schema.json#/$defs/obligation" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/contracts/authorization/v1/schemas/evidence.schema.json
+++ b/contracts/authorization/v1/schemas/evidence.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yukh.example/schemas/authorization/v1/evidence.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["authorization_evidence_version", "evidence_id", "authorization_request_id", "request_digest", "decision_id", "decision_digest", "effect", "basis", "reason_codes", "subject_ref", "authentication_context_ref", "action", "resource", "environment_ref", "policy", "attribute_snapshot_ref", "attribute_snapshot_digest", "constraints_digest", "obligations", "evaluator_ref", "evaluated_at", "enforcement", "obligation_receipt_refs"],
+  "properties": {
+    "authorization_evidence_version": { "const": 1 },
+    "evidence_id": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+    "authorization_request_id": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+    "request_digest": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/digest" },
+    "decision_id": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+    "decision_digest": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/digest" },
+    "effect": { "enum": ["allow", "deny"] },
+    "basis": { "enum": ["explicit", "default", "error", "indeterminate"] },
+    "reason_codes": { "type": "array", "minItems": 1, "maxItems": 64, "uniqueItems": true, "items": { "$ref": "https://yukh.example/schemas/authorization/v1/common.schema.json#/$defs/reasonCode" } },
+    "subject_ref": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+    "authentication_context_ref": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+    "action": { "$ref": "https://yukh.example/schemas/authorization/v1/common.schema.json#/$defs/action" },
+    "resource": { "type": "object", "additionalProperties": false, "required": ["kind", "refs"], "properties": { "kind": { "type": "string", "pattern": "^[a-z][a-z0-9._-]{0,63}$", "maxLength": 64 }, "refs": { "type": "array", "minItems": 1, "maxItems": 1000, "uniqueItems": true, "items": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/resourceRef" } } } },
+    "environment_ref": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/environment" },
+    "policy": { "$ref": "https://yukh.example/schemas/authorization/v1/common.schema.json#/$defs/policy" },
+    "attribute_snapshot_ref": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+    "attribute_snapshot_digest": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/digest" },
+    "constraints_digest": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/digest" },
+    "obligations": { "type": "array", "maxItems": 32, "items": { "$ref": "https://yukh.example/schemas/authorization/v1/common.schema.json#/$defs/obligation" } },
+    "evaluator_ref": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/implementationRef" },
+    "evaluated_at": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/timestamp" },
+    "enforcement": { "enum": ["not_attempted", "allowed", "denied", "obligation_pending"] },
+    "obligation_receipt_refs": { "type": "array", "maxItems": 32, "uniqueItems": true, "items": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" } }
+  }
+}

--- a/contracts/authorization/v1/schemas/request.schema.json
+++ b/contracts/authorization/v1/schemas/request.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yukh.example/schemas/authorization/v1/request.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["authorization_request_version", "authorization_request_id", "request_digest", "subject", "action", "resource", "environment", "request_context", "policy", "attributes"],
+  "properties": {
+    "authorization_request_version": { "const": 1 },
+    "authorization_request_id": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+    "request_digest": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/digest" },
+    "subject": {
+      "type": "object", "additionalProperties": false,
+      "required": ["ref", "kind", "authentication_context_ref", "authentication_strength"],
+      "properties": {
+        "ref": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+        "kind": { "enum": ["human", "workload"] },
+        "authentication_context_ref": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+        "authentication_strength": { "enum": ["bounded_session", "phishing_resistant", "workload_attested"] }
+      }
+    },
+    "action": { "$ref": "https://yukh.example/schemas/authorization/v1/common.schema.json#/$defs/action" },
+    "resource": {
+      "type": "object", "additionalProperties": false, "required": ["kind", "refs", "attributes_digest"],
+      "properties": {
+        "kind": { "type": "string", "pattern": "^[a-z][a-z0-9._-]{0,63}$", "maxLength": 64 },
+        "refs": {
+          "type": "array", "minItems": 1, "maxItems": 1000, "uniqueItems": true,
+          "items": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/resourceRef" }
+        },
+        "attributes_digest": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/digest" }
+      }
+    },
+    "environment": {
+      "type": "object", "additionalProperties": false, "required": ["ref", "attributes_digest"],
+      "properties": {
+        "ref": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/environment" },
+        "attributes_digest": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/digest" }
+      }
+    },
+    "request_context": {
+      "type": "object", "additionalProperties": false, "required": ["normalized_input_digest", "risk", "requested_at"],
+      "properties": {
+        "normalized_input_digest": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/digest" },
+        "risk": { "enum": ["low", "medium", "high", "critical"] },
+        "requested_at": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/timestamp" }
+      }
+    },
+    "policy": { "$ref": "https://yukh.example/schemas/authorization/v1/common.schema.json#/$defs/policy" },
+    "attributes": {
+      "type": "object", "additionalProperties": false, "required": ["snapshot_ref", "digest", "observed_at"],
+      "properties": {
+        "snapshot_ref": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/opaqueId" },
+        "digest": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/digest" },
+        "observed_at": { "$ref": "https://yukh.example/schemas/capability/v1/common.schema.json#/$defs/timestamp" }
+      }
+    }
+  }
+}

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -144,7 +144,11 @@ RFCs are superseded rather than edited.
 
 ## Open Foundation work
 
-- #3 defines the complete authorization decision and failure contract.
+- RFC-0002 defines the authorization decision and failure contract. Its v1
+  network-free reference package validates exact bindings, deny overrides,
+  all-or-nothing resource sets, constraint intersection, obligation
+  accumulation, and one-shot decision consumption. External identity and policy
+  adapters, durable replay state, and production enforcement remain absent.
 - #5 defines the versioned capability contract and bounded provider semantics.
 - #9 defines audit envelopes, redaction, retention, ordering, and integrity.
 - #10 qualifies repository, CI, dependency, and release supply-chain controls.

--- a/test/contracts/authorization-v1.test.mjs
+++ b/test/contracts/authorization-v1.test.mjs
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  buildAuthorizationEvidence, buildAuthorizationRequest, combineAuthorization,
+  createDecisionEnforcer, validateAuthorizationRecord,
+} from "../../contracts/authorization/v1/authorization.mjs";
+
+const definition = JSON.parse(readFileSync(new URL("../../contracts/capability/v1/examples/read-definition.json", import.meta.url)));
+const zero = `sha256:${"0".repeat(64)}`;
+const one = `sha256:${"1".repeat(64)}`;
+
+function request(overrides = {}) {
+  return buildAuthorizationRequest({
+    authorization_request_id: "authreq_example001",
+    subject: { ref: "subject_example001", kind: "workload", authentication_context_ref: "authctx_example001", authentication_strength: "workload_attested" },
+    definition,
+    resource: { kind: "node", refs: ["node-example-01"], attributes_digest: zero },
+    environment: { ref: "development", attributes_digest: one },
+    normalized_input: { include: ["health"] }, risk: "low", requested_at: "2026-08-03T00:00:00Z",
+    policy: { bundle_ref: "policy_example001", revision: 17, digest: zero },
+    attributes: { snapshot_ref: "attrs_example001", digest: one, observed_at: "2026-08-03T00:00:00Z" },
+    ...overrides,
+  });
+}
+
+function evaluation(req, statements) {
+  return { evaluation_version: 1, authorization_request_id: req.authorization_request_id, request_digest: req.request_digest,
+    policy: structuredClone(req.policy), evaluator_ref: "impl_evaluator_reference001", evaluated_at: "2026-08-03T00:00:01Z", statements };
+}
+
+function statement(effect, reason_code, extra = {}) {
+  return { statement_ref: `stmt_${effect}_${reason_code}`, effect, reason_code, constraints: [], obligations: [], ...extra };
+}
+
+function decide(req, evaln, id = "decision_example001") {
+  return combineAuthorization({ request: req, evaluation: evaln, decision_id: id, issued_at: "2026-08-03T00:00:02Z", expires_at: "2026-08-03T00:00:30Z" });
+}
+
+test("an exact explicit allow authorizes", () => {
+  const req = request();
+  const decision = decide(req, evaluation(req, [statement("allow", "policy_allow_read")]));
+  assert.equal(decision.effect, "allow");
+  assert.deepEqual(validateAuthorizationRecord("decision", decision), { valid: true, diagnostics: [] });
+});
+
+test("explicit deny overrides allow independent of order", () => {
+  const req = request();
+  const allow = statement("allow", "policy_allow_read");
+  const deny = statement("deny", "policy_deny_scope");
+  for (const statements of [[allow, deny], [deny, allow]]) {
+    const decision = decide(req, evaluation(req, statements));
+    assert.equal(decision.effect, "deny"); assert.equal(decision.basis, "explicit");
+    assert.equal(validateAuthorizationRecord("decision", decision).valid, true);
+  }
+});
+
+test("no applicable allow is default deny", () => {
+  const req = request();
+  const decision = decide(req, evaluation(req, []));
+  assert.deepEqual([decision.effect, decision.basis], ["deny", "default"]);
+  assert.equal(validateAuthorizationRecord("decision", decision).valid, true);
+});
+
+test("malformed or mismatched evaluation fails closed", () => {
+  const req = request();
+  const evaln = evaluation(req, [statement("allow", "policy_allow_read")]);
+  evaln.request_digest = one;
+  const decision = decide(req, evaln);
+  assert.deepEqual([decision.effect, decision.basis], ["deny", "error"]);
+  assert.equal(validateAuthorizationRecord("decision", decision).valid, true);
+});
+
+test("multi-resource authorization is all-or-nothing", () => {
+  const req = request({ resource: { kind: "node", refs: ["node-a", "node-b"], attributes_digest: zero } });
+  const evaln = evaluation(req, [statement("allow", "policy_allow_a", { resource_refs: ["node-a"] })]);
+  assert.deepEqual([decide(req, evaln).effect, decide(req, evaln).basis], ["deny", "default"]);
+  evaln.statements.push(statement("allow", "policy_allow_b", { resource_refs: ["node-b"] }));
+  assert.equal(decide(req, evaln).effect, "allow");
+});
+
+test("constraints intersect and obligations accumulate at strongest value", () => {
+  const req = request();
+  const evaln = evaluation(req, [
+    statement("allow", "policy_allow_one", { constraints: [{ type: "output_fields", value: ["health", "uptime"] }], obligations: [{ type: "redaction_profile", value: "standard" }] }),
+    statement("allow", "policy_allow_two", { constraints: [{ type: "output_fields", value: ["health"] }], obligations: [{ type: "redaction_profile", value: "strict" }] }),
+  ]);
+  const decision = decide(req, evaln);
+  assert.deepEqual(decision.constraints, [{ type: "output_fields", value: ["health"] }]);
+  assert.deepEqual(decision.obligations, [{ type: "redaction_profile", value: "strict" }]);
+});
+
+test("empty constraint intersection is indeterminate deny", () => {
+  const req = request();
+  const evaln = evaluation(req, [
+    statement("allow", "policy_allow_one", { constraints: [{ type: "output_fields", value: ["health"] }] }),
+    statement("allow", "policy_allow_two", { constraints: [{ type: "output_fields", value: ["uptime"] }] }),
+  ]);
+  const decision = decide(req, evaln);
+  assert.deepEqual([decision.effect, decision.basis], ["deny", "indeterminate"]);
+  assert.equal(validateAuthorizationRecord("decision", decision).valid, true);
+});
+
+test("one-shot enforcement rejects replay and every changed binding", () => {
+  const req = request();
+  const evaln = evaluation(req, [statement("allow", "policy_allow_read")]);
+  const variants = [
+    { subject: { ...req.subject, ref: "subject_other001" } },
+    { resource: { kind: "node", refs: ["node-other"], attributes_digest: req.resource.attributes_digest } },
+    { environment: { ...req.environment, ref: "production" } },
+    { policy: { ...req.policy, revision: 18 } },
+  ];
+  for (const [index, change] of variants.entries()) {
+    const decision = decide(req, evaln, `decision_variant00${index}`);
+    const changed = structuredClone(req); Object.assign(changed, change);
+    assert.equal(createDecisionEnforcer()({ decision, request: changed, now: "2026-08-03T00:00:03Z" }).allowed, false);
+  }
+  const decision = decide(req, evaln, "decision_replay001");
+  const enforce = createDecisionEnforcer();
+  assert.equal(enforce({ decision, request: req, now: "2026-08-03T00:00:03Z" }).allowed, true);
+  assert.deepEqual(enforce({ decision, request: req, now: "2026-08-03T00:00:04Z" }), { allowed: false, code: "decision_already_consumed" });
+});
+
+test("unfulfilled obligations block before invocation", () => {
+  const req = request();
+  const evaln = evaluation(req, [statement("allow", "policy_allow_read", { obligations: [{ type: "approval_required", value: "standard" }] })]);
+  const decision = decide(req, evaln);
+  assert.deepEqual(createDecisionEnforcer()({ decision, request: req, now: "2026-08-03T00:00:03Z" }), { allowed: false, code: "obligation_pending" });
+  assert.deepEqual(createDecisionEnforcer()({ decision, request: req, now: "2026-08-03T00:00:03Z", obligation_receipts: [{ type: "approval_required", value: "standard", decision_id: decision.decision_id }] }), { allowed: false, code: "obligation_pending" });
+});
+
+test("a constraint without its registered handler fails closed", () => {
+  const req = request();
+  const evaln = evaluation(req, [statement("allow", "policy_allow_read", { constraints: [{ type: "max_output_bytes", value: 1024 }] })]);
+  const decision = decide(req, evaln);
+  assert.deepEqual(createDecisionEnforcer()({ decision, request: req, now: "2026-08-03T00:00:03Z" }), { allowed: false, code: "constraint_unenforceable" });
+  assert.equal(createDecisionEnforcer()({ decision, request: req, now: "2026-08-03T00:00:03Z", constraint_handlers: { max_output_bytes: (value) => value === 1024 } }).allowed, true);
+});
+
+test("deny monotonicity holds across generated statement permutations", () => {
+  const req = request();
+  const base = [statement("allow", "policy_allow_read"), statement("allow", "policy_allow_second")];
+  for (let seed = 0; seed < 32; seed++) {
+    const ordered = seed % 2 ? [...base].reverse() : [...base];
+    assert.equal(decide(req, evaluation(req, ordered), `decision_allow${seed}`).effect, "allow");
+    ordered.splice(seed % 3, 0, statement("deny", "policy_deny_generated"));
+    assert.equal(decide(req, evaluation(req, ordered), `decision_deny${seed}`).effect, "deny");
+  }
+});
+
+test("sanitized evidence contains digests, not policy or attribute values", () => {
+  const req = request(); const evaln = evaluation(req, []); const decision = decide(req, evaln);
+  const evidence = buildAuthorizationEvidence({ evidence_id: "evidence_example001", request: req, decision, evaluation: evaln, enforcement: "denied" });
+  assert.deepEqual(validateAuthorizationRecord("evidence", evidence), { valid: true, diagnostics: [] });
+  assert.equal(JSON.stringify(evidence).includes("raw_attributes"), false);
+});


### PR DESCRIPTION
## What changed

- add versioned JSON Schemas for authorization requests, evaluations, decisions, constraints, obligations, and evidence
- add a network-free request builder, deterministic deny-override combiner, constraint intersection, obligation accumulation, and sanitized evidence builder
- add one-shot exact-binding enforcement that rejects replay and fails closed when constraints or obligations cannot be enforced
- update the threat model and package documentation

## Why

Implements the accepted RFC-0002 reference contract for #3 while preserving the gateway boundary: no identity adapter, policy service, MCP listener, provider, credential, or production runtime is introduced.

Approval receipts remain intentionally unaccepted until #4 defines their verifiable lifecycle.

## Validation

- `npm test` — 28 passing
- `npm audit --audit-level=high` — 0 vulnerabilities
- `git diff --check`

Closes #3