### PR TITLE
Implement a local read-only node provider

### DIFF
--- a/.context/sessions/SESSION-2026-08-03-08-local-read-provider.md
+++ b/.context/sessions/SESSION-2026-08-03-08-local-read-provider.md
@@ -23,7 +23,7 @@ references. The inert MCP listener remains unchanged and discovers no tools.
 - capability definition accepted by the v1 contract validator;
 - TypeScript typecheck and build;
 - 50 contract and supply-chain tests;
-- 14 runtime tests including traversal, symlink, pre-authorization denial,
+- 16 runtime tests including traversal, symlink, pre-authorization denial,
   malformed input, and malformed provider output;
 - Prettier and `git diff --check`.
 

--- a/.context/sessions/SESSION-2026-08-03-08-local-read-provider.md
+++ b/.context/sessions/SESSION-2026-08-03-08-local-read-provider.md
@@ -1,0 +1,35 @@
+# Session — local read-only node provider
+
+- Date: 2026-08-03
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/8
+- Branch: `agent/issue-8-local-read-provider`
+- Status: implementation complete locally; draft PR pending
+
+## Outcome
+
+Implemented the experimental network-free `node.inspect` provider boundary.
+Configured node roots are canonicalized server-side. Requests reject traversal,
+absolute paths, control characters, unknown nodes, unsupported entries, and all
+symbolic links. Results contain bounded metadata, source, observation time, and
+freshness without file contents or directory listings.
+
+The invocation pipeline validates input before authorization, records zero
+provider attempts on deny, validates and bounds provider output before release,
+and returns capability-contract-shaped results with authorization evidence
+references. The inert MCP listener remains unchanged and discovers no tools.
+
+## Validation
+
+- capability definition accepted by the v1 contract validator;
+- TypeScript typecheck and build;
+- 50 contract and supply-chain tests;
+- 14 runtime tests including traversal, symlink, pre-authorization denial,
+  malformed input, and malformed provider output;
+- Prettier and `git diff --check`.
+
+## Boundary
+
+No MCP tool, authentication adapter, policy engine, Project mutation,
+coordination authority, credential, production root, release, or publication is
+introduced. OS-level containment and authenticated transport integration remain
+future work.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -281,3 +281,24 @@ separate accepted threat-model impact review.
 This baseline authorizes source validation and security-analysis uploads only.
 It does not authorize package/container publication, a signing identity, release
 credentials, OIDC federation, or a production release.
+
+## Local read-only node provider implementation review — 2026-08-03
+
+- Governing issue: #8
+- Scope: network-free `node.inspect` definition, configured-root resolver,
+  authorization-enforced invocation boundary, bounded metadata result, and tests
+- New trust boundary: capability invocation to a local read-only filesystem provider
+
+| Threat | Control | Residual risk |
+| --- | --- | --- |
+| traversal or absolute-path escape | relative path grammar, canonical configured roots, containment checks before observation | platform path semantics require qualification on every supported OS |
+| symbolic-link escape | every path component is inspected and any symlink is rejected; canonical target is checked again | filesystem replacement races remain possible without an OS-level directory-handle sandbox |
+| authorization bypass | malformed requests fail before authorization; denied requests record zero provider attempts | the injected authorizer is not yet connected to an authenticated transport or durable decision enforcer |
+| malicious or oversized provider output | closed runtime schema, 4 KiB serialized bound, invalid output withheld as `provider_protocol_error` | metadata such as requested relative paths may still be sensitive in a deployment-specific root |
+| content or credential disclosure | capability returns file type, size, modification time, source, and freshness only; no contents or directory listing | file names supplied by an authorized caller remain visible in its own result |
+| accidental public authority | inert MCP discovery remains empty and no provider configuration is loaded by the listener | a future MCP binding requires identity, policy, configuration, and audit review |
+
+This review authorizes the network-free experimental provider boundary and its
+tests only. It does not authorize MCP exposure, production roots, credentials,
+non-loopback deployment, filesystem contents, directory enumeration, mutation,
+or a claim that application-level checks eliminate local TOCTOU races.

