### PR TITLE
Bootstrap inert MCP Streamable HTTP runtime

### DIFF
--- a/.context/sessions/SESSION-2026-08-03-06-runtime-skeleton.md
+++ b/.context/sessions/SESSION-2026-08-03-06-runtime-skeleton.md
@@ -1,0 +1,28 @@
+# Session — inert MCP runtime skeleton
+
+- Date: 2026-08-03
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/6
+- Branch: `agent/issue-6-runtime-skeleton`
+- Status: implementation complete locally; draft PR pending
+
+## Outcome
+
+Added a strict TypeScript workspace and a stateless MCP Streamable HTTP gateway
+using the official modular SDK v2. The listener provides health/readiness and
+empty tools/resources/prompts discovery, bounded configuration and request
+bodies, host/origin checks, closed redacted JSON logs, graceful shutdown,
+protocol integration tests, runtime CI, and a constrained Compose path.
+
+## Dependency decision
+
+The official `@modelcontextprotocol/node` adapter was evaluated and removed
+because its current transitive `@hono/node-server` version carried a moderate
+path-traversal advisory with no available resolution through that package. The
+runtime uses `createMcpHandler` from the official server SDK and a small bounded
+Node-core/Web Request adapter instead. Production dependency audit is clean.
+
+## Boundary
+
+No tool implementation, resource content, prompt, provider, target, identity,
+authorization evaluator, approval adapter, credential, persistence, audit sink,
+task API, mutation, or production deployment was introduced.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+.context
+coverage
+dist
+docs
+node_modules
+test
+*.log

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -1,0 +1,67 @@
+name: Runtime
+
+on:
+  pull_request:
+    paths:
+      - "apps/**"
+      - "packages/**"
+      - "test/**"
+      - "package.json"
+      - "package-lock.json"
+      - "tsconfig*.json"
+      - "Dockerfile"
+      - "compose.yaml"
+      - ".github/workflows/runtime.yml"
+  push:
+    branches: [main]
+    paths:
+      - "apps/**"
+      - "packages/**"
+      - "test/**"
+      - "package.json"
+      - "package-lock.json"
+      - "tsconfig*.json"
+      - "Dockerfile"
+      - "compose.yaml"
+      - ".github/workflows/runtime.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runtime-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out source
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24.6.0"
+          cache: npm
+
+      - name: Install locked dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=moderate
+
+      - name: Build inert container
+        run: docker build --tag yukh-mcp:test .

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
+dist/
 coverage/
 *.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:24.6.0-bookworm-slim AS build
+WORKDIR /workspace
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+COPY tsconfig.json tsconfig.build.json ./
+COPY apps ./apps
+COPY packages ./packages
+RUN npm run build && npm prune --omit=dev --ignore-scripts
+
+FROM node:24.6.0-bookworm-slim
+ENV NODE_ENV=production
+WORKDIR /app
+COPY --from=build --chown=node:node /workspace/package.json /workspace/package-lock.json ./
+COPY --from=build --chown=node:node /workspace/node_modules ./node_modules
+COPY --from=build --chown=node:node /workspace/dist ./dist
+USER node
+EXPOSE 3000
+CMD ["node", "dist/apps/gateway/src/main.js"]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ policy evaluation to the exact request, combines deny-overrides deterministicall
 and rejects decision replay without implementing identity, policy, or provider
 integrations.
 
+The [inert runtime skeleton](docs/architecture/runtime-skeleton.md) initializes
+the official MCP Streamable HTTP transport and supports empty capability
+discovery. It exposes no operational tool, resource, prompt, provider, or
+credential path.
+
 ## Principles
 
 - Capability, not custody.

