### PR TITLE
Launch professional documentation on GitHub Pages

### DIFF
--- a/.context/sessions/SESSION-2026-08-03-09-pages-launch.md
+++ b/.context/sessions/SESSION-2026-08-03-09-pages-launch.md
@@ -1,0 +1,32 @@
+# Session — GitHub Pages documentation launch
+
+- Date: 2026-08-03
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/12
+- Branch: `agent/issue-12-pages-launch`
+- Status: implementation complete locally; deployment verification pending
+
+## Outcome
+
+Enabled GitHub Pages with GitHub Actions as its source and HTTPS enforcement.
+Verified that the `github-pages` environment permits only the `main` branch.
+The strict MkDocs build, Pages configuration, and artifact upload succeeded.
+
+The first deploy exposed an invalid historical `actions/deploy-pages` commit.
+The workflow now pins the verified commit for the official v5.0.0 release,
+which uses Node.js 24.
+
+## Privacy and accessibility review
+
+- MkDocs uses only the local search plugin and repository-owned assets;
+- no analytics, tracker, remote font, or CDN runtime dependency is configured;
+- security documentation is a first-class navigation section;
+- Material provides keyboard-operable navigation and visible focus behavior;
+- custom light and dark palette contrasts were checked: violet/white 5.70:1,
+  dark-violet/white 8.98:1, and light-violet/black 7.72:1;
+- responsive behavior remains provided by the unmodified Material layout.
+
+## Boundary
+
+This change publishes public repository documentation only. It introduces no
+runtime artifact, credential, MCP capability, provider authority, analytics,
+third-party page script, or production deployment.

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -63,4 +63,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@decdde0ac072f6c095aec75db5a0d1acd028b1ee # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
Closes #12.

## What changed

- enables GitHub Pages with GitHub Actions and HTTPS enforcement;
- verifies the `github-pages` environment deploys only from `main`;
- replaces an invalid historical `actions/deploy-pages` pin with the verified
  immutable commit for official release v5.0.0;
- records privacy, accessibility, responsive-layout, and contrast review
  evidence.

## Root cause

The documentation built strictly and uploaded its artifact, but deployment
failed before execution because the pinned `actions/deploy-pages` commit did not
exist. The replacement commit is verified in the official `actions/deploy-pages`
repository and uses Node.js 24.

## Boundary

This publishes public documentation only. It adds no analytics, remote runtime
asset, credential, MCP authority, provider access, or production artifact.

## Validation

- `npm run format:check`;
- `npm test` — 50 contract/supply-chain and 16 runtime tests;
- `npm run build`;
- `git diff --check`;
- strict MkDocs build, Pages configuration, and artifact upload succeeded in
  GitHub Actions;
- official replacement commit signature verified through GitHub.

Deployment can be proven only after merge because the protected environment
accepts `main` exclusively.