--- a/packages/capabilities/src/node-inspect-validation.ts
+++ b/packages/capabilities/src/node-inspect-validation.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+const requestSchema = z
+  .object({
+    request_version: z.literal(1),
+    request_id: z.string().min(1).max(128),
+    capability: z.object({ id: z.literal("node.inspect"), version: z.literal("1.0.0") }).strict(),
+    resource: z.object({ kind: z.literal("node"), ref: z.string().min(1).max(128) }).strict(),
+    environment: z.string().min(1).max(128),
+    input: z.object({ path: z.string().min(1).max(512) }).strict(),
+    idempotency_key: z.null(),
+  })
+  .strict();
+
+const outputSchema = z
+  .object({
+    source: z
+      .object({
+        node_ref: z.string().min(1).max(128),
+        relative_path: z.string().min(1).max(512),
+      })
+      .strict(),
+    observed_at: z.iso.datetime(),
+    freshness_seconds: z.number().int().min(0).max(86_400),
+    entry: z
+      .object({
+        kind: z.enum(["file", "directory"]),
+        size_bytes: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+        modified_at: z.iso.datetime(),
+      })
+      .strict(),
+  })
+  .strict();
+
+export function validNodeInspectRequest(value: unknown): boolean {
+  return requestSchema.safeParse(value).success;
+}
+
+export function validNodeInspectOutput(value: unknown): boolean {
+  return (
+    outputSchema.safeParse(value).success &&
+    Buffer.byteLength(JSON.stringify(value), "utf8") <= 4_096
+  );
+}