--- a/apps/gateway/src/main.ts
+++ b/apps/gateway/src/main.ts
@@ -1,0 +1,32 @@
+import { loadRuntimeConfig } from "../../../packages/config/src/runtime-config.js";
+import { createLogger } from "../../../packages/logging/src/logger.js";
+import { createGatewayRuntime } from "./server.js";
+
+const logger = createLogger();
+
+try {
+  const config = loadRuntimeConfig(process.env);
+  const runtime = createGatewayRuntime(config, logger);
+  await runtime.listen();
+
+  let stopping = false;
+  const stop = async () => {
+    if (stopping) return;
+    stopping = true;
+    const timeout = setTimeout(() => process.exit(1), config.shutdownTimeoutMs);
+    timeout.unref();
+    try {
+      await runtime.close();
+      clearTimeout(timeout);
+      process.exitCode = 0;
+    } catch {
+      logger.write("error", "runtime_failure", { code: "internal_error" });
+      process.exitCode = 1;
+    }
+  };
+  process.once("SIGINT", stop);
+  process.once("SIGTERM", stop);
+} catch {
+  logger.write("error", "runtime_failure", { code: "internal_error" });
+  process.exitCode = 1;
+}

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1,0 +1,147 @@
+import { randomUUID } from "node:crypto";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { McpServer, createMcpHandler, hostHeaderValidationResponse } from "@modelcontextprotocol/server";
+import type { RuntimeConfig } from "../../../packages/config/src/runtime-config.js";
+import { createLogger, type Logger } from "../../../packages/logging/src/logger.js";
+
+export interface GatewayRuntime {
+  listen(): Promise<{ host: string; port: number }>;
+  close(): Promise<void>;
+  address(): { host: string; port: number } | null;
+}
+
+class RequestTooLargeError extends Error {}
+
+function correlationRef(): string {
+  return `request_${randomUUID().replaceAll("-", "")}`;
+}
+
+async function readBody(request: IncomingMessage, maximum: number): Promise<Uint8Array | undefined> {
+  if (request.method === "GET" || request.method === "HEAD" || request.method === "DELETE") return undefined;
+  const declared = Number(request.headers["content-length"]);
+  if (Number.isFinite(declared) && declared > maximum) throw new RequestTooLargeError();
+  const chunks: Buffer[] = [];
+  let length = 0;
+  for await (const chunk of request) {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    length += bytes.length;
+    if (length > maximum) throw new RequestTooLargeError();
+    chunks.push(bytes);
+  }
+  return new Uint8Array(Buffer.concat(chunks));
+}
+
+function originRejected(request: Request, allowedOrigins: readonly string[]): boolean {
+  const origin = request.headers.get("origin");
+  if (origin === null) return false;
+  return !allowedOrigins.includes(origin);
+}
+
+async function writeWebResponse(response: Response, target: ServerResponse): Promise<void> {
+  target.statusCode = response.status;
+  for (const [name, value] of response.headers) target.setHeader(name, value);
+  target.end(Buffer.from(await response.arrayBuffer()));
+}
+
+function json(target: ServerResponse, status: number, value: object): void {
+  const body = JSON.stringify(value);
+  target.writeHead(status, { "content-type": "application/json; charset=utf-8", "content-length": Buffer.byteLength(body), "cache-control": "no-store" });
+  target.end(body);
+}
+
+function createInertMcpServer(): McpServer {
+  return new McpServer(
+    { name: "yukh-mcp", version: "0.0.0" },
+    { capabilities: { tools: { listChanged: false }, resources: { listChanged: false, subscribe: false }, prompts: { listChanged: false } } },
+  );
+}
+
+export function createGatewayRuntime(config: RuntimeConfig, logger: Logger = createLogger()): GatewayRuntime {
+  let ready = false;
+  const mcp = createMcpHandler(() => createInertMcpServer(), { legacy: "stateless" });
+  const server: Server = createServer(async (request, response) => {
+    const correlation_ref = correlationRef();
+    response.setHeader("x-request-id", correlation_ref);
+    try {
+      const pathname = new URL(request.url ?? "/", "http://runtime.invalid").pathname;
+      if (request.method === "GET" && pathname === "/healthz") {
+        json(response, 200, { status: "ok" });
+      } else if (request.method === "GET" && pathname === "/readyz") {
+        json(response, ready ? 200 : 503, { status: ready ? "ready" : "not_ready" });
+      } else if (pathname === "/mcp") {
+        if (request.method !== "POST") {
+          response.setHeader("allow", "POST");
+          logger.write("warn", "request_rejected", { correlation_ref, status: 405, code: "method_not_allowed" });
+          json(response, 405, { error: "method_not_allowed" });
+          return;
+        }
+        const body = await readBody(request, config.maxBodyBytes);
+        const headers = new Headers();
+        for (const [name, value] of Object.entries(request.headers)) {
+          if (value !== undefined) headers.set(name, Array.isArray(value) ? value.join(",") : value);
+        }
+        const webRequest = new Request(`http://${config.host === "::" ? "[::]" : config.host}:${config.port}/mcp`, {
+          method: request.method ?? "GET",
+          headers,
+          ...(body === undefined ? {} : { body: Buffer.from(body) }),
+        });
+        const hostRejection = hostHeaderValidationResponse(webRequest, [...config.allowedHosts]);
+        if (hostRejection) {
+          logger.write("warn", "request_rejected", { correlation_ref, status: hostRejection.status, code: "host_rejected" });
+          await writeWebResponse(hostRejection, response);
+          return;
+        }
+        if (originRejected(webRequest, config.allowedOrigins)) {
+          logger.write("warn", "request_rejected", { correlation_ref, status: 403, code: "origin_rejected" });
+          json(response, 403, { error: "origin_not_allowed" });
+          return;
+        }
+        await writeWebResponse(await mcp.fetch(webRequest), response);
+      } else {
+        logger.write("warn", "request_rejected", { correlation_ref, status: 404, code: "route_not_found" });
+        json(response, 404, { error: "not_found" });
+        return;
+      }
+      logger.write("info", "request_completed", { correlation_ref, status: response.statusCode });
+    } catch (error) {
+      if (error instanceof RequestTooLargeError) {
+        logger.write("warn", "request_rejected", { correlation_ref, status: 413, code: "body_too_large" });
+        json(response, 413, { error: "request_too_large" });
+      } else {
+        logger.write("error", "runtime_failure", { correlation_ref, status: 500, code: "internal_error" });
+        if (!response.headersSent) json(response, 500, { error: "internal_error" });
+        else response.destroy();
+      }
+    }
+  });
+  server.requestTimeout = 10_000;
+  server.headersTimeout = 5_000;
+  server.keepAliveTimeout = 5_000;
+  server.maxRequestsPerSocket = 100;
+  server.maxConnections = 128;
+
+  return {
+    async listen() {
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(config.port, config.host, () => { server.off("error", reject); resolve(); });
+      });
+      ready = true;
+      const bound = server.address();
+      if (!bound || typeof bound === "string") throw new Error("runtime did not bind a TCP address");
+      logger.write("info", "runtime_started");
+      return { host: config.host, port: bound.port };
+    },
+    async close() {
+      ready = false;
+      logger.write("info", "runtime_stopping");
+      await mcp.close();
+      if (server.listening) await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+      logger.write("info", "runtime_stopped");
+    },
+    address() {
+      const bound = server.address();
+      return bound && typeof bound !== "string" ? { host: config.host, port: bound.port } : null;
+    },
+  };
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,26 @@
+services:
+  gateway:
+    build:
+      context: .
+    environment:
+      YUKH_HOST: 0.0.0.0
+      YUKH_ALLOWED_HOSTS: localhost,127.0.0.1
+    ports:
+      - "127.0.0.1:3000:3000"
+    read_only: true
+    tmpfs:
+      - /tmp:size=16m,mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 128
+    mem_limit: 256m
+    cpus: 1.0
+    restart: "no"
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3000/readyz').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s

