### PR TITLE
Define the inert MCP coordination consumer contract

### DIFF
--- a/.context/sessions/SESSION-2026-08-03-12-coordination-consumer-contract.md
+++ b/.context/sessions/SESSION-2026-08-03-12-coordination-consumer-contract.md
@@ -1,0 +1,25 @@
+# Session — inert coordination consumer contract
+
+- Date: 2026-08-03
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/45
+- Branch: `agent/issue-45-coordination-consumer-contract`
+- Status: implementation complete locally; pull request pending
+
+## Outcome
+
+Added an MCP-owned, provider-neutral consumer port for the nonce and fenced
+lease semantics required by the accepted lifecycle RFCs. Closed schemas enforce
+exact operation and binding digests, receipt freshness, bounded values, stable
+errors, one driver attempt, and a finite timeout. Network-free fakes cover all
+five semantic operations and negative failure paths.
+
+## Boundary
+
+No Coordination source, component, schema, bundle, client, endpoint, transport,
+credential, or deployment configuration was copied or imported. The port is not
+wired into the gateway and can create no execution authority. Nonces and lease
+handles are sensitive runtime material and are excluded from durable evidence.
+
+Real integration remains blocked until `nomed/yukh-coordination#71` merges and
+its stable contract is separately reviewed. This increment stops before that
+integration as required.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -24,3 +24,22 @@ flowchart TD
 - Audit records are structured, redacted, and tamper-evident by design.
 
 The architecture remains under public RFC review during foundation.
+
+## Inert coordination consumer port
+
+The MCP-owned coordination consumer contract is a provider-neutral application
+port for the nonce-consumption and fenced-lease semantics required by the
+accepted lifecycle RFCs. It validates closed, bounded requests and treats every
+driver response as untrusted. Unknown versions or fields, binding substitution,
+stale leases, timeout, and dependency failure stop progression without retry.
+
+The port selects no protocol, endpoint, credential, deployment, or upstream
+implementation. Its current driver is exercised only by network-free fakes and
+is not wired into the gateway. Nonces and lease handles are sensitive runtime
+material: they must never enter logs, audit evidence, errors, model context, or
+durable repository context.
+
+Real integration remains blocked until `nomed/yukh-coordination#71` is merged
+and its stable consumer contract is reviewed. That future increment must adapt
+the stable contract at this port; it must not copy Coordination components into
+Yukh MCP.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -322,3 +322,25 @@ The printed evidence is a sanitized protected projection marked
 checkpoint, production audit claim, authentication profile, or authorization
 adapter. Production MCP exposure remains forbidden pending separate accepted
 identity, policy, audit-writer, and deployment profiles.
+
+## Inert coordination consumer contract review — 2026-08-03
+
+- Governing issue: #45
+- Scope: MCP-owned consumer types, closed response validation, bounded timeout,
+  and network-free fake conformance tests
+- New live trust boundary: none; the driver is not connected to the gateway or
+  to a transport
+
+| Threat | Control | Residual risk / dependency |
+| --- | --- | --- |
+| malformed or substituted coordination receipt advances lifecycle | strict closed schemas plus exact operation and binding-digest checks | the future canonical digest implementation must be reviewed against the stable upstream contract |
+| stale lease is treated as current | expiry is checked against an injected trusted clock and equality is stale | clock source and skew policy remain deployment-specific |
+| dependency detail leaks through errors | all driver exceptions and timeouts normalize to one bounded code | future observability must retain the closed error surface |
+| hidden retry duplicates nonce or lease operations | the consumer performs one bounded driver call and never retries | a future transport adapter must prove it does not retry, redirect, or poll internally |
+| nonce or sealed lease handle enters evidence | sensitive values are absent from receipts intended for evidence and explicitly forbidden from logs, audit, errors, model context, and repository context | future adapter memory handling and crash diagnostics require review |
+| Coordination implementation becomes coupled into MCP | only an MCP-owned port and fake driver exist; no source, bundle, client, schema, or transport is imported | compatibility cannot be claimed until PR #71 merges and an adapter is separately reviewed |
+
+This review authorizes only the inert consumer contract. It does not authorize
+an HTTP adapter, Coordination client import, endpoint, credential,
+authentication profile, real nonce consumption, real lease, gateway wiring,
+provider invocation, mutation, deployment, or release claim.