--- a/packages/capabilities/src/node-inspect.ts
+++ b/packages/capabilities/src/node-inspect.ts
@@ -1,0 +1,222 @@
+import {
+  LocalReadProviderError,
+  NODE_INSPECT_IMPLEMENTATION_REF,
+  type LocalReadNodeProvider,
+  type NodeInspectInput,
+} from "../../providers/local-read/src/node-inspect.js";
+import { validNodeInspectOutput, validNodeInspectRequest } from "./node-inspect-validation.js";
+
+export const nodeInspectDefinition = {
+  contract_version: 1,
+  capability: {
+    id: "node.inspect",
+    version: "1.0.0",
+    summary: "Inspect bounded metadata for one configured local node path",
+    stability: "experimental",
+  },
+  resource: { kinds: ["node"], cardinality: "one" },
+  environment: { required: true },
+  operation: { model: "typed", class: "read", effects: ["observe"] },
+  input: {
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["path"],
+      properties: { path: { type: "string", minLength: 1, maxLength: 512 } },
+    },
+  },
+  output: {
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["source", "observed_at", "freshness_seconds", "entry"],
+      properties: {
+        source: {
+          type: "object",
+          additionalProperties: false,
+          required: ["node_ref", "relative_path"],
+          properties: {
+            node_ref: { type: "string", minLength: 1, maxLength: 128 },
+            relative_path: { type: "string", minLength: 1, maxLength: 512 },
+          },
+        },
+        observed_at: { type: "string", minLength: 20, maxLength: 64 },
+        freshness_seconds: { type: "integer", minimum: 0, maximum: 86_400 },
+        entry: {
+          type: "object",
+          additionalProperties: false,
+          required: ["kind", "size_bytes", "modified_at"],
+          properties: {
+            kind: { type: "string", enum: ["file", "directory"], maxLength: 16 },
+            size_bytes: { type: "integer", minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
+            modified_at: { type: "string", minLength: 20, maxLength: 64 },
+          },
+        },
+      },
+    },
+  },
+  risk: { level: "low", data_classes: ["operational_metadata"] },
+  mutation: { mode: "none", destructive: false },
+  approval: { mode: "never" },
+  execution: {
+    timeout_ms: 2_000,
+    max_attempts: 1,
+    concurrency: "per_resource",
+    max_input_bytes: 1_024,
+    max_output_bytes: 4_096,
+  },
+  idempotency: { classification: "naturally_idempotent", key: "forbidden" },
+  retry: { policy: "safe_before_start_only" },
+  verification: {
+    mode: "required",
+    postconditions: ["resource_identity_matches", "output_schema_valid"],
+  },
+  rollback: { mode: "not_applicable" },
+  errors: { taxonomy_version: 1 },
+} as const;
+
+export interface NodeInspectRequest {
+  readonly request_version: 1;
+  readonly request_id: string;
+  readonly capability: { readonly id: "node.inspect"; readonly version: "1.0.0" };
+  readonly resource: { readonly kind: "node"; readonly ref: string };
+  readonly environment: string;
+  readonly input: NodeInspectInput;
+  readonly idempotency_key: null;
+}
+
+export interface InvocationAuthorization {
+  readonly allowed: boolean;
+  readonly evidence_ref: string;
+}
+export type NodeInspectAuthorizer = (
+  request: NodeInspectRequest,
+) => Promise<InvocationAuthorization>;
+
+function capabilityError(
+  code:
+    | "authorization_denied"
+    | "scope_resolution_failed"
+    | "schema_validation_failed"
+    | "provider_protocol_error",
+  phase: "authorize" | "resolve" | "validate" | "execute",
+) {
+  return {
+    error_version: 1,
+    code,
+    phase,
+    retry: code === "authorization_denied" ? "after_policy_change" : "after_correction",
+    message:
+      code === "authorization_denied"
+        ? "The request is not authorized"
+        : code === "scope_resolution_failed"
+          ? "The configured resource could not be resolved"
+          : code === "schema_validation_failed"
+            ? "The request is invalid"
+            : "The provider returned an invalid result",
+    diagnostics: [],
+  } as const;
+}
+
+export function createNodeInspectCapability(options: {
+  readonly provider: LocalReadNodeProvider;
+  readonly authorize: NodeInspectAuthorizer;
+  readonly now?: () => Date;
+}) {
+  const now = options.now ?? (() => new Date());
+  return Object.freeze({
+    definition: nodeInspectDefinition,
+    async invoke(request: NodeInspectRequest) {
+      const started = now().toISOString();
+      if (!validNodeInspectRequest(request))
+        return result(
+          request,
+          started,
+          now().toISOString(),
+          "evidence_validation1",
+          0,
+          null,
+          "failed",
+          capabilityError("schema_validation_failed", "validate"),
+        );
+      const authorization = await options.authorize(request);
+      if (!authorization.allowed)
+        return result(
+          request,
+          started,
+          now().toISOString(),
+          authorization.evidence_ref,
+          0,
+          null,
+          "denied",
+          capabilityError("authorization_denied", "authorize"),
+        );
+      try {
+        const output = await options.provider.inspect(request.resource.ref, request.input);
+        if (!validNodeInspectOutput(output))
+          return result(
+            request,
+            started,
+            now().toISOString(),
+            authorization.evidence_ref,
+            1,
+            null,
+            "failed",
+            capabilityError("provider_protocol_error", "execute"),
+          );
+        return result(
+          request,
+          started,
+          now().toISOString(),
+          authorization.evidence_ref,
+          1,
+          output,
+          "succeeded",
+          null,
+        );
+      } catch (error) {
+        if (!(error instanceof LocalReadProviderError)) throw error;
+        return result(
+          request,
+          started,
+          now().toISOString(),
+          authorization.evidence_ref,
+          1,
+          null,
+          "failed",
+          capabilityError("scope_resolution_failed", "resolve"),
+        );
+      }
+    },
+  });
+}
+
+function result(
+  request: NodeInspectRequest,
+  started_at: string,
+  finished_at: string,
+  evidence: string,
+  attempts: 0 | 1,
+  output: object | null,
+  status: "succeeded" | "denied" | "failed",
+  error: object | null,
+) {
+  return {
+    result_version: 1,
+    request_id: request.request_id,
+    capability: request.capability,
+    status,
+    resource_ref: request.resource.ref,
+    environment: request.environment,
+    attempts,
+    implementation_ref: NODE_INSPECT_IMPLEMENTATION_REF,
+    started_at,
+    finished_at,
+    output,
+    verification: {
+      status: status === "succeeded" ? "verified" : "not_applicable",
+      evidence_refs: [evidence],
+    },
+    error,
+  } as const;
+}

--- a/packages/capabilities/src/node-inspect.ts
+++ b/packages/capabilities/src/node-inspect.ts
@@ -93,19 +93,41 @@ export type NodeInspectAuthorizer = (
   request: NodeInspectRequest,
 ) => Promise<InvocationAuthorization>;
 