--- a/docs/architecture/runtime-skeleton.md
+++ b/docs/architecture/runtime-skeleton.md
@@ -1,0 +1,80 @@
+# Inert runtime skeleton
+
+Issue #6 introduces the smallest production-shaped Yukh MCP process without
+operational authority. It uses the official modular MCP TypeScript SDK v2 and a
+stateless Streamable HTTP endpoint at `/mcp`.
+
+The runtime deliberately registers empty `tools`, `resources`, and `prompts`
+capabilities. Initialization and discovery work, but no handler can inspect or
+change a target. There is no authentication adapter, authorization evaluator,
+provider registry, credential loader, approval service, audit store, task API,
+resumability, or mutation path.
+
+## HTTP surface
+
+| Route | Method | Purpose |
+| --- | --- | --- |
+| `/healthz` | `GET` | process liveness only |
+| `/readyz` | `GET` | listener and inert MCP handler readiness |
+| `/mcp` | `POST` | stateless MCP initialization and empty discovery |
+
+Other routes return a bounded `404`; non-POST MCP requests return `405`. The
+runtime does not open a long-lived notification stream in this phase.
+
+The listener defaults to `127.0.0.1:3000`. Binding to all interfaces requires
+an explicit host allowlist. Host validation protects the MCP route against DNS
+rebinding; browser requests with an `Origin` header are denied unless that exact
+origin is configured. MCP bodies are bounded before SDK parsing.
+
+## Configuration
+
+| Variable | Default | Bound |
+| --- | --- | --- |
+| `YUKH_HOST` | `127.0.0.1` | loopback or explicit wildcard enum |
+| `YUKH_PORT` | `3000` | `0..65535`; zero is test-only ephemeral binding |
+| `YUKH_ALLOWED_HOSTS` | `127.0.0.1,localhost` | 1–32 hostnames; required for wildcard bind |
+| `YUKH_ALLOWED_ORIGINS` | empty | 0–32 exact URLs |
+| `YUKH_MAX_BODY_BYTES` | `65536` | 1 KiB–1 MiB |
+| `YUKH_SHUTDOWN_TIMEOUT_MS` | `5000` | 100 ms–30 s |
+
+Configuration errors expose field names, never submitted values. Environment
+variables outside this registry are ignored and cannot register capabilities.
+
+## Logging
+
+Runtime logs are closed JSON records containing timestamp, registered event,
+level, server-created correlation reference, bounded HTTP status, and an
+allowlisted code. Request bodies, headers, URLs, host/origin values, exception
+messages, stack traces, client identity, and MCP payloads are excluded.
+
+These logs are operational diagnostics, not RFC-0004 protected audit evidence.
+No audit durability or integrity claim is made.
+
+## Local use
+
+```sh
+npm ci --ignore-scripts
+npm run typecheck
+npm test
+npm run build
+npm start
+```
+
+The Compose path publishes only to host loopback and applies a read-only root
+filesystem, non-root runtime user, dropped Linux capabilities, no-new-privileges,
+and CPU, memory, PID, and temporary-filesystem bounds:
+
+```sh
+docker compose up --build
+```
+
+The base-image tag is version-pinned but not digest-pinned. Image provenance,
+digest selection, SBOM, signing, and release qualification remain governed by
+issue #10.
+
+## Compatibility
+
+The server uses `createMcpHandler` from `@modelcontextprotocol/server` 2.0.0
+with its stateless compatibility mode. New protocol features remain disabled
+until separately reviewed. The implementation follows the
+[official MCP TypeScript server guide](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/server.md).

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -233,3 +233,29 @@ This review authorizes no store, key, identity resolver, export service,
 provider, mutation, or production integrity claim. Each deployment profile must
 document durability, confidentiality, checkpoint custody, access, retention,
 backup deletion, recovery, and monitoring evidence.
