### PR TITLE
Deliver a five-minute read-only MCP demo

### DIFF
--- a/.context/sessions/SESSION-2026-08-03-10-read-only-demo.md
+++ b/.context/sessions/SESSION-2026-08-03-10-read-only-demo.md
@@ -1,0 +1,25 @@
+# Session — five-minute read-only demo
+
+- Date: 2026-08-03
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/11
+- Branch: `agent/issue-11-read-only-demo`
+- Status: implementation complete locally; draft PR pending
+
+## Outcome
+
+Added `npm run demo`, which creates a synthetic temporary node fixture, starts
+the gateway on loopback and an ephemeral port, connects an MCP client,
+discovers the demo-only `node.inspect` tool, executes an explicit allow and an
+explicit deny, prints bounded structured results plus protected in-memory
+evidence projections, and tears everything down.
+
+The default gateway server factory remains inert. Demo authority is isolated in
+the demo entry point and cannot select a production root, credential, provider
+method, command, or mutation.
+
+## Boundary
+
+The evidence is labelled `in_memory_demo_only` and is not durable RFC-0004
+audit. No authentication profile, production policy adapter, credential,
+provider deployment, persistent state, mutation, or production MCP tool is
+introduced.

--- a/apps/demo/src/demo.ts
+++ b/apps/demo/src/demo.ts
@@ -1,0 +1,130 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Client, StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
+import { McpServer } from "@modelcontextprotocol/server";
+import { z } from "zod";
+import { createGatewayRuntime } from "../../gateway/src/server.js";
+import { createNodeInspectCapability } from "../../../packages/capabilities/src/node-inspect.js";
+import { createLocalReadNodeProvider } from "../../../packages/providers/local-read/src/node-inspect.js";
+import { createLogger } from "../../../packages/logging/src/logger.js";
+
+const inputSchema = z
+  .object({ node_ref: z.enum(["node-demo", "node-denied"]), path: z.literal("status.txt") })
+  .strict();
+
+export interface DemoTranscript {
+  readonly mode: "synthetic_local_demo";
+  readonly discovery: { readonly tools: readonly string[] };
+  readonly allowed: unknown;
+  readonly denied: unknown;
+  readonly evidence_projection: readonly {
+    readonly evidence_ref: string;
+    readonly event_type: "authorization.enforcement_recorded.v1";
+    readonly effect: "allow" | "deny";
+    readonly basis: "explicit";
+    readonly subject_ref: "subject_demo";
+    readonly policy_ref: "policy_demo_v1";
+    readonly classification: "protected";
+    readonly durability: "in_memory_demo_only";
+  }[];
+}
+
+export async function runReadOnlyDemo(): Promise<DemoTranscript> {
+  const root = await mkdtemp(join(tmpdir(), "yukh-demo-"));
+  try {
+    await writeFile(join(root, "status.txt"), "synthetic healthy fixture\n", "utf8");
+    const evidence: DemoTranscript["evidence_projection"][number][] = [];
+    const provider = await createLocalReadNodeProvider([{ ref: "node-demo", root }]);
+    let sequence = 0;
+    const capability = createNodeInspectCapability({
+      provider,
+      authorize: async (request) => {
+        const allowed = request.resource.ref === "node-demo";
+        const evidence_ref = `evidence_demo_${++sequence}`;
+        evidence.push({
+          evidence_ref,
+          event_type: "authorization.enforcement_recorded.v1",
+          effect: allowed ? "allow" : "deny",
+          basis: "explicit",
+          subject_ref: "subject_demo",
+          policy_ref: "policy_demo_v1",
+          classification: "protected",
+          durability: "in_memory_demo_only",
+        });
+        return { allowed, evidence_ref };
+      },
+    });
+
+    const createDemoServer = () => {
+      const server = new McpServer({ name: "yukh-mcp-demo", version: "0.0.0" });
+      server.registerTool(
+        "node.inspect",
+        {
+          title: "Inspect synthetic demo node",
+          description: "Read bounded metadata from the synthetic local demo fixture",
+          inputSchema,
+          annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+        },
+        async ({ node_ref, path }) => {
+          const result = await capability.invoke({
+            request_version: 1,
+            request_id: `req_demo_${sequence + 1}`,
+            capability: { id: "node.inspect", version: "1.0.0" },
+            resource: { kind: "node", ref: node_ref },
+            environment: "demo",
+            input: { path },
+            idempotency_key: null,
+          });
+          return {
+            content: [{ type: "text", text: JSON.stringify(result) }],
+            structuredContent: { result },
+            isError: result.status !== "succeeded",
+          };
+        },
+      );
+      return server;
+    };
+
+    const runtime = createGatewayRuntime(
+      {
+        host: "127.0.0.1",
+        port: 0,
+        allowedHosts: ["127.0.0.1"],
+        allowedOrigins: [],
+        maxBodyBytes: 8_192,
+        shutdownTimeoutMs: 1_000,
+      },
+      createLogger({ sink: () => undefined }),
+      createDemoServer,
+    );
+    const { port } = await runtime.listen();
+    const client = new Client({ name: "yukh-demo-client", version: "1.0.0" });
+    try {
+      await client.connect(
+        new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`)),
+      );
+      const tools = (await client.listTools()).tools.map(({ name }) => name).sort();
+      const allowed = await client.callTool({
+        name: "node.inspect",
+        arguments: { node_ref: "node-demo", path: "status.txt" },
+      });
+      const denied = await client.callTool({
+        name: "node.inspect",
+        arguments: { node_ref: "node-denied", path: "status.txt" },
+      });
+      return {
+        mode: "synthetic_local_demo",
+        discovery: { tools },
+        allowed,
+        denied,
+        evidence_projection: evidence,
+      };
+    } finally {
+      await client.close();
+      await runtime.close();
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/apps/demo/src/main.ts
+++ b/apps/demo/src/main.ts
@@ -1,0 +1,3 @@
+import { runReadOnlyDemo } from "./demo.js";
+
+process.stdout.write(`${JSON.stringify(await runReadOnlyDemo(), null, 2)}\n`);

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -61,7 +61,7 @@ function json(target: ServerResponse, status: number, value: object): void {
   target.end(body);
 }
 
-function createInertMcpServer(): McpServer {
+export function createInertMcpServer(): McpServer {
   return new McpServer(
     { name: "yukh-mcp", version: "0.0.0" },
     {
@@ -77,9 +77,10 @@ function createInertMcpServer(): McpServer {
 export function createGatewayRuntime(
   config: RuntimeConfig,
   logger: Logger = createLogger(),
+  createServerInstance: () => McpServer = createInertMcpServer,
 ): GatewayRuntime {
   let ready = false;
-  const mcp = createMcpHandler(() => createInertMcpServer(), { legacy: "stateless" });
+  const mcp = createMcpHandler(createServerInstance, { legacy: "stateless" });
   const server: Server = createServer(async (request, response) => {
     const correlation_ref = correlationRef();
     response.setHeader("x-request-id", correlation_ref);

--- a/docs/guides/read-only-demo.md
+++ b/docs/guides/read-only-demo.md
@@ -1,0 +1,21 @@
+# Five-minute read-only demo
+
+This synthetic demo proves the Yukh flow without credentials, elevated
+privileges, production targets, or persistent state.
+
+From a clean checkout with Node.js 22 or newer:
+
+```sh
+npm ci --ignore-scripts
+npm run demo
+```
+
+The command starts a loopback gateway on an ephemeral port, connects an MCP
+client, discovers `node.inspect`, performs one explicitly allowed read and one
+explicitly denied read, prints structured results and sanitized evidence, then
+removes its temporary fixture and stops the gateway.
+
+The output is labelled `synthetic_local_demo`. Its evidence projection is
+classified `protected` and marked `in_memory_demo_only`: it demonstrates
+structure and correlation but is not a durable RFC-0004 audit record. The
+ordinary gateway remains inert and exposes no operational tools.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -302,3 +302,23 @@ This review authorizes the network-free experimental provider boundary and its
 tests only. It does not authorize MCP exposure, production roots, credentials,
 non-loopback deployment, filesystem contents, directory enumeration, mutation,
 or a claim that application-level checks eliminate local TOCTOU races.
+
+## Synthetic read-only demo review — 2026-08-03
+
+- Governing issue: #11
+- Scope: loopback MCP demo binding, synthetic temporary fixture, explicit demo
+  policy, allow/deny transcript, and protected in-memory evidence projection
+- New trust boundary: local demo MCP client to a fixture-only provider profile
+
+The ordinary gateway remains inert. The demo registers only `node.inspect`,
+binds only synthetic node references, returns metadata without fixture content,
+uses no credential or elevated privilege, and removes its temporary root during
+success or failure teardown. Input, provider output, request size, host, origin,
+and timeout bounds remain enforced by the existing runtime and capability
+layers.
+
+The printed evidence is a sanitized protected projection marked
+`in_memory_demo_only`. It is not a durable RFC-0004 event, integrity chain,
+checkpoint, production audit claim, authentication profile, or authorization
+adapter. Production MCP exposure remains forbidden pending separate accepted
+identity, policy, audit-writer, and deployment profiles.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,8 @@ nav:
   - Architecture:
       - Overview: architecture/overview.md
       - Inert runtime skeleton: architecture/runtime-skeleton.md
+  - Guides:
+      - Five-minute read-only demo: guides/read-only-demo.md
   - Security:
       - Security model: security/security-model.md
       - Threat model: security/threat-model.md

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "tsc --project tsconfig.build.json",
     "start": "node dist/apps/gateway/src/main.js",
     "dev": "tsx apps/gateway/src/main.ts",
+    "demo": "tsx apps/demo/src/main.ts",
     "format:check": "prettier --check apps packages test/runtime package.json tsconfig.json tsconfig.build.json compose.yaml '.github/**/*.yml'",
     "test": "node --test test/contracts/*.test.mjs test/supply-chain/*.test.mjs && npm run test:runtime",
     "test:contracts": "node --test test/contracts/*.test.mjs",

--- a/test/runtime/demo.test.ts
+++ b/test/runtime/demo.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import test from "node:test";
+import { runReadOnlyDemo } from "../../apps/demo/src/demo.js";
+
+test("five-minute demo discovers one read tool and proves allow plus deny", async () => {
+  const before = new Set((await readdir(tmpdir())).filter((name) => name.startsWith("yukh-demo-")));
+  const transcript = await runReadOnlyDemo();
+  assert.deepEqual(transcript.discovery.tools, ["node.inspect"]);
+  assert.equal((transcript.allowed as { isError?: boolean }).isError, false);
+  assert.equal((transcript.denied as { isError?: boolean }).isError, true);
+  assert.deepEqual(
+    transcript.evidence_projection.map(({ effect }) => effect),
+    ["allow", "deny"],
+  );
+  assert.ok(
+    transcript.evidence_projection.every(
+      ({ durability, classification }) =>
+        durability === "in_memory_demo_only" && classification === "protected",
+    ),
+  );
+  assert.equal(JSON.stringify(transcript).includes("synthetic healthy fixture"), false);
+  const after = (await readdir(tmpdir())).filter((name) => name.startsWith("yukh-demo-"));
+  assert.deepEqual(
+    after.filter((name) => !before.has(name)),
+    [],
+  );
+});


### PR DESCRIPTION
Closes #11.

## What changed

- adds `npm run demo` as the reproducible local entry point;
- starts the real loopback HTTP gateway on an ephemeral port and connects an
  MCP client;
- discovers only the demo-bound `node.inspect` tool;
- executes one explicit allow and one explicit deny against synthetic node
  references;
- prints bounded Capability v1 results and protected, sanitized evidence
  projections;
- removes its temporary fixture and stops client and gateway;
- exercises the complete demo in CI and documents the five-minute flow.

## Security boundary

The default gateway remains inert. The demo uses no credential, elevated
privilege, production target, persistent state, mutation, unrestricted command,
or provider-selected method. Its evidence is explicitly labelled
`in_memory_demo_only`: it is not durable RFC-0004 audit evidence or a production
integrity claim.

## Validation

- `npm run demo` completed with discovery, allow, deny, and structured evidence;
- `npm run format:check`;
- `npm run typecheck`;
- `npm test` — 50 contract/supply-chain and 17 runtime tests;
- `npm run build`;
- `git diff --check`;
- teardown test confirms no new `yukh-demo-*` directory remains.

MkDocs strict is delegated to the existing CI job, which installs the exact
documentation dependency in a clean runner.