+class ProviderTimeoutError extends Error {}
+
+async function withTimeout<T>(operation: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new ProviderTimeoutError()), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 function capabilityError(
   code:
     | "authorization_denied"
     | "scope_resolution_failed"
     | "schema_validation_failed"
-    | "provider_protocol_error",
+    | "provider_protocol_error"
+    | "execution_timeout",
   phase: "authorize" | "resolve" | "validate" | "execute",
 ) {
   return {
     error_version: 1,
     code,
     phase,
-    retry: code === "authorization_denied" ? "after_policy_change" : "after_correction",
+    retry:
+      code === "authorization_denied"
+        ? "after_policy_change"
+        : code === "execution_timeout"
+          ? "policy_declared"
+          : "after_correction",
     message:
       code === "authorization_denied"
         ? "The request is not authorized"
@@ -113,7 +135,9 @@ function capabilityError(
           ? "The configured resource could not be resolved"
           : code === "schema_validation_failed"
             ? "The request is invalid"
-            : "The provider returned an invalid result",
+            : code === "provider_protocol_error"
+              ? "The provider returned an invalid result"
+              : "The provider invocation timed out",
     diagnostics: [],
   } as const;
 }
@@ -122,8 +146,16 @@ export function createNodeInspectCapability(options: {
   readonly provider: LocalReadNodeProvider;
   readonly authorize: NodeInspectAuthorizer;
   readonly now?: () => Date;
+  readonly providerTimeoutMs?: number;
 }) {
   const now = options.now ?? (() => new Date());
+  const providerTimeoutMs = options.providerTimeoutMs ?? nodeInspectDefinition.execution.timeout_ms;
+  if (
+    !Number.isInteger(providerTimeoutMs) ||
+    providerTimeoutMs < 1 ||
+    providerTimeoutMs > nodeInspectDefinition.execution.timeout_ms
+  )
+    throw new TypeError("invalid provider timeout");
   return Object.freeze({
     definition: nodeInspectDefinition,
     async invoke(request: NodeInspectRequest) {
@@ -133,7 +165,7 @@ export function createNodeInspectCapability(options: {
           request,
           started,
           now().toISOString(),
-          "evidence_validation1",
+          [],
           0,
           null,
           "failed",
@@ -145,20 +177,23 @@ export function createNodeInspectCapability(options: {
           request,
           started,
           now().toISOString(),
-          authorization.evidence_ref,
+          [authorization.evidence_ref],
           0,
           null,
           "denied",
           capabilityError("authorization_denied", "authorize"),
         );
       try {
-        const output = await options.provider.inspect(request.resource.ref, request.input);
+        const output = await withTimeout(
+          options.provider.inspect(request.resource.ref, request.input),
+          providerTimeoutMs,
+        );
         if (!validNodeInspectOutput(output))
           return result(
             request,
             started,
             now().toISOString(),
-            authorization.evidence_ref,
+            [authorization.evidence_ref],
             1,
             null,
             "failed",
@@ -168,19 +203,30 @@ export function createNodeInspectCapability(options: {
           request,
           started,
           now().toISOString(),
-          authorization.evidence_ref,
+          [authorization.evidence_ref],
           1,
           output,
           "succeeded",
           null,
         );
       } catch (error) {
+        if (error instanceof ProviderTimeoutError)
+          return result(
+            request,
+            started,
+            now().toISOString(),
+            [authorization.evidence_ref],
+            1,
+            null,
+            "failed",
+            capabilityError("execution_timeout", "execute"),
+          );
         if (!(error instanceof LocalReadProviderError)) throw error;
         return result(
           request,
           started,
           now().toISOString(),
-          authorization.evidence_ref,
+          [authorization.evidence_ref],
           1,
           null,
           "failed",
@@ -195,7 +241,7 @@ function result(
   request: NodeInspectRequest,
   started_at: string,
   finished_at: string,
-  evidence: string,
+  evidence_refs: readonly string[],
   attempts: 0 | 1,
   output: object | null,
   status: "succeeded" | "denied" | "failed",
@@ -215,7 +261,7 @@ function result(
     output,
     verification: {
       status: status === "succeeded" ? "verified" : "not_applicable",
-      evidence_refs: [evidence],
+      evidence_refs,
     },
     error,
   } as const;

--- a/packages/providers/local-read/src/node-inspect.ts
+++ b/packages/providers/local-read/src/node-inspect.ts
@@ -1,0 +1,114 @@
+import { lstat, realpath } from "node:fs/promises";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+export const NODE_INSPECT_IMPLEMENTATION_REF = "impl_local_read_node_inspect_v1";
+
+export interface LocalNodeConfig {
+  readonly ref: string;
+  readonly root: string;
+}
+export interface NodeInspectInput {
+  readonly path: string;
+}
+export interface NodeInspectOutput {
+  readonly source: { readonly node_ref: string; readonly relative_path: string };
+  readonly observed_at: string;
+  readonly freshness_seconds: number;
+  readonly entry: {
+    readonly kind: "file" | "directory";
+    readonly size_bytes: number;
+    readonly modified_at: string;
+  };
+}
+
+export class LocalReadProviderError extends Error {
+  constructor(readonly code: "invalid_path" | "not_found" | "unsupported_entry") {
+    super(code);
+    this.name = "LocalReadProviderError";
+  }
+}
+
+export interface LocalReadNodeProvider {
+  inspect(nodeRef: string, input: NodeInspectInput): Promise<NodeInspectOutput>;
+}
+
+interface CanonicalNode {
+  readonly ref: string;
+  readonly root: string;
+}
+const nodeRefPattern = /^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$/;
+
+function validRelativePath(value: string): boolean {
+  return (
+    value.length > 0 &&
+    Buffer.byteLength(value, "utf8") <= 512 &&
+    !isAbsolute(value) &&
+    !/[\u0000-\u001f\u007f]/u.test(value) &&
+    value.split(/[\\/]/u).every((part) => part.length > 0 && part !== "." && part !== "..")
+  );
+}
+
+function contained(root: string, target: string): boolean {
+  const fromRoot = relative(root, target);
+  return (
+    fromRoot === "" ||
+    (!fromRoot.startsWith(`..${sep}`) && fromRoot !== ".." && !isAbsolute(fromRoot))
+  );
+}
+
+export async function createLocalReadNodeProvider(
+  configs: readonly LocalNodeConfig[],
+  options: { readonly now?: () => Date } = {},
+): Promise<LocalReadNodeProvider> {
+  if (configs.length === 0 || configs.length > 32)
+    throw new TypeError("invalid node configuration");
+  const nodes = new Map<string, CanonicalNode>();
+  for (const config of configs) {
+    if (!nodeRefPattern.test(config.ref) || nodes.has(config.ref))
+      throw new TypeError("invalid node configuration");
+    const root = await realpath(config.root);
+    if (!(await lstat(root)).isDirectory()) throw new TypeError("invalid node configuration");
+    nodes.set(config.ref, { ref: config.ref, root });
+  }
+  const now = options.now ?? (() => new Date());
+  return Object.freeze({
+    async inspect(nodeRef: string, input: NodeInspectInput): Promise<NodeInspectOutput> {
+      const node = nodes.get(nodeRef);
+      if (!node || !validRelativePath(input.path)) throw new LocalReadProviderError("invalid_path");
+      const target = resolve(node.root, input.path);
+      if (!contained(node.root, target)) throw new LocalReadProviderError("invalid_path");
+      let current = node.root;
+      let metadata;
+      try {
+        for (const component of input.path.split(/[\\/]/u)) {
+          current = resolve(current, component);
+          const candidate = await lstat(current);
+          if (candidate.isSymbolicLink()) throw new LocalReadProviderError("invalid_path");
+          metadata = candidate;
+        }
+      } catch (error) {
+        if (error instanceof LocalReadProviderError) throw error;
+        throw new LocalReadProviderError("not_found");
+      }
+      if (!metadata) throw new LocalReadProviderError("not_found");
+      if (!contained(node.root, await realpath(target)))
+        throw new LocalReadProviderError("invalid_path");
+      const kind = metadata.isFile() ? "file" : metadata.isDirectory() ? "directory" : null;
+      if (!kind) throw new LocalReadProviderError("unsupported_entry");
+      const observed = now();
+      return Object.freeze({
+        source: Object.freeze({ node_ref: node.ref, relative_path: input.path }),
+        observed_at: observed.toISOString(),
+        freshness_seconds: Math.max(
+          0,
+          Math.min(86_400, Math.floor((observed.getTime() - metadata.mtimeMs) / 1000)),
+        ),
+        entry: Object.freeze({
+          kind,
+          size_bytes: Math.min(metadata.size, Number.MAX_SAFE_INTEGER),
+          modified_at: metadata.mtime.toISOString(),
+        }),
+      });
+    },
+  });
+}

--- a/test/runtime/local-read-provider.test.ts
+++ b/test/runtime/local-read-provider.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { mkdtemp, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createNodeInspectCapability } from "../../packages/capabilities/src/node-inspect.js";
+import {
+  createLocalReadNodeProvider,
+  LocalReadProviderError,
+} from "../../packages/providers/local-read/src/node-inspect.js";
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "yukh-node-root-"));
+  const outside = await mkdtemp(join(tmpdir(), "yukh-node-outside-"));
+  await writeFile(join(root, "status.txt"), "bounded fixture\n", "utf8");
+  await writeFile(join(outside, "secret.txt"), "must not be observed\n", "utf8");
+  return { root, outside };
+}
+
+test("local provider returns bounded metadata with source and freshness", async () => {
+  const { root } = await fixture();
+  const now = new Date("2026-08-03T13:00:00.000Z");
+  const provider = await createLocalReadNodeProvider([{ ref: "node-local", root }], {
+    now: () => now,
+  });
+  const output = await provider.inspect("node-local", { path: "status.txt" });
+  assert.deepEqual(output.source, { node_ref: "node-local", relative_path: "status.txt" });
+  assert.equal(output.entry.kind, "file");
+  assert.equal(output.entry.size_bytes, 16);
+  assert.equal(output.observed_at, now.toISOString());
+  assert.equal(Object.hasOwn(output.entry, "content"), false);
+  assert.ok(JSON.stringify(output).length < 1_024);
+});
+
+test("traversal, absolute paths, controls, and symlinks fail closed", async () => {
+  const { root, outside } = await fixture();
+  await symlink(join(outside, "secret.txt"), join(root, "escape"));
+  const provider = await createLocalReadNodeProvider([{ ref: "node-local", root }]);
+  for (const path of [
+    "../secret.txt",
+    "/etc/passwd",
+    "sub/../status.txt",
+    "status.txt\n",
+    "escape",
+  ])
+    await assert.rejects(provider.inspect("node-local", { path }), LocalReadProviderError);
+  await assert.rejects(
+    provider.inspect("unknown-node", { path: "status.txt" }),
+    LocalReadProviderError,
+  );
+});
+
+test("authorization denies before provider invocation", async () => {
+  let invocations = 0;
+  const capability = createNodeInspectCapability({
+    provider: {
+      async inspect() {
+        invocations += 1;
+        throw new Error("must not run");
+      },
+    },
+    authorize: async () => ({ allowed: false, evidence_ref: "evidence_denied1" }),
+    now: () => new Date("2026-08-03T13:00:00.000Z"),
+  });
+  const response = await capability.invoke(request("req_denied1"));
+  assert.equal(response.status, "denied");
+  assert.equal(response.attempts, 0);
+  assert.equal(invocations, 0);
+});
+
+test("authorized invocation returns a structured capability result", async () => {
+  const { root } = await fixture();
+  const now = () => new Date("2026-08-03T13:00:00.000Z");
+  const provider = await createLocalReadNodeProvider([{ ref: "node-local", root }], { now });
+  const capability = createNodeInspectCapability({
+    provider,
+    authorize: async () => ({ allowed: true, evidence_ref: "evidence_allow1" }),
+    now,
+  });
+  const response = await capability.invoke(request("req_allowed1"));
+  assert.equal(response.status, "succeeded");
+  assert.equal(response.verification.status, "verified");
+  assert.deepEqual(response.verification.evidence_refs, ["evidence_allow1"]);
+});
+
+function request(request_id: string) {
+  return {
+    request_version: 1 as const,
+    request_id,
+    capability: { id: "node.inspect" as const, version: "1.0.0" as const },
+    resource: { kind: "node" as const, ref: "node-local" },
+    environment: "development",
+    input: { path: "status.txt" },
+    idempotency_key: null,
+  };
+}

--- a/test/runtime/node-inspect-boundary.test.ts
+++ b/test/runtime/node-inspect-boundary.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createNodeInspectCapability,
+  type NodeInspectRequest,
+} from "../../packages/capabilities/src/node-inspect.js";
+
+const validRequest: NodeInspectRequest = {
+  request_version: 1,
+  request_id: "req_boundary1",
+  capability: { id: "node.inspect", version: "1.0.0" },
+  resource: { kind: "node", ref: "node-local" },
+  environment: "development",
+  input: { path: "status.txt" },
+  idempotency_key: null,
+};
+
+test("invalid input fails before authorization and provider invocation", async () => {
+  let authorizations = 0;
+  let invocations = 0;
+  const capability = createNodeInspectCapability({
+    authorize: async () => {
+      authorizations += 1;
+      return { allowed: true, evidence_ref: "evidence_unused1" };
+    },
+    provider: {
+      async inspect() {
+        invocations += 1;
+        throw new Error("must not run");
+      },
+    },
+  });
+  const malformed = { ...validRequest, input: { path: "status.txt", extra: "rejected" } };
+  const response = await capability.invoke(malformed as NodeInspectRequest);
+  assert.equal((response.error as { code: string } | null)?.code, "schema_validation_failed");
+  assert.equal(response.attempts, 0);
+  assert.equal(authorizations, 0);
+  assert.equal(invocations, 0);
+});
+
+test("invalid provider output is withheld", async () => {
+  const capability = createNodeInspectCapability({
+    authorize: async () => ({ allowed: true, evidence_ref: "evidence_allow2" }),
+    provider: {
+      async inspect() {
+        return {
+          source: { node_ref: "node-local", relative_path: "status.txt" },
+          observed_at: "invalid",
+          freshness_seconds: 0,
+          entry: { kind: "file", size_bytes: 1, modified_at: "invalid" },
+        };
+      },
+    },
+  });
+  const response = await capability.invoke(validRequest);
+  assert.equal((response.error as { code: string } | null)?.code, "provider_protocol_error");
+  assert.equal(response.output, null);
+});

--- a/test/runtime/node-inspect-review-fixes.test.ts
+++ b/test/runtime/node-inspect-review-fixes.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createNodeInspectCapability,
+  type NodeInspectRequest,
+} from "../../packages/capabilities/src/node-inspect.js";
+
+const request: NodeInspectRequest = {
+  request_version: 1,
+  request_id: "req_review1",
+  capability: { id: "node.inspect", version: "1.0.0" },
+  resource: { kind: "node", ref: "node-local" },
+  environment: "development",
+  input: { path: "status.txt" },
+  idempotency_key: null,
+};
+
+test("provider timeout fails closed with no output", async () => {
+  const capability = createNodeInspectCapability({
+    authorize: async () => ({ allowed: true, evidence_ref: "evidence_allow3" }),
+    providerTimeoutMs: 5,
+    provider: {
+      async inspect() {
+        return await new Promise(() => undefined);
+      },
+    },
+  });
+  const response = await capability.invoke(request);
+  assert.equal((response.error as { code: string } | null)?.code, "execution_timeout");
+  assert.equal(response.output, null);
+  assert.equal(response.attempts, 1);
+});
+
+test("validation failure does not claim nonexistent evidence", async () => {
+  const capability = createNodeInspectCapability({
+    authorize: async () => {
+      throw new Error("must not run");
+    },
+    provider: {
+      async inspect() {
+        throw new Error("must not run");
+      },
+    },
+  });
+  const malformed = { ...request, input: { path: "" } } as NodeInspectRequest;
+  const response = await capability.invoke(malformed);
+  assert.equal((response.error as { code: string } | null)?.code, "schema_validation_failed");
+  assert.deepEqual(response.verification.evidence_refs, []);
+});


### PR DESCRIPTION
Closes #8.

## What changed

- adds the experimental, network-free `node.inspect` capability definition;
- adds a local read-only provider with server-configured canonical roots;
- rejects traversal, absolute paths, control characters, unknown nodes,
  unsupported entries, and symbolic links;
- validates input before authorization and never invokes the provider on deny;
- validates and bounds provider output before returning a CapabilityResult v1;
- records source and freshness without file contents or directory listings;
- adds negative tests, a threat-model impact review, and session evidence.

## Security boundary

The MCP listener remains inert and continues to discover no tools. This PR does
not introduce an authentication adapter, policy engine, provider configuration,
production root, credential, mutation, Project authority, or Coordination
authority. A future MCP binding requires a separate identity, policy,
configuration, and audit review.

The provider rejects symlinks and rechecks canonical containment, but does not
claim that application-level checks eliminate local filesystem TOCTOU races.

## Validation

- capability definition and successful result validate against Capability v1;
- `npm run typecheck`;
- `npm test` — 50 contract/supply-chain and 16 runtime tests;
- `npm run build`;
- `npm run format:check`;
- `git diff --check`.