+
+## Inert MCP runtime implementation review — 2026-08-03
+
+- Governing issue: #6
+- Scope: Node.js listener, stateless MCP initialization and empty discovery,
+  configuration, health/readiness, closed operational logs, tests, and Compose
+- New trust boundary: unauthenticated network client to inert gateway listener
+
+The runtime exposes no operational capability, provider, credential, target
+resolver, policy adapter, approval service, task API, audit store, or mutation
+path. Its controls and residual risks are:
+
+| Threat | Control | Residual risk |
+| --- | --- | --- |
+| DNS rebinding or virtual-host confusion | exact host allowlist on `/mcp`; wildcard bind requires explicit configuration | reverse-proxy host rewriting requires a future deployment profile |
+| cross-origin browser invocation | any `Origin` is denied unless exactly allowlisted | non-browser clients have no Origin and authentication is not implemented |
+| oversized or slow request | content-length and streamed byte bound before SDK parsing; request/header/keep-alive timeouts, connection and per-socket request ceilings | distributed rate limiting still needs a deployment edge profile |
+| protocol parser or SDK defect | official modular SDK pinned to 2.0.0; strict TypeScript; protocol integration tests; empty registries | dependency compromise and future protocol drift remain possible |
+| accidental operational authority | empty tools/resources/prompts; no provider or credential modules; discovery test asserts empty lists | later capability registration requires its own review |
+| log disclosure or injection | closed records, server-generated correlation, no headers/body/URL/error text | stdout transport, retention, and integrity are not RFC-0004 audit |
+| container privilege or exhaustion | non-root user, read-only Compose filesystem, dropped capabilities, no-new-privileges, CPU/memory/PID bounds | base image is tag-pinned, not digest-qualified; #10 remains open |
+
+This review authorizes only the inert development skeleton. Non-loopback
+deployment, authentication, authorization integration, a real capability,
+provider access, credentials, persistence, or production readiness requires a
+separate accepted threat-model impact review.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
       - Project charter: concepts/project-charter.md
   - Architecture:
       - Overview: architecture/overview.md