--- a/packages/coordination-consumer/src/contract.ts
+++ b/packages/coordination-consumer/src/contract.ts
@@ -1,0 +1,264 @@
+import { z } from "zod";
+
+const boundedRef = z.string().min(1).max(128);
+const digest = z.string().regex(/^sha256:[0-9a-f]{64}$/);
+const instant = z.iso.datetime({ offset: true });
+
+const bindingSchema = z
+  .object({
+    binding_version: z.literal(1),
+    operation_ref: boundedRef,
+    subject_ref: boundedRef,
+    capability_ref: boundedRef,
+    resource_set_digest: digest,
+    environment_ref: boundedRef,
+    plan_digest: digest,
+    approval_digest: digest,
+  })
+  .strict();
+
+export type CoordinationBinding = z.infer<typeof bindingSchema>;
+
+const nonceRequestSchema = z
+  .object({
+    request_version: z.literal(1),
+    binding: bindingSchema,
+    nonce: z.string().min(16).max(512),
+  })
+  .strict();
+
+const leaseAcquireRequestSchema = z
+  .object({
+    request_version: z.literal(1),
+    binding: bindingSchema,
+    holder_digest: digest,
+    ttl_ms: z.number().int().min(1_000).max(60_000),
+  })
+  .strict();
+
+const leaseHandleRequestSchema = z
+  .object({
+    request_version: z.literal(1),
+    binding: bindingSchema,
+    lease_handle: z.string().min(16).max(2_048),
+  })
+  .strict();
+
+const leaseRenewRequestSchema = leaseHandleRequestSchema
+  .extend({ ttl_ms: z.number().int().min(1_000).max(60_000) })
+  .strict();
+
+export type NonceConsumeRequest = z.infer<typeof nonceRequestSchema>;
+export type LeaseAcquireRequest = z.infer<typeof leaseAcquireRequestSchema>;
+export type LeaseHandleRequest = z.infer<typeof leaseHandleRequestSchema>;
+export type LeaseRenewRequest = z.infer<typeof leaseRenewRequestSchema>;
+
+const receiptBase = {
+  response_version: z.literal(1),
+  operation_ref: boundedRef,
+  binding_digest: digest,
+  evidence_ref: boundedRef,
+} as const;
+
+const nonceReceiptSchema = z
+  .object({
+    ...receiptBase,
+    outcome: z.literal("consumed"),
+    consumed_at: instant,
+  })
+  .strict();
+
+const leaseReceiptSchema = z
+  .object({
+    ...receiptBase,
+    outcome: z.enum(["acquired", "active", "renewed"]),
+    lease_ref: boundedRef,
+    lease_handle: z.string().min(16).max(2_048),
+    fencing_token: z.string().regex(/^[1-9][0-9]{0,39}$/),
+    expires_at: instant,
+  })
+  .strict();
+
+const releaseReceiptSchema = z
+  .object({
+    ...receiptBase,
+    outcome: z.literal("released"),
+    lease_ref: boundedRef,
+    fencing_token: z.string().regex(/^[1-9][0-9]{0,39}$/),
+    released_at: instant,
+  })
+  .strict();
+
+export type NonceReceipt = z.infer<typeof nonceReceiptSchema>;
+export type LeaseReceipt = z.infer<typeof leaseReceiptSchema>;
+export type ReleaseReceipt = z.infer<typeof releaseReceiptSchema>;
+
+/**
+ * An inert MCP-side port. Implementations may be fakes today; no network,
+ * authentication, endpoint, or Coordination client is selected here.
+ */
+export interface CoordinationConsumerDriver {
+  consumeNonce(request: NonceConsumeRequest): Promise<unknown>;
+  acquireLease(request: LeaseAcquireRequest): Promise<unknown>;
+  inspectLease(request: LeaseHandleRequest): Promise<unknown>;
+  renewLease(request: LeaseRenewRequest): Promise<unknown>;
+  releaseLease(request: LeaseHandleRequest): Promise<unknown>;
+}
+
+export type CoordinationConsumerErrorCode =
+  | "coordination_request_invalid"
+  | "coordination_unavailable"
+  | "coordination_response_invalid"
+  | "coordination_binding_mismatch"
+  | "coordination_receipt_stale";
+
+export class CoordinationConsumerError extends Error {
+  readonly code: CoordinationConsumerErrorCode;
+
+  constructor(code: CoordinationConsumerErrorCode) {
+    super(code);
+    this.name = "CoordinationConsumerError";
+    this.code = code;
+  }
+}
+
+export interface CoordinationConsumer {
+  consumeNonce(request: NonceConsumeRequest): Promise<NonceReceipt>;
+  acquireLease(request: LeaseAcquireRequest): Promise<LeaseReceipt>;
+  inspectLease(request: LeaseHandleRequest): Promise<LeaseReceipt>;
+  renewLease(request: LeaseRenewRequest): Promise<LeaseReceipt>;
+  releaseLease(request: LeaseHandleRequest): Promise<ReleaseReceipt>;
+}
+
+function assertRequest<T>(schema: z.ZodType<T>, request: unknown): T {
+  const parsed = schema.safeParse(request);
+  if (!parsed.success) throw new CoordinationConsumerError("coordination_request_invalid");
+  return parsed.data;
+}
+
+function assertReceipt<T extends { operation_ref: string; binding_digest: string }>(
+  schema: z.ZodType<T>,
+  value: unknown,
+  binding: CoordinationBinding,
+  expectedBindingDigest: string,
+  now: Date,
+): T {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) throw new CoordinationConsumerError("coordination_response_invalid");
+  if (
+    parsed.data.operation_ref !== binding.operation_ref ||
+    parsed.data.binding_digest !== expectedBindingDigest
+  )
+    throw new CoordinationConsumerError("coordination_binding_mismatch");
+  if ("expires_at" in parsed.data && Date.parse(String(parsed.data.expires_at)) <= now.getTime())
+    throw new CoordinationConsumerError("coordination_receipt_stale");
+  return Object.freeze(parsed.data);
+}
+
+async function callDriver<T>(operation: () => Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      operation(),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new CoordinationConsumerError("coordination_unavailable")),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } catch (error) {
+    if (error instanceof CoordinationConsumerError) throw error;
+    throw new CoordinationConsumerError("coordination_unavailable");
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export function createCoordinationConsumer(options: {
+  readonly driver: CoordinationConsumerDriver;
+  readonly digestBinding: (binding: CoordinationBinding) => string;
+  readonly now?: () => Date;
+  readonly driverTimeoutMs?: number;
+}): CoordinationConsumer {
+  const now = options.now ?? (() => new Date());
+  const driverTimeoutMs = options.driverTimeoutMs ?? 500;
+  if (!Number.isInteger(driverTimeoutMs) || driverTimeoutMs < 1 || driverTimeoutMs > 2_000)
+    throw new TypeError("invalid coordination driver timeout");
+
+  function context(binding: CoordinationBinding) {
+    let bindingDigest: string;
+    try {
+      bindingDigest = options.digestBinding(binding);
+    } catch {
+      throw new CoordinationConsumerError("coordination_request_invalid");
+    }
+    if (!digest.safeParse(bindingDigest).success)
+      throw new CoordinationConsumerError("coordination_request_invalid");
+    const observedAt = now();
+    if (Number.isNaN(observedAt.getTime()))
+      throw new CoordinationConsumerError("coordination_request_invalid");
+    return { bindingDigest, observedAt };
+  }
+
+  const consumer: CoordinationConsumer = {
+    async consumeNonce(request: NonceConsumeRequest) {
+      const valid = assertRequest(nonceRequestSchema, request);
+      const { bindingDigest, observedAt } = context(valid.binding);
+      const raw = await callDriver(() => options.driver.consumeNonce(valid), driverTimeoutMs);
+      return assertReceipt(nonceReceiptSchema, raw, valid.binding, bindingDigest, observedAt);
+    },
+    async acquireLease(request: LeaseAcquireRequest) {
+      const valid = assertRequest(leaseAcquireRequestSchema, request);
+      const { bindingDigest, observedAt } = context(valid.binding);
+      const raw = await callDriver(() => options.driver.acquireLease(valid), driverTimeoutMs);
+      const receipt = assertReceipt(
+        leaseReceiptSchema,
+        raw,
+        valid.binding,
+        bindingDigest,
+        observedAt,
+      );
+      if (receipt.outcome !== "acquired")
+        throw new CoordinationConsumerError("coordination_response_invalid");
+      return receipt;
+    },
+    async inspectLease(request: LeaseHandleRequest) {
+      const valid = assertRequest(leaseHandleRequestSchema, request);
+      const { bindingDigest, observedAt } = context(valid.binding);
+      const raw = await callDriver(() => options.driver.inspectLease(valid), driverTimeoutMs);
+      const receipt = assertReceipt(
+        leaseReceiptSchema,
+        raw,
+        valid.binding,
+        bindingDigest,
+        observedAt,
+      );
+      if (receipt.outcome !== "active")
+        throw new CoordinationConsumerError("coordination_response_invalid");
+      return receipt;
+    },
+    async renewLease(request: LeaseRenewRequest) {
+      const valid = assertRequest(leaseRenewRequestSchema, request);
+      const { bindingDigest, observedAt } = context(valid.binding);
+      const raw = await callDriver(() => options.driver.renewLease(valid), driverTimeoutMs);
+      const receipt = assertReceipt(
+        leaseReceiptSchema,
+        raw,
+        valid.binding,
+        bindingDigest,
+        observedAt,
+      );
+      if (receipt.outcome !== "renewed")
+        throw new CoordinationConsumerError("coordination_response_invalid");
+      return receipt;
+    },
+    async releaseLease(request: LeaseHandleRequest) {
+      const valid = assertRequest(leaseHandleRequestSchema, request);
+      const { bindingDigest, observedAt } = context(valid.binding);
+      const raw = await callDriver(() => options.driver.releaseLease(valid), driverTimeoutMs);
+      return assertReceipt(releaseReceiptSchema, raw, valid.binding, bindingDigest, observedAt);
+    },
+  };
+  return Object.freeze(consumer);
+}

--- a/test/runtime/coordination-consumer-contract.test.ts
+++ b/test/runtime/coordination-consumer-contract.test.ts
@@ -1,0 +1,224 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  CoordinationConsumerError,
+  createCoordinationConsumer,
+  type CoordinationBinding,
+  type CoordinationConsumerDriver,
+} from "../../packages/coordination-consumer/src/contract.js";
+
+const binding: CoordinationBinding = {
+  binding_version: 1,
+  operation_ref: "operation-1",
+  subject_ref: "subject-1",
+  capability_ref: "service.restart@1.0.0",
+  resource_set_digest: `sha256:${"1".repeat(64)}`,
+  environment_ref: "staging",
+  plan_digest: `sha256:${"2".repeat(64)}`,
+  approval_digest: `sha256:${"3".repeat(64)}`,
+};
+
+const bindingDigest = `sha256:${"4".repeat(64)}`;
+const now = new Date("2026-08-03T15:00:00.000Z");
+
+function driver(overrides: Partial<CoordinationConsumerDriver> = {}): CoordinationConsumerDriver {
+  const lease = (outcome: "acquired" | "active" | "renewed") => ({
+    response_version: 1,
+    operation_ref: binding.operation_ref,
+    binding_digest: bindingDigest,
+    evidence_ref: "evidence-lease-1",
+    outcome,
+    lease_ref: "lease-1",
+    lease_handle: "sealed-lease-handle",
+    fencing_token: "7",
+    expires_at: "2026-08-03T15:00:30.000Z",
+  });
+  return {
+    consumeNonce: async () => ({
+      response_version: 1,
+      operation_ref: binding.operation_ref,
+      binding_digest: bindingDigest,
+      evidence_ref: "evidence-nonce-1",
+      outcome: "consumed",
+      consumed_at: now.toISOString(),
+    }),
+    acquireLease: async () => lease("acquired"),
+    inspectLease: async () => lease("active"),
+    renewLease: async () => lease("renewed"),
+    releaseLease: async () => ({
+      response_version: 1,
+      operation_ref: binding.operation_ref,
+      binding_digest: bindingDigest,
+      evidence_ref: "evidence-release-1",
+      outcome: "released",
+      lease_ref: "lease-1",
+      fencing_token: "7",
+      released_at: now.toISOString(),
+    }),
+    ...overrides,
+  };
+}
+
+function consumer(overrides: Partial<CoordinationConsumerDriver> = {}) {
+  return createCoordinationConsumer({
+    driver: driver(overrides),
+    digestBinding: () => bindingDigest,
+    now: () => now,
+  });
+}
+
+test("network-free fake satisfies the five closed consumer operations", async () => {
+  const port = consumer();
+  const nonce = await port.consumeNonce({
+    request_version: 1,
+    binding,
+    nonce: "one-time-nonce-value",
+  });
+  assert.equal(nonce.outcome, "consumed");
+
+  const acquired = await port.acquireLease({
+    request_version: 1,
+    binding,
+    holder_digest: `sha256:${"5".repeat(64)}`,
+    ttl_ms: 30_000,
+  });
+  assert.equal(acquired.fencing_token, "7");
+
+  const handleRequest = {
+    request_version: 1 as const,
+    binding,
+    lease_handle: acquired.lease_handle,
+  };
+  assert.equal((await port.inspectLease(handleRequest)).outcome, "active");
+  assert.equal((await port.renewLease({ ...handleRequest, ttl_ms: 30_000 })).outcome, "renewed");
+  assert.equal((await port.releaseLease(handleRequest)).outcome, "released");
+});
+
+test("malformed requests fail before the driver", async () => {
+  let calls = 0;
+  const port = consumer({
+    consumeNonce: async () => {
+      calls += 1;
+      return {};
+    },
+  });
+  await assert.rejects(
+    port.consumeNonce({ request_version: 1, binding, nonce: "short" }),
+    (error: unknown) =>
+      error instanceof CoordinationConsumerError && error.code === "coordination_request_invalid",
+  );
+  assert.equal(calls, 0);
+});
+
+test("unknown fields and operation outcomes fail closed", async () => {
+  const port = consumer({
+    acquireLease: async () => ({
+      response_version: 1,
+      operation_ref: binding.operation_ref,
+      binding_digest: bindingDigest,
+      evidence_ref: "evidence-1",
+      outcome: "acquired",
+      lease_ref: "lease-1",
+      lease_handle: "sealed-lease-handle",
+      fencing_token: "7",
+      expires_at: "2026-08-03T15:00:30.000Z",
+      provider_debug: "must not cross boundary",
+    }),
+  });
+  await assert.rejects(
+    port.acquireLease({
+      request_version: 1,
+      binding,
+      holder_digest: `sha256:${"5".repeat(64)}`,
+      ttl_ms: 30_000,
+    }),
+    (error: unknown) =>
+      error instanceof CoordinationConsumerError && error.code === "coordination_response_invalid",
+  );
+});
+
+test("cross-operation substitution and stale leases fail closed", async () => {
+  const mismatched = consumer({
+    inspectLease: async () => ({
+      ...((await driver().inspectLease({
+        request_version: 1,
+        binding,
+        lease_handle: "sealed-lease-handle",
+      })) as object),
+      operation_ref: "another-operation",
+    }),
+  });
+  await assert.rejects(
+    mismatched.inspectLease({
+      request_version: 1,
+      binding,
+      lease_handle: "sealed-lease-handle",
+    }),
+    (error: unknown) =>
+      error instanceof CoordinationConsumerError && error.code === "coordination_binding_mismatch",
+  );
+
+  const stale = consumer({
+    inspectLease: async () => ({
+      ...((await driver().inspectLease({
+        request_version: 1,
+        binding,
+        lease_handle: "sealed-lease-handle",
+      })) as object),
+      expires_at: now.toISOString(),
+    }),
+  });
+  await assert.rejects(
+    stale.inspectLease({
+      request_version: 1,
+      binding,
+      lease_handle: "sealed-lease-handle",
+    }),
+    (error: unknown) =>
+      error instanceof CoordinationConsumerError && error.code === "coordination_receipt_stale",
+  );
+});
+
+test("dependency errors are normalized without leaking their message", async () => {
+  const port = consumer({
+    consumeNonce: async () => {
+      throw new Error("sensitive upstream detail");
+    },
+  });
+  await assert.rejects(
+    port.consumeNonce({
+      request_version: 1,
+      binding,
+      nonce: "one-time-nonce-value",
+    }),
+    (error: unknown) =>
+      error instanceof CoordinationConsumerError &&
+      error.code === "coordination_unavailable" &&
+      !error.message.includes("sensitive"),
+  );
+});
+
+test("an unresponsive dependency times out without retry", async () => {
+  let calls = 0;
+  const port = createCoordinationConsumer({
+    driver: driver({
+      consumeNonce: async () => {
+        calls += 1;
+        return await new Promise(() => undefined);
+      },
+    }),
+    digestBinding: () => bindingDigest,
+    now: () => now,
+    driverTimeoutMs: 5,
+  });
+  await assert.rejects(
+    port.consumeNonce({
+      request_version: 1,
+      binding,
+      nonce: "one-time-nonce-value",
+    }),
+    (error: unknown) =>
+      error instanceof CoordinationConsumerError && error.code === "coordination_unavailable",
+  );
+  assert.equal(calls, 1);
+});


### PR DESCRIPTION
## What changed

- adds an MCP-owned consumer port for nonce consumption and fenced lease acquire/inspect/renew/release semantics
- validates closed bounded requests and untrusted driver responses
- enforces exact operation/binding correlation, freshness, one bounded attempt, timeout, and normalized errors
- adds network-free fake conformance and negative tests
- records architecture, threat-model, and durable session impact

## Boundary

This PR copies or imports no Coordination source, component, schema, bundle, client, endpoint, transport, credential, or deployment configuration. The port is not wired into the gateway. It stops before real integration as required.

Real integration remains blocked until `nomed/yukh-coordination#71` is merged and its stable contract is separately reviewed. Yukh MCP does not take ownership of `nomed/yukh-coordination#58`.

## Validation

- `npm run format:check`
- `npm run typecheck`
- `npm test` (50 contract/supply-chain and 23 runtime tests)
- `npm run build`
- `git diff --check`

Closes #45