+      - Inert runtime skeleton: architecture/runtime-skeleton.md
   - Security:
       - Security model: security/security-model.md
       - Threat model: security/threat-model.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,854 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "ajv": "8.20.0"
+        "@modelcontextprotocol/server": "2.0.0",
+        "ajv": "8.20.0",
+        "zod": "4.4.3"
+      },
+      "devDependencies": {
+        "@modelcontextprotocol/client": "2.0.0",
+        "@types/node": "24.10.1",
+        "tsx": "4.20.6",
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
+      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/ajv": {
@@ -29,6 +873,86 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -53,11 +977,76 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.1.tgz",
+      "integrity": "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
@@ -66,6 +1055,126 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,10 +9,23 @@
     "node": ">=22"
   },
   "scripts": {
-    "test": "node --test",
-    "test:contracts": "node --test test/contracts/*.test.mjs"
+    "build": "tsc --project tsconfig.build.json",
+    "start": "node dist/apps/gateway/src/main.js",
+    "dev": "tsx apps/gateway/src/main.ts",
+    "test": "node --test test/contracts/*.test.mjs && npm run test:runtime",
+    "test:contracts": "node --test test/contracts/*.test.mjs",
+    "test:runtime": "tsx --test test/runtime/*.test.ts",
+    "typecheck": "tsc --project tsconfig.json --noEmit"
   },
   "dependencies": {
-    "ajv": "8.20.0"
+    "@modelcontextprotocol/server": "2.0.0",
+    "ajv": "8.20.0",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@modelcontextprotocol/client": "2.0.0",
+    "@types/node": "24.10.1",
+    "tsx": "4.20.6",
+    "typescript": "7.0.2"
   }
 }

--- a/packages/config/src/runtime-config.ts
+++ b/packages/config/src/runtime-config.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+
+const hostname = z.string().min(1).max(253).regex(/^(?:localhost|\[[0-9a-fA-F:]+\]|[A-Za-z0-9](?:[A-Za-z0-9.-]{0,251}[A-Za-z0-9])?)$/);
+
+const runtimeConfigSchema = z.object({
+  host: z.enum(["127.0.0.1", "::1", "0.0.0.0", "::"]),
+  port: z.number().int().min(0).max(65535),
+  allowedHosts: z.array(hostname).min(1).max(32),
+  allowedOrigins: z.array(z.url().max(2048)).max(32),
+  maxBodyBytes: z.number().int().min(1024).max(1_048_576),
+  shutdownTimeoutMs: z.number().int().min(100).max(30_000),
+}).strict();
+
+export interface RuntimeConfig extends Omit<z.infer<typeof runtimeConfigSchema>, "allowedHosts" | "allowedOrigins"> {
+  readonly allowedHosts: readonly string[];
+  readonly allowedOrigins: readonly string[];
+}
+
+function integer(name: string, value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  if (!/^(?:0|[1-9][0-9]*)$/.test(value)) throw new TypeError(`${name} must be an unsigned base-10 integer`);
+  return Number(value);
+}
+
+function list(value: string | undefined, fallback: string[]): string[] {
+  if (value === undefined) return fallback;
+  return [...new Set(value.split(",").map((item) => item.trim()).filter(Boolean))];
+}
+
+export function loadRuntimeConfig(environment: NodeJS.ProcessEnv): RuntimeConfig {
+  const host = environment.YUKH_HOST ?? "127.0.0.1";
+  const defaults = host === "::1" ? ["[::1]", "localhost"] : ["127.0.0.1", "localhost"];
+  const result = runtimeConfigSchema.safeParse({
+    host,
+    port: integer("YUKH_PORT", environment.YUKH_PORT, 3000),
+    allowedHosts: list(environment.YUKH_ALLOWED_HOSTS, defaults),
+    allowedOrigins: list(environment.YUKH_ALLOWED_ORIGINS, []),
+    maxBodyBytes: integer("YUKH_MAX_BODY_BYTES", environment.YUKH_MAX_BODY_BYTES, 65_536),
+    shutdownTimeoutMs: integer("YUKH_SHUTDOWN_TIMEOUT_MS", environment.YUKH_SHUTDOWN_TIMEOUT_MS, 5_000),
+  });
+  if (!result.success) {
+    const paths = result.error.issues.map(({ path }) => path.join(".")).sort().join(",");
+    throw new TypeError(`invalid runtime configuration: ${paths}`);
+  }
+  if ((host === "0.0.0.0" || host === "::") && environment.YUKH_ALLOWED_HOSTS === undefined) {
+    throw new TypeError("YUKH_ALLOWED_HOSTS is required for a non-loopback bind");
+  }
+  return Object.freeze({ ...result.data, allowedHosts: Object.freeze([...result.data.allowedHosts]), allowedOrigins: Object.freeze([...result.data.allowedOrigins]) });
+}

--- a/packages/logging/src/logger.ts
+++ b/packages/logging/src/logger.ts
@@ -1,0 +1,25 @@
+export type LogLevel = "info" | "warn" | "error";
+export type LogEvent = "runtime_started" | "runtime_stopping" | "runtime_stopped" | "request_completed" | "request_rejected" | "runtime_failure";
+
+export interface LogRecord {
+  timestamp: string;
+  level: LogLevel;
+  event: LogEvent;
+  correlation_ref?: string;
+  status?: number;
+  code?: "body_too_large" | "host_rejected" | "origin_rejected" | "method_not_allowed" | "route_not_found" | "internal_error";
+}
+
+export interface Logger {
+  write(level: LogLevel, event: LogEvent, fields?: Pick<LogRecord, "correlation_ref" | "status" | "code">): void;
+}
+
+export function createLogger(options: { sink?: (line: string) => void; now?: () => Date } = {}): Logger {
+  const sink = options.sink ?? ((line: string) => process.stdout.write(`${line}\n`));
+  const now = options.now ?? (() => new Date());
+  return {
+    write(level, event, fields = {}) {
+      sink(JSON.stringify({ timestamp: now().toISOString(), level, event, ...fields } satisfies LogRecord));
+    },
+  };
+}

--- a/test/runtime/config.test.ts
+++ b/test/runtime/config.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { loadRuntimeConfig } from "../../packages/config/src/runtime-config.js";
+
+test("runtime config defaults to a bounded loopback listener", () => {
+  assert.deepEqual(loadRuntimeConfig({}), {
+    host: "127.0.0.1", port: 3000,
+    allowedHosts: ["127.0.0.1", "localhost"], allowedOrigins: [],
+    maxBodyBytes: 65_536, shutdownTimeoutMs: 5_000,
+  });
+});
+
+test("non-loopback binding requires an explicit host allowlist", () => {
+  assert.throws(() => loadRuntimeConfig({ YUKH_HOST: "0.0.0.0" }), {
+    name: "TypeError", message: "YUKH_ALLOWED_HOSTS is required for a non-loopback bind",
+  });
+});
+
+test("invalid configuration reports fields without their values", () => {
+  assert.throws(() => loadRuntimeConfig({ YUKH_PORT: "secret-value", YUKH_ALLOWED_ORIGINS: "not a url" }), {
+    name: "TypeError", message: "YUKH_PORT must be an unsigned base-10 integer",
+  });
+  assert.throws(() => loadRuntimeConfig({ YUKH_ALLOWED_ORIGINS: "not a url" }), {
+    name: "TypeError", message: "invalid runtime configuration: allowedOrigins.0",
+  });
+});

--- a/test/runtime/gateway.test.ts
+++ b/test/runtime/gateway.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client, StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
+import { createGatewayRuntime } from "../../apps/gateway/src/server.js";
+import type { RuntimeConfig } from "../../packages/config/src/runtime-config.js";
+import { createLogger } from "../../packages/logging/src/logger.js";
+
+const config: RuntimeConfig = {
+  host: "127.0.0.1", port: 0,
+  allowedHosts: ["127.0.0.1"], allowedOrigins: [],
+  maxBodyBytes: 1_024, shutdownTimeoutMs: 1_000,
+};
+
+async function runtimeTest(run: (base: URL, lines: string[]) => Promise<void>): Promise<void> {
+  const lines: string[] = [];
+  const runtime = createGatewayRuntime(config, createLogger({ sink: (line) => lines.push(line) }));
+  const { port } = await runtime.listen();
+  try {
+    await run(new URL(`http://127.0.0.1:${port}`), lines);
+  } finally {
+    await runtime.close();
+  }
+}
+
+test("health, readiness, and unknown routes are bounded", async () => {
+  await runtimeTest(async (base) => {
+    const health = await fetch(new URL("/healthz", base));
+    assert.equal(health.status, 200);
+    assert.deepEqual(await health.json(), { status: "ok" });
+    assert.match(health.headers.get("x-request-id") ?? "", /^request_[a-f0-9]{32}$/);
+
+    const ready = await fetch(new URL("/readyz", base));
+    assert.equal(ready.status, 200);
+    assert.deepEqual(await ready.json(), { status: "ready" });
+
+    const missing = await fetch(new URL("/unknown", base));
+    assert.equal(missing.status, 404);
+    assert.deepEqual(await missing.json(), { error: "not_found" });
+
+    const streamingGet = await fetch(new URL("/mcp", base));
+    assert.equal(streamingGet.status, 405);
+    assert.equal(streamingGet.headers.get("allow"), "POST");
+  });
+});
+
+test("host, origin, and body bounds reject before MCP handling", async () => {
+  await runtimeTest(async (base) => {
+    const badHost = await fetch(new URL("/mcp", base), { method: "POST", headers: { host: "attacker.example", "content-type": "application/json" }, body: "{}" });
+    assert.equal(badHost.status, 400);
+
+    const badOrigin = await fetch(new URL("/mcp", base), { method: "POST", headers: { origin: "https://attacker.example", "content-type": "application/json" }, body: "{}" });
+    assert.equal(badOrigin.status, 403);
+
+    const oversized = await fetch(new URL("/mcp", base), { method: "POST", headers: { "content-type": "application/json" }, body: "x".repeat(1_025) });
+    assert.equal(oversized.status, 413);
+  });
+});
+
+test("MCP initializes and discovers no operational surface", async () => {
+  await runtimeTest(async (base) => {
+    const client = new Client({ name: "yukh-test-client", version: "1.0.0" });
+    const transport = new StreamableHTTPClientTransport(new URL("/mcp", base));
+    try {
+      await client.connect(transport);
+      assert.deepEqual((await client.listTools()).tools, []);
+      assert.deepEqual((await client.listResources()).resources, []);
+      assert.deepEqual((await client.listPrompts()).prompts, []);
+    } finally {
+      await client.close();
+    }
+  });
+});
+
+test("logs contain bounded metadata but no request body", async () => {
+  await runtimeTest(async (base, lines) => {
+    const marker = "do-not-retain-this-body";
+    await fetch(new URL("/mcp", base), { method: "POST", headers: { "content-type": "application/json" }, body: marker });
+    assert.equal(lines.join("\n").includes(marker), false);
+  });
+});

--- a/test/runtime/logger.test.ts
+++ b/test/runtime/logger.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createLogger } from "../../packages/logging/src/logger.js";
+
+test("logger emits only its closed redacted record", () => {
+  const lines: string[] = [];
+  const logger = createLogger({ sink: (line) => lines.push(line), now: () => new Date("2026-08-03T00:00:00Z") });
+  logger.write("warn", "request_rejected", { correlation_ref: "request_example001", status: 403, code: "origin_rejected" });
+  assert.deepEqual(JSON.parse(lines[0] ?? "null"), {
+    timestamp: "2026-08-03T00:00:00.000Z", level: "warn", event: "request_rejected",
+    correlation_ref: "request_example001", status: 403, code: "origin_rejected",
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["apps/**/*.ts", "packages/**/*.ts"],
+  "exclude": ["dist", "node_modules", "test"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": ".",
+    "outDir": "dist",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "verbatimModuleSyntax": true,
+    "declaration": true,
+    "sourceMap": true,
+    "skipLibCheck": false,
+    "types": ["node"]
+  },
+  "include": ["apps/**/*.ts", "packages/**/*.ts", "test/runtime/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## What changed

- add a strict TypeScript workspace and official modular MCP SDK v2 integration
- add a stateless `/mcp` endpoint with successful initialization and empty tools/resources/prompts discovery
- add loopback-default configuration, explicit wildcard host allowlisting, DNS-rebinding host validation, origin checks, body and connection bounds
- add health/readiness endpoints, closed redacted JSON operational logs, and graceful shutdown
- add 8 unit/protocol tests alongside the 28 existing contract tests
- add a non-root, read-only, resource-bounded Compose path and runtime CI including container build
- document the inert boundary and add a threat-model implementation review

## Why

Issue #6 needs the smallest production-shaped gateway without operational authority. This creates a real MCP transport and reproducible build/test path while registering no tool, resource content, prompt, provider, credential, authorization adapter, persistence, or mutation.

The official `@modelcontextprotocol/node` adapter was evaluated but removed because its current transitive dependency carried a moderate advisory with no available fix through that package. The implementation uses `createMcpHandler` from the official server SDK and a bounded Node-core/Web Request adapter; production dependency audit is clean.

## Validation

- `npm ci --ignore-scripts`
- `npm run typecheck`
- `npm test` — 28 contract + 8 runtime passing
- `npm run build`
- `npm audit --omit=dev --audit-level=moderate` — 0 vulnerabilities
- `git diff --check`

Docker is unavailable in the local session; the pinned runtime CI job builds the image as a required validation step.

Closes #6