### PR TITLE
Implement the synthetic Coordination adapter

### DIFF
--- a/.context/sessions/SESSION-2026-08-03-14-synthetic-coordination-adapter.md
+++ b/.context/sessions/SESSION-2026-08-03-14-synthetic-coordination-adapter.md
@@ -3,7 +3,7 @@
 - Date: 2026-08-03
 - Governing issue: https://github.com/nomed/yukh-mcp/issues/47
 - Branch: `agent/issue-47-synthetic-coordination-adapter`
-- Status: implementation candidate complete; TLS loopback qualification pending
+- Status: implementation and TLS loopback qualification complete
 
 ## Outcome
 
@@ -26,9 +26,11 @@ error normalization, deadline and one-call behavior. The adapter is not wired
 into the gateway and no Coordination component, endpoint, real credential,
 provider execution, mutation, deployment or live apply exists.
 
-The accepted RFC additionally requires a real synthetic loopback HTTPS server.
-That qualification remains pending because the repository must not commit a
-private key and the implementation may not add a subprocess or dependency to
-generate one. The current injected transport evidence is not represented as a
-real TLS crossing; the PR must remain draft until a compliant ephemeral TLS
-fixture is reviewed or the owner explicitly narrows that qualification.
+The accepted RFC's loopback requirement is qualified by a test-only HTTPS
+server on `127.0.0.1`. A fixed-argument OpenSSL invocation generates a one-day
+self-signed certificate and private key in a mode-`0700` temporary directory;
+the key is mode `0600`, is trusted only by the test transport, and the complete
+fixture is removed in `finally`. Certificate verification remains enabled.
+This owner-authorized test helper is absent from the runtime and build output,
+adds no dependency, uses no shell, and does not weaken the product prohibition
+on subprocesses or ambient trust.

--- a/.context/sessions/SESSION-2026-08-03-14-synthetic-coordination-adapter.md
+++ b/.context/sessions/SESSION-2026-08-03-14-synthetic-coordination-adapter.md
@@ -1,0 +1,34 @@
+# Session — synthetic Coordination adapter implementation
+
+- Date: 2026-08-03
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/47
+- Branch: `agent/issue-47-synthetic-coordination-adapter`
+- Status: implementation candidate complete; TLS loopback qualification pending
+
+## Outcome
+
+Revised the experimental consumer port to carry trusted epoch and exact expiry
+and removed invented evidence references. Added an independent MCP-native
+adapter for the accepted Coordination primitives v1 wire contract using only
+Node platform APIs and injected authentication/transport ports.
+
+The adapter derives domain-separated scope, nonce and holder digests; emits only
+the five fixed HTTPS routes; bounds canonical request and streamed response
+bytes; rejects redirects, framing drift and unknown outcomes; applies one
+deadline across authentication, transport and response; performs no retry; and
+keeps lease capabilities in a redacted, non-serializable private wrapper.
+
+## Validation and boundary
+
+Synthetic transport tests cover binding minimization, all lease operations,
+normative `409 conflict`, nonce replay, stale input, malformed output, secret
+error normalization, deadline and one-call behavior. The adapter is not wired
+into the gateway and no Coordination component, endpoint, real credential,
+provider execution, mutation, deployment or live apply exists.
+
+The accepted RFC additionally requires a real synthetic loopback HTTPS server.
+That qualification remains pending because the repository must not commit a
+private key and the implementation may not add a subprocess or dependency to
+generate one. The current injected transport evidence is not represented as a
+real TLS crossing; the PR must remain draft until a compliant ephemeral TLS
+fixture is reviewed or the owner explicitly narrows that qualification.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -43,3 +43,10 @@ Real integration remains blocked until `nomed/yukh-coordination#71` is merged
 and its stable consumer contract is reviewed. That future increment must adapt
 the stable contract at this port; it must not copy Coordination components into
 Yukh MCP.
+
+RFC-0005 now governs an MCP-native adapter implementation behind this port. The
+adapter uses fixed Coordination primitives v1 routes, exact lifecycle-derived
+digests, explicit authentication and an injected fetch-compatible transport.
+It remains disconnected from the gateway. The current implementation candidate
+has synthetic transport conformance evidence; its required ephemeral loopback
+TLS qualification is still pending and no real endpoint profile exists.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -376,8 +376,8 @@ mutation, deployment, public listener, or live apply.
 - Governing issue: #47
 - Accepted architecture: RFC-0005
 - Scope: MCP-native digest translation, closed HTTPS framing, explicit
-  authenticator/transport ports, secret capability wrapper, and synthetic
-  transport conformance
+  authenticator/transport ports, secret capability wrapper, synthetic
+  transport conformance, and verified loopback TLS qualification
 
 The implementation imports no Coordination code or artifact and is not wired
 into the gateway. Exact HTTPS targets, fixed routes, canonical bounded bodies,
@@ -386,9 +386,12 @@ deadline and no retry enforce the accepted boundary. Raw identities and nonce
 values are replaced by domain-separated digests; lease capabilities reject JSON
 and redact string/inspection output.
 
-The synthetic tests do not yet cross a real TLS socket. Ephemeral loopback TLS
-qualification remains required without committing private keys, adding a
-dependency or invoking a subprocess. Until that evidence exists, the adapter
-PR remains draft and no compatibility-complete claim is made. No endpoint,
-credential, gateway wiring, provider execution, mutation, deployment, public
-listener or live apply is authorized.
+The loopback qualification crosses a real TLS socket on `127.0.0.1` with
+certificate verification enabled. Its owner-authorized test-only helper invokes
+OpenSSL with fixed arguments and no shell to generate a one-day certificate and
+private key in a private temporary directory, then removes all fixture material
+in `finally`. No key is committed, no dependency is added, and subprocess use is
+absent from runtime and build output. This evidence does not select or qualify
+production trust, DNS, identity, key custody, or endpoint configuration. No real
+endpoint, credential, gateway wiring, provider execution, mutation, deployment,
+public listener or live apply is authorized.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -370,3 +370,25 @@ outcome. RFC-0005 is explicitly accepted for a separately reviewed MCP-native
 adapter and synthetic loopback qualification only. This review authorizes no
 real endpoint, credential, request, gateway wiring, provider execution,
 mutation, deployment, public listener, or live apply.
+
+## Coordination adapter implementation review — 2026-08-03
+
+- Governing issue: #47
+- Accepted architecture: RFC-0005
+- Scope: MCP-native digest translation, closed HTTPS framing, explicit
+  authenticator/transport ports, secret capability wrapper, and synthetic
+  transport conformance
+
+The implementation imports no Coordination code or artifact and is not wired
+into the gateway. Exact HTTPS targets, fixed routes, canonical bounded bodies,
+streamed response limits, strict media/cache headers, closed outcomes, one
+deadline and no retry enforce the accepted boundary. Raw identities and nonce
+values are replaced by domain-separated digests; lease capabilities reject JSON
+and redact string/inspection output.
+
+The synthetic tests do not yet cross a real TLS socket. Ephemeral loopback TLS
+qualification remains required without committing private keys, adding a
+dependency or invoking a subprocess. Until that evidence exists, the adapter
+PR remains draft and no compatibility-complete claim is made. No endpoint,
+credential, gateway wiring, provider execution, mutation, deployment, public
+listener or live apply is authorized.

--- a/packages/coordination-consumer/src/contract.ts
+++ b/packages/coordination-consumer/src/contract.ts
@@ -1,264 +1,70 @@
-import { z } from "zod";
+export interface CoordinationBinding {
+  readonly binding_version: 1;
+  readonly operation_ref: string;
+  readonly subject_ref: string;
+  readonly capability_ref: string;
+  readonly resource_set_digest: string;
+  readonly environment_ref: string;
+  readonly plan_digest: string;
+  readonly approval_digest: string;
+  readonly epoch: number;
+  readonly expires_at: string;
+}
 
-const boundedRef = z.string().min(1).max(128);
-const digest = z.string().regex(/^sha256:[0-9a-f]{64}$/);
-const instant = z.iso.datetime({ offset: true });
+export interface LeaseCapability {
+  readonly kind: "coordination_lease_capability_v1";
+  toString(): "LeaseCapability{REDACTED}";
+  toJSON(): never;
+}
 
-const bindingSchema = z
-  .object({
-    binding_version: z.literal(1),
-    operation_ref: boundedRef,
-    subject_ref: boundedRef,
-    capability_ref: boundedRef,
-    resource_set_digest: digest,
-    environment_ref: boundedRef,
-    plan_digest: digest,
-    approval_digest: digest,
-  })
-  .strict();
+export interface NonceConsumeRequest {
+  readonly request_version: 1;
+  readonly binding: CoordinationBinding;
+  readonly nonce: string;
+}
+export interface LeaseAcquireRequest {
+  readonly request_version: 1;
+  readonly binding: CoordinationBinding;
+}
+export interface LeaseHandleRequest {
+  readonly request_version: 1;
+  readonly binding: CoordinationBinding;
+  readonly lease_capability: LeaseCapability;
+}
+export interface LeaseRenewRequest extends LeaseHandleRequest {
+  readonly expires_at: string;
+}
 
-export type CoordinationBinding = z.infer<typeof bindingSchema>;
+export type NonceResult = Readonly<{ outcome: "consumed" }>;
+export type LeaseResult = Readonly<{
+  outcome: "acquired" | "renewed";
+  lease_capability: LeaseCapability;
+  fencing_token: number;
+  expires_at: string;
+}>;
+export type InspectResult = Readonly<{ outcome: "valid" }>;
+export type ReleaseResult = Readonly<{ outcome: "released" }>;
 
-const nonceRequestSchema = z
-  .object({
-    request_version: z.literal(1),
-    binding: bindingSchema,
-    nonce: z.string().min(16).max(512),
-  })
-  .strict();
-
-const leaseAcquireRequestSchema = z
-  .object({
-    request_version: z.literal(1),
-    binding: bindingSchema,
-    holder_digest: digest,
-    ttl_ms: z.number().int().min(1_000).max(60_000),
-  })
-  .strict();
-
-const leaseHandleRequestSchema = z
-  .object({
-    request_version: z.literal(1),
-    binding: bindingSchema,
-    lease_handle: z.string().min(16).max(2_048),
-  })
-  .strict();
-
-const leaseRenewRequestSchema = leaseHandleRequestSchema
-  .extend({ ttl_ms: z.number().int().min(1_000).max(60_000) })
-  .strict();
-
-export type NonceConsumeRequest = z.infer<typeof nonceRequestSchema>;
-export type LeaseAcquireRequest = z.infer<typeof leaseAcquireRequestSchema>;
-export type LeaseHandleRequest = z.infer<typeof leaseHandleRequestSchema>;
-export type LeaseRenewRequest = z.infer<typeof leaseRenewRequestSchema>;
-
-const receiptBase = {
-  response_version: z.literal(1),
-  operation_ref: boundedRef,
-  binding_digest: digest,
-  evidence_ref: boundedRef,
-} as const;
-
-const nonceReceiptSchema = z
-  .object({
-    ...receiptBase,
-    outcome: z.literal("consumed"),
-    consumed_at: instant,
-  })
-  .strict();
-
-const leaseReceiptSchema = z
-  .object({
-    ...receiptBase,
-    outcome: z.enum(["acquired", "active", "renewed"]),
-    lease_ref: boundedRef,
-    lease_handle: z.string().min(16).max(2_048),
-    fencing_token: z.string().regex(/^[1-9][0-9]{0,39}$/),
-    expires_at: instant,
-  })
-  .strict();
-
-const releaseReceiptSchema = z
-  .object({
-    ...receiptBase,
-    outcome: z.literal("released"),
-    lease_ref: boundedRef,
-    fencing_token: z.string().regex(/^[1-9][0-9]{0,39}$/),
-    released_at: instant,
-  })
-  .strict();
-
-export type NonceReceipt = z.infer<typeof nonceReceiptSchema>;
-export type LeaseReceipt = z.infer<typeof leaseReceiptSchema>;
-export type ReleaseReceipt = z.infer<typeof releaseReceiptSchema>;
-
-/**
- * An inert MCP-side port. Implementations may be fakes today; no network,
- * authentication, endpoint, or Coordination client is selected here.
- */
-export interface CoordinationConsumerDriver {
-  consumeNonce(request: NonceConsumeRequest): Promise<unknown>;
-  acquireLease(request: LeaseAcquireRequest): Promise<unknown>;
-  inspectLease(request: LeaseHandleRequest): Promise<unknown>;
-  renewLease(request: LeaseRenewRequest): Promise<unknown>;
-  releaseLease(request: LeaseHandleRequest): Promise<unknown>;
+export interface CoordinationConsumer {
+  consumeNonce(request: NonceConsumeRequest): Promise<NonceResult>;
+  acquireLease(request: LeaseAcquireRequest): Promise<LeaseResult>;
+  inspectLease(request: LeaseHandleRequest): Promise<InspectResult>;
+  renewLease(request: LeaseRenewRequest): Promise<LeaseResult>;
+  releaseLease(request: LeaseHandleRequest): Promise<ReleaseResult>;
 }
 
 export type CoordinationConsumerErrorCode =
   | "coordination_request_invalid"
+  | "coordination_denied"
+  | "coordination_conflict"
+  | "coordination_replayed"
+  | "coordination_stale"
   | "coordination_unavailable"
-  | "coordination_response_invalid"
-  | "coordination_binding_mismatch"
-  | "coordination_receipt_stale";
+  | "coordination_response_invalid";
 
 export class CoordinationConsumerError extends Error {
-  readonly code: CoordinationConsumerErrorCode;
-
-  constructor(code: CoordinationConsumerErrorCode) {
+  constructor(readonly code: CoordinationConsumerErrorCode) {
     super(code);
     this.name = "CoordinationConsumerError";
-    this.code = code;
   }
-}
-
-export interface CoordinationConsumer {
-  consumeNonce(request: NonceConsumeRequest): Promise<NonceReceipt>;
-  acquireLease(request: LeaseAcquireRequest): Promise<LeaseReceipt>;
-  inspectLease(request: LeaseHandleRequest): Promise<LeaseReceipt>;
-  renewLease(request: LeaseRenewRequest): Promise<LeaseReceipt>;
-  releaseLease(request: LeaseHandleRequest): Promise<ReleaseReceipt>;
-}
-
-function assertRequest<T>(schema: z.ZodType<T>, request: unknown): T {
-  const parsed = schema.safeParse(request);
-  if (!parsed.success) throw new CoordinationConsumerError("coordination_request_invalid");
-  return parsed.data;
-}
-
-function assertReceipt<T extends { operation_ref: string; binding_digest: string }>(
-  schema: z.ZodType<T>,
-  value: unknown,
-  binding: CoordinationBinding,
-  expectedBindingDigest: string,
-  now: Date,
-): T {
-  const parsed = schema.safeParse(value);
-  if (!parsed.success) throw new CoordinationConsumerError("coordination_response_invalid");
-  if (
-    parsed.data.operation_ref !== binding.operation_ref ||
-    parsed.data.binding_digest !== expectedBindingDigest
-  )
-    throw new CoordinationConsumerError("coordination_binding_mismatch");
-  if ("expires_at" in parsed.data && Date.parse(String(parsed.data.expires_at)) <= now.getTime())
-    throw new CoordinationConsumerError("coordination_receipt_stale");
-  return Object.freeze(parsed.data);
-}
-
-async function callDriver<T>(operation: () => Promise<T>, timeoutMs: number): Promise<T> {
-  let timer: NodeJS.Timeout | undefined;
-  try {
-    return await Promise.race([
-      operation(),
-      new Promise<never>((_resolve, reject) => {
-        timer = setTimeout(
-          () => reject(new CoordinationConsumerError("coordination_unavailable")),
-          timeoutMs,
-        );
-      }),
-    ]);
-  } catch (error) {
-    if (error instanceof CoordinationConsumerError) throw error;
-    throw new CoordinationConsumerError("coordination_unavailable");
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
-}
-
-export function createCoordinationConsumer(options: {
-  readonly driver: CoordinationConsumerDriver;
-  readonly digestBinding: (binding: CoordinationBinding) => string;
-  readonly now?: () => Date;
-  readonly driverTimeoutMs?: number;
-}): CoordinationConsumer {
-  const now = options.now ?? (() => new Date());
-  const driverTimeoutMs = options.driverTimeoutMs ?? 500;
-  if (!Number.isInteger(driverTimeoutMs) || driverTimeoutMs < 1 || driverTimeoutMs > 2_000)
-    throw new TypeError("invalid coordination driver timeout");
-
-  function context(binding: CoordinationBinding) {
-    let bindingDigest: string;
-    try {
-      bindingDigest = options.digestBinding(binding);
-    } catch {
-      throw new CoordinationConsumerError("coordination_request_invalid");
-    }
-    if (!digest.safeParse(bindingDigest).success)
-      throw new CoordinationConsumerError("coordination_request_invalid");
-    const observedAt = now();
-    if (Number.isNaN(observedAt.getTime()))
-      throw new CoordinationConsumerError("coordination_request_invalid");
-    return { bindingDigest, observedAt };
-  }
-
-  const consumer: CoordinationConsumer = {
-    async consumeNonce(request: NonceConsumeRequest) {
-      const valid = assertRequest(nonceRequestSchema, request);
-      const { bindingDigest, observedAt } = context(valid.binding);
-      const raw = await callDriver(() => options.driver.consumeNonce(valid), driverTimeoutMs);
-      return assertReceipt(nonceReceiptSchema, raw, valid.binding, bindingDigest, observedAt);
-    },
-    async acquireLease(request: LeaseAcquireRequest) {
-      const valid = assertRequest(leaseAcquireRequestSchema, request);
-      const { bindingDigest, observedAt } = context(valid.binding);
-      const raw = await callDriver(() => options.driver.acquireLease(valid), driverTimeoutMs);
-      const receipt = assertReceipt(
-        leaseReceiptSchema,
-        raw,
-        valid.binding,
-        bindingDigest,
-        observedAt,
-      );
-      if (receipt.outcome !== "acquired")
-        throw new CoordinationConsumerError("coordination_response_invalid");
-      return receipt;
-    },
-    async inspectLease(request: LeaseHandleRequest) {
-      const valid = assertRequest(leaseHandleRequestSchema, request);
-      const { bindingDigest, observedAt } = context(valid.binding);
-      const raw = await callDriver(() => options.driver.inspectLease(valid), driverTimeoutMs);
-      const receipt = assertReceipt(
-        leaseReceiptSchema,
-        raw,
-        valid.binding,
-        bindingDigest,
-        observedAt,
-      );
-      if (receipt.outcome !== "active")
-        throw new CoordinationConsumerError("coordination_response_invalid");
-      return receipt;
-    },
-    async renewLease(request: LeaseRenewRequest) {
-      const valid = assertRequest(leaseRenewRequestSchema, request);
-      const { bindingDigest, observedAt } = context(valid.binding);
-      const raw = await callDriver(() => options.driver.renewLease(valid), driverTimeoutMs);
-      const receipt = assertReceipt(
-        leaseReceiptSchema,
-        raw,
-        valid.binding,
-        bindingDigest,
-        observedAt,
-      );
-      if (receipt.outcome !== "renewed")
-        throw new CoordinationConsumerError("coordination_response_invalid");
-      return receipt;
-    },
-    async releaseLease(request: LeaseHandleRequest) {
-      const valid = assertRequest(leaseHandleRequestSchema, request);
-      const { bindingDigest, observedAt } = context(valid.binding);
-      const raw = await callDriver(() => options.driver.releaseLease(valid), driverTimeoutMs);
-      return assertReceipt(releaseReceiptSchema, raw, valid.binding, bindingDigest, observedAt);
-    },
-  };
-  return Object.freeze(consumer);
 }

--- a/packages/coordination-consumer/src/https-adapter.ts
+++ b/packages/coordination-consumer/src/https-adapter.ts
@@ -1,0 +1,398 @@
+import { createHash } from "node:crypto";
+import { inspect } from "node:util";
+import { z } from "zod";
+import {
+  CoordinationConsumerError,
+  type CoordinationBinding,
+  type CoordinationConsumer,
+  type LeaseAcquireRequest,
+  type LeaseCapability,
+  type LeaseHandleRequest,
+  type LeaseRenewRequest,
+  type NonceConsumeRequest,
+} from "./contract.js";
+
+export const COORDINATION_MEDIA_TYPE = "application/yukh-coordination-primitives+json;version=1";
+const MAX_BYTES = 4_096;
+const ROUTES = {
+  nonce: "/coordination-primitives/v1/nonces:consume",
+  acquire: "/coordination-primitives/v1/leases:acquire",
+  inspect: "/coordination-primitives/v1/leases:inspect",
+  renew: "/coordination-primitives/v1/leases:renew",
+  release: "/coordination-primitives/v1/leases:release",
+} as const;
+const digest = z.string().regex(/^[0-9a-f]{64}$/);
+const prefixedDigest = z.string().regex(/^sha256:[0-9a-f]{64}$/);
+const expiry = z.string().regex(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+const capabilities = new WeakMap<object, string>();
+
+class SecretLeaseCapability implements LeaseCapability {
+  readonly kind = "coordination_lease_capability_v1" as const;
+  constructor(value: string) {
+    capabilities.set(this, value);
+    Object.freeze(this);
+  }
+  toString() {
+    return "LeaseCapability{REDACTED}" as const;
+  }
+  toJSON(): never {
+    throw new TypeError("lease capability is not serializable");
+  }
+  [inspect.custom]() {
+    return this.toString();
+  }
+}
+
+export interface RequestAuthentication {
+  readonly credential: string;
+  readonly proof: string;
+}
+export type RequestAuthenticator = (request: {
+  readonly method: "POST";
+  readonly target: string;
+  readonly body_digest: string;
+  readonly deadline_ms: number;
+}) => Promise<RequestAuthentication>;
+export type CoordinationTransport = (target: string, init: RequestInit) => Promise<Response>;
+
+function fail(code: ConstructorParameters<typeof CoordinationConsumerError>[0]): never {
+  throw new CoordinationConsumerError(code);
+}
+function sha(domain: string, value: string) {
+  return createHash("sha256").update(domain).update("\0").update(value).digest("hex");
+}
+function canonical(value: Record<string, unknown>) {
+  return JSON.stringify(
+    Object.fromEntries(Object.entries(value).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))),
+  );
+}
+function validateBinding(value: CoordinationBinding) {
+  const schema = z
+    .object({
+      binding_version: z.literal(1),
+      operation_ref: z.string().min(1).max(128),
+      subject_ref: z.string().min(1).max(128),
+      capability_ref: z.string().min(1).max(128),
+      resource_set_digest: prefixedDigest,
+      environment_ref: z.string().min(1).max(128),
+      plan_digest: prefixedDigest,
+      approval_digest: prefixedDigest,
+      epoch: z.number().int().min(1).max(Number.MAX_SAFE_INTEGER),
+      expires_at: expiry,
+    })
+    .strict();
+  const parsed = schema.safeParse(value);
+  if (!parsed.success || Date.parse(parsed.data.expires_at) <= Date.now())
+    fail("coordination_request_invalid");
+  return parsed.data;
+}
+function scopeDigest(binding: CoordinationBinding) {
+  return sha(
+    "yukh-mcp:coordination-scope:v1",
+    canonical(binding as unknown as Record<string, unknown>),
+  );
+}
+function holderDigest(binding: CoordinationBinding, scope: string) {
+  return sha(
+    "yukh-mcp:coordination-holder:v1",
+    canonical({
+      approval_digest: binding.approval_digest,
+      operation_ref: binding.operation_ref,
+      plan_digest: binding.plan_digest,
+      scope_digest: scope,
+      subject_ref: binding.subject_ref,
+    }),
+  );
+}
+function reveal(value: LeaseCapability) {
+  const raw = capabilities.get(value as object);
+  if (!raw) fail("coordination_request_invalid");
+  return raw;
+}
+
+function withAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted)
+    return Promise.reject(new CoordinationConsumerError("coordination_unavailable"));
+  return new Promise<T>((resolve, reject) => {
+    const aborted = () => reject(new CoordinationConsumerError("coordination_unavailable"));
+    signal.addEventListener("abort", aborted, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", aborted);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", aborted);
+        reject(error);
+      },
+    );
+  });
+}
+
+async function boundedBody(response: Response) {
+  if (response.headers.get("content-type") !== COORDINATION_MEDIA_TYPE)
+    fail("coordination_response_invalid");
+  if (response.headers.get("cache-control") !== "no-store") fail("coordination_response_invalid");
+  const reader = response.body?.getReader();
+  if (!reader) fail("coordination_response_invalid");
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+  while (true) {
+    const part = await reader.read();
+    if (part.done) break;
+    length += part.value.byteLength;
+    if (length > MAX_BYTES) {
+      await reader.cancel();
+      fail("coordination_response_invalid");
+    }
+    chunks.push(part.value);
+  }
+  const bytes = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    fail("coordination_response_invalid");
+  }
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    Array.isArray(parsed) ||
+    canonical(parsed as Record<string, unknown>) !== text
+  )
+    fail("coordination_response_invalid");
+  return parsed;
+}
+
+const problems = new Map([
+  ["unauthenticated", 401],
+  ["access_denied", 403],
+  ["conflict", 409],
+  ["replayed", 409],
+  ["stale_fence", 409],
+  ["temporarily_unavailable", 503],
+  ["invariant_violation", 500],
+  ["invalid_request", 400],
+]);
+
+function problem(value: unknown, status: number): never {
+  const parsed = z
+    .object({ code: z.string(), status: z.number(), title: z.string(), type: z.string() })
+    .strict()
+    .safeParse(value);
+  if (
+    !parsed.success ||
+    problems.get(parsed.data.code) !== status ||
+    parsed.data.status !== status ||
+    parsed.data.title !== parsed.data.code ||
+    parsed.data.type !== `urn:yukh:coordination-primitives:problem:${parsed.data.code}`
+  )
+    fail("coordination_response_invalid");
+  if (parsed.data.code === "conflict") fail("coordination_conflict");
+  if (parsed.data.code === "replayed") fail("coordination_replayed");
+  if (parsed.data.code === "stale_fence") fail("coordination_stale");
+  if (parsed.data.code === "unauthenticated" || parsed.data.code === "access_denied")
+    fail("coordination_denied");
+  fail("coordination_unavailable");
+}
+
+export function createHttpsCoordinationConsumer(options: {
+  readonly baseUri: string;
+  readonly deadlineMs: number;
+  readonly authenticate: RequestAuthenticator;
+  readonly transport: CoordinationTransport;
+}): CoordinationConsumer {
+  let base: URL;
+  try {
+    base = new URL(options.baseUri);
+  } catch {
+    throw new TypeError("invalid coordination base URI");
+  }
+  if (
+    base.protocol !== "https:" ||
+    base.username ||
+    base.password ||
+    base.search ||
+    base.hash ||
+    base.pathname !== "/" ||
+    options.deadlineMs < 1 ||
+    options.deadlineMs > 2_000
+  )
+    throw new TypeError("invalid coordination adapter configuration");
+
+  async function call(
+    route: string,
+    body: Record<string, unknown>,
+    outcomes: readonly string[],
+    lease: boolean,
+  ) {
+    const text = canonical(body);
+    if (Buffer.byteLength(text) > MAX_BYTES) fail("coordination_request_invalid");
+    const target = new URL(route, base).href;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), options.deadlineMs);
+    try {
+      const authentication = await withAbort(
+        options.authenticate({
+          method: "POST",
+          target,
+          body_digest: sha("yukh-mcp:coordination-body:v1", text),
+          deadline_ms: options.deadlineMs,
+        }),
+        controller.signal,
+      );
+      if (
+        !z
+          .object({ credential: z.string().min(1).max(2048), proof: z.string().min(1).max(2048) })
+          .strict()
+          .safeParse(authentication).success
+      )
+        fail("coordination_request_invalid");
+      const response = await withAbort(
+        options.transport(target, {
+          method: "POST",
+          redirect: "manual",
+          signal: controller.signal,
+          headers: {
+            accept: COORDINATION_MEDIA_TYPE,
+            authorization: authentication.credential,
+            "content-type": COORDINATION_MEDIA_TYPE,
+            dpop: authentication.proof,
+          },
+          body: text,
+        }),
+        controller.signal,
+      );
+      if (response.redirected || response.type === "opaqueredirect")
+        fail("coordination_response_invalid");
+      const value = await withAbort(boundedBody(response), controller.signal);
+      if (!response.ok) problem(value, response.status);
+      if (lease) {
+        const parsed = z
+          .object({
+            specversion: z.literal("1"),
+            outcome: z.enum(["acquired", "renewed"]),
+            lease_capability: z.string().min(1).max(3800),
+            fencing_token: z.number().int().min(1).max(Number.MAX_SAFE_INTEGER),
+            expires_at: expiry,
+          })
+          .strict()
+          .safeParse(value);
+        if (!parsed.success || !outcomes.includes(parsed.data.outcome))
+          fail("coordination_response_invalid");
+        return Object.freeze({
+          ...parsed.data,
+          lease_capability: new SecretLeaseCapability(parsed.data.lease_capability),
+        });
+      }
+      const parsed = z
+        .object({ specversion: z.literal("1"), outcome: z.string() })
+        .strict()
+        .safeParse(value);
+      if (!parsed.success || !outcomes.includes(parsed.data.outcome))
+        fail(
+          parsed.success && ["replayed"].includes(parsed.data.outcome)
+            ? "coordination_replayed"
+            : parsed.success && ["expired", "released", "stale"].includes(parsed.data.outcome)
+              ? "coordination_stale"
+              : "coordination_response_invalid",
+        );
+      return Object.freeze({ outcome: parsed.data.outcome });
+    } catch (error) {
+      if (error instanceof CoordinationConsumerError) throw error;
+      fail("coordination_unavailable");
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  const consumer: CoordinationConsumer = {
+    consumeNonce: async (request: NonceConsumeRequest) => {
+      const binding = validateBinding(request.binding);
+      if (
+        request.request_version !== 1 ||
+        typeof request.nonce !== "string" ||
+        request.nonce.length < 16 ||
+        request.nonce.length > 512
+      )
+        fail("coordination_request_invalid");
+      const scope = scopeDigest(binding);
+      return (await call(
+        ROUTES.nonce,
+        {
+          epoch: binding.epoch,
+          expires_at: binding.expires_at,
+          scope_digest: scope,
+          value_digest: sha("yukh-mcp:coordination-nonce:v1", request.nonce),
+        },
+        ["consumed"],
+        false,
+      )) as { outcome: "consumed" };
+    },
+    acquireLease: async (request: LeaseAcquireRequest) => {
+      const binding = validateBinding(request.binding);
+      if (request.request_version !== 1) fail("coordination_request_invalid");
+      const scope = scopeDigest(binding);
+      const result = (await call(
+        ROUTES.acquire,
+        {
+          epoch: binding.epoch,
+          expires_at: binding.expires_at,
+          holder_digest: holderDigest(binding, scope),
+          scope_digest: scope,
+        },
+        ["acquired"],
+        true,
+      )) as unknown as { expires_at: string };
+      if (Date.parse(result.expires_at) > Date.parse(binding.expires_at))
+        fail("coordination_response_invalid");
+      return result as never;
+    },
+    inspectLease: async (request: LeaseHandleRequest) => {
+      validateBinding(request.binding);
+      if (request.request_version !== 1) fail("coordination_request_invalid");
+      return (await call(
+        ROUTES.inspect,
+        { lease_capability: reveal(request.lease_capability) },
+        ["valid"],
+        false,
+      )) as { outcome: "valid" };
+    },
+    renewLease: async (request: LeaseRenewRequest) => {
+      const binding = validateBinding(request.binding);
+      if (
+        request.request_version !== 1 ||
+        !expiry.safeParse(request.expires_at).success ||
+        Date.parse(request.expires_at) <= Date.now() ||
+        Date.parse(request.expires_at) > Date.parse(binding.expires_at)
+      )
+        fail("coordination_request_invalid");
+      const result = (await call(
+        ROUTES.renew,
+        { expires_at: request.expires_at, lease_capability: reveal(request.lease_capability) },
+        ["renewed"],
+        true,
+      )) as unknown as { expires_at: string };
+      if (Date.parse(result.expires_at) > Date.parse(request.expires_at))
+        fail("coordination_response_invalid");
+      return result as never;
+    },
+    releaseLease: async (request: LeaseHandleRequest) => {
+      validateBinding(request.binding);
+      if (request.request_version !== 1) fail("coordination_request_invalid");
+      return (await call(
+        ROUTES.release,
+        { lease_capability: reveal(request.lease_capability) },
+        ["released"],
+        false,
+      )) as { outcome: "released" };
+    },
+  };
+  return Object.freeze(consumer);
+}

--- a/test/runtime/coordination-consumer-contract.test.ts
+++ b/test/runtime/coordination-consumer-contract.test.ts
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  COORDINATION_MEDIA_TYPE,
+  createHttpsCoordinationConsumer,
+  type CoordinationTransport,
+} from "../../packages/coordination-consumer/src/https-adapter.js";
+import {
   CoordinationConsumerError,
-  createCoordinationConsumer,
   type CoordinationBinding,
-  type CoordinationConsumerDriver,
 } from "../../packages/coordination-consumer/src/contract.js";
 
 const binding: CoordinationBinding = {
@@ -16,181 +19,160 @@ const binding: CoordinationBinding = {
   environment_ref: "staging",
   plan_digest: `sha256:${"2".repeat(64)}`,
   approval_digest: `sha256:${"3".repeat(64)}`,
+  epoch: 7,
+  expires_at: "2099-08-03T15:00:30.000Z",
 };
 
-const bindingDigest = `sha256:${"4".repeat(64)}`;
-const now = new Date("2026-08-03T15:00:00.000Z");
-
-function driver(overrides: Partial<CoordinationConsumerDriver> = {}): CoordinationConsumerDriver {
-  const lease = (outcome: "acquired" | "active" | "renewed") => ({
-    response_version: 1,
-    operation_ref: binding.operation_ref,
-    binding_digest: bindingDigest,
-    evidence_ref: "evidence-lease-1",
-    outcome,
-    lease_ref: "lease-1",
-    lease_handle: "sealed-lease-handle",
-    fencing_token: "7",
-    expires_at: "2026-08-03T15:00:30.000Z",
-  });
-  return {
-    consumeNonce: async () => ({
-      response_version: 1,
-      operation_ref: binding.operation_ref,
-      binding_digest: bindingDigest,
-      evidence_ref: "evidence-nonce-1",
-      outcome: "consumed",
-      consumed_at: now.toISOString(),
-    }),
-    acquireLease: async () => lease("acquired"),
-    inspectLease: async () => lease("active"),
-    renewLease: async () => lease("renewed"),
-    releaseLease: async () => ({
-      response_version: 1,
-      operation_ref: binding.operation_ref,
-      binding_digest: bindingDigest,
-      evidence_ref: "evidence-release-1",
-      outcome: "released",
-      lease_ref: "lease-1",
-      fencing_token: "7",
-      released_at: now.toISOString(),
-    }),
-    ...overrides,
-  };
-}
-
-function consumer(overrides: Partial<CoordinationConsumerDriver> = {}) {
-  return createCoordinationConsumer({
-    driver: driver(overrides),
-    digestBinding: () => bindingDigest,
-    now: () => now,
-  });
-}
-
-test("network-free fake satisfies the five closed consumer operations", async () => {
-  const port = consumer();
-  const nonce = await port.consumeNonce({
-    request_version: 1,
-    binding,
-    nonce: "one-time-nonce-value",
-  });
-  assert.equal(nonce.outcome, "consumed");
-
-  const acquired = await port.acquireLease({
-    request_version: 1,
-    binding,
-    holder_digest: `sha256:${"5".repeat(64)}`,
-    ttl_ms: 30_000,
-  });
-  assert.equal(acquired.fencing_token, "7");
-
-  const handleRequest = {
-    request_version: 1 as const,
-    binding,
-    lease_handle: acquired.lease_handle,
-  };
-  assert.equal((await port.inspectLease(handleRequest)).outcome, "active");
-  assert.equal((await port.renewLease({ ...handleRequest, ttl_ms: 30_000 })).outcome, "renewed");
-  assert.equal((await port.releaseLease(handleRequest)).outcome, "released");
-});
-
-test("malformed requests fail before the driver", async () => {
-  let calls = 0;
-  const port = consumer({
-    consumeNonce: async () => {
-      calls += 1;
-      return {};
+function response(value: object, status = 200, headers: Record<string, string> = {}) {
+  const body = JSON.stringify(
+    Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b))),
+  );
+  return new Response(body, {
+    status,
+    headers: {
+      "cache-control": "no-store",
+      "content-type": COORDINATION_MEDIA_TYPE,
+      ...headers,
     },
   });
-  await assert.rejects(
-    port.consumeNonce({ request_version: 1, binding, nonce: "short" }),
-    (error: unknown) =>
-      error instanceof CoordinationConsumerError && error.code === "coordination_request_invalid",
-  );
-  assert.equal(calls, 0);
+}
+
+function adapter(transport: CoordinationTransport) {
+  return createHttpsCoordinationConsumer({
+    baseUri: "https://127.0.0.1/",
+    deadlineMs: 100,
+    authenticate: async ({ target, body_digest }) => {
+      assert.match(target, /^https:\/\/127\.0\.0\.1\/coordination-primitives\/v1\//);
+      assert.match(body_digest, /^[0-9a-f]{64}$/);
+      return { credential: "synthetic-credential", proof: "synthetic-proof" };
+    },
+    transport,
+  });
+}
+
+test("maps MCP bindings to one closed acquire request without raw identities", async () => {
+  let calls = 0;
+  const consumer = adapter(async (target, init) => {
+    calls += 1;
+    assert.equal(target, "https://127.0.0.1/coordination-primitives/v1/leases:acquire");
+    assert.equal(init.redirect, "manual");
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+    assert.deepEqual(Object.keys(body), ["epoch", "expires_at", "holder_digest", "scope_digest"]);
+    assert.equal(body.epoch, 7);
+    assert.match(String(body.scope_digest), /^[0-9a-f]{64}$/);
+    assert.match(String(body.holder_digest), /^[0-9a-f]{64}$/);
+    assert.equal(String(init.body).includes("subject-1"), false);
+    return response({
+      expires_at: binding.expires_at,
+      fencing_token: 9,
+      lease_capability: "opaque-synthetic-capability",
+      outcome: "acquired",
+      specversion: "1",
+    });
+  });
+  const acquired = await consumer.acquireLease({ request_version: 1, binding });
+  assert.equal(acquired.outcome, "acquired");
+  assert.equal(acquired.fencing_token, 9);
+  assert.equal(String(acquired.lease_capability), "LeaseCapability{REDACTED}");
+  assert.throws(() => JSON.stringify(acquired.lease_capability));
+  assert.equal(calls, 1);
 });
 
-test("unknown fields and operation outcomes fail closed", async () => {
-  const port = consumer({
-    acquireLease: async () => ({
-      response_version: 1,
-      operation_ref: binding.operation_ref,
-      binding_digest: bindingDigest,
-      evidence_ref: "evidence-1",
-      outcome: "acquired",
-      lease_ref: "lease-1",
-      lease_handle: "sealed-lease-handle",
-      fencing_token: "7",
-      expires_at: "2026-08-03T15:00:30.000Z",
-      provider_debug: "must not cross boundary",
-    }),
+test("uses the opaque capability only in fixed inspect renew and release bodies", async () => {
+  const observed: string[] = [];
+  const consumer = adapter(async (target, init) => {
+    observed.push(target);
+    if (target.endsWith("leases:acquire"))
+      return response({
+        expires_at: binding.expires_at,
+        fencing_token: 1,
+        lease_capability: "opaque-synthetic-capability",
+        outcome: "acquired",
+        specversion: "1",
+      });
+    if (target.endsWith("leases:inspect")) return response({ outcome: "valid", specversion: "1" });
+    if (target.endsWith("leases:renew"))
+      return response({
+        expires_at: binding.expires_at,
+        fencing_token: 2,
+        lease_capability: "replacement-capability",
+        outcome: "renewed",
+        specversion: "1",
+      });
+    assert.equal(JSON.parse(String(init.body)).lease_capability, "replacement-capability");
+    return response({ outcome: "released", specversion: "1" });
   });
+  const acquired = await consumer.acquireLease({ request_version: 1, binding });
+  assert.equal(
+    (
+      await consumer.inspectLease({
+        request_version: 1,
+        binding,
+        lease_capability: acquired.lease_capability,
+      })
+    ).outcome,
+    "valid",
+  );
+  const renewed = await consumer.renewLease({
+    request_version: 1,
+    binding,
+    lease_capability: acquired.lease_capability,
+    expires_at: binding.expires_at,
+  });
+  assert.equal(
+    (
+      await consumer.releaseLease({
+        request_version: 1,
+        binding,
+        lease_capability: renewed.lease_capability,
+      })
+    ).outcome,
+    "released",
+  );
+  assert.equal(observed.length, 4);
+});
+
+test("maps normative conflict and replay to closed fail-closed codes", async () => {
+  const conflict = adapter(async () =>
+    response(
+      {
+        code: "conflict",
+        status: 409,
+        title: "conflict",
+        type: "urn:yukh:coordination-primitives:problem:conflict",
+      },
+      409,
+    ),
+  );
   await assert.rejects(
-    port.acquireLease({
-      request_version: 1,
-      binding,
-      holder_digest: `sha256:${"5".repeat(64)}`,
-      ttl_ms: 30_000,
-    }),
+    conflict.acquireLease({ request_version: 1, binding }),
+    (error: unknown) =>
+      error instanceof CoordinationConsumerError && error.code === "coordination_conflict",
+  );
+
+  const replay = adapter(async () => response({ outcome: "replayed", specversion: "1" }));
+  await assert.rejects(
+    replay.consumeNonce({ request_version: 1, binding, nonce: "synthetic-one-shot-nonce" }),
+    (error: unknown) =>
+      error instanceof CoordinationConsumerError && error.code === "coordination_replayed",
+  );
+});
+
+test("rejects malformed framing, redirects, unknown fields, and dependency detail", async () => {
+  const malformed = adapter(async () =>
+    response({ outcome: "consumed", provider_secret: "hidden", specversion: "1" }),
+  );
+  await assert.rejects(
+    malformed.consumeNonce({ request_version: 1, binding, nonce: "synthetic-one-shot-nonce" }),
     (error: unknown) =>
       error instanceof CoordinationConsumerError && error.code === "coordination_response_invalid",
   );
-});
 
-test("cross-operation substitution and stale leases fail closed", async () => {
-  const mismatched = consumer({
-    inspectLease: async () => ({
-      ...((await driver().inspectLease({
-        request_version: 1,
-        binding,
-        lease_handle: "sealed-lease-handle",
-      })) as object),
-      operation_ref: "another-operation",
-    }),
+  const unavailable = adapter(async () => {
+    throw new Error("sensitive upstream detail");
   });
   await assert.rejects(
-    mismatched.inspectLease({
-      request_version: 1,
-      binding,
-      lease_handle: "sealed-lease-handle",
-    }),
-    (error: unknown) =>
-      error instanceof CoordinationConsumerError && error.code === "coordination_binding_mismatch",
-  );
-
-  const stale = consumer({
-    inspectLease: async () => ({
-      ...((await driver().inspectLease({
-        request_version: 1,
-        binding,
-        lease_handle: "sealed-lease-handle",
-      })) as object),
-      expires_at: now.toISOString(),
-    }),
-  });
-  await assert.rejects(
-    stale.inspectLease({
-      request_version: 1,
-      binding,
-      lease_handle: "sealed-lease-handle",
-    }),
-    (error: unknown) =>
-      error instanceof CoordinationConsumerError && error.code === "coordination_receipt_stale",
-  );
-});
-
-test("dependency errors are normalized without leaking their message", async () => {
-  const port = consumer({
-    consumeNonce: async () => {
-      throw new Error("sensitive upstream detail");
-    },
-  });
-  await assert.rejects(
-    port.consumeNonce({
-      request_version: 1,
-      binding,
-      nonce: "one-time-nonce-value",
-    }),
+    unavailable.acquireLease({ request_version: 1, binding }),
     (error: unknown) =>
       error instanceof CoordinationConsumerError &&
       error.code === "coordination_unavailable" &&
@@ -198,27 +180,46 @@ test("dependency errors are normalized without leaking their message", async () 
   );
 });
 
-test("an unresponsive dependency times out without retry", async () => {
-  let calls = 0;
-  const port = createCoordinationConsumer({
-    driver: driver({
-      consumeNonce: async () => {
-        calls += 1;
-        return await new Promise(() => undefined);
-      },
+test("configuration and stale bindings fail before transport", async () => {
+  assert.throws(() =>
+    createHttpsCoordinationConsumer({
+      baseUri: "http://127.0.0.1/",
+      deadlineMs: 10,
+      authenticate: async () => ({ credential: "x", proof: "y" }),
+      transport: async () => response({}),
     }),
-    digestBinding: () => bindingDigest,
-    now: () => now,
-    driverTimeoutMs: 5,
+  );
+  let calls = 0;
+  const consumer = adapter(async () => {
+    calls += 1;
+    return response({});
   });
   await assert.rejects(
-    port.consumeNonce({
+    consumer.acquireLease({
       request_version: 1,
-      binding,
-      nonce: "one-time-nonce-value",
+      binding: { ...binding, expires_at: "2020-01-01T00:00:00.000Z" },
     }),
+    (error: unknown) =>
+      error instanceof CoordinationConsumerError && error.code === "coordination_request_invalid",
+  );
+  assert.equal(calls, 0);
+});
+
+test("deadline covers authentication and performs no transport retry", async () => {
+  let transports = 0;
+  const consumer = createHttpsCoordinationConsumer({
+    baseUri: "https://127.0.0.1/",
+    deadlineMs: 5,
+    authenticate: async () => await new Promise(() => undefined),
+    transport: async () => {
+      transports += 1;
+      return response({});
+    },
+  });
+  await assert.rejects(
+    consumer.acquireLease({ request_version: 1, binding }),
     (error: unknown) =>
       error instanceof CoordinationConsumerError && error.code === "coordination_unavailable",
   );
-  assert.equal(calls, 1);
+  assert.equal(transports, 0);
 });

--- a/test/runtime/coordination-consumer-contract.test.ts
+++ b/test/runtime/coordination-consumer-contract.test.ts
@@ -1,4 +1,9 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createServer, request as httpsRequest } from "node:https";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import {
   COORDINATION_MEDIA_TYPE,
@@ -49,6 +54,132 @@ function adapter(transport: CoordinationTransport) {
     transport,
   });
 }
+
+function loopbackTransport(certificate: Buffer): CoordinationTransport {
+  return async (target, init) =>
+    await new Promise<Response>((resolve, reject) => {
+      const headers = Object.fromEntries(new Headers(init.headers).entries());
+      const request = httpsRequest(
+        target,
+        {
+          method: init.method,
+          headers,
+          ca: certificate,
+          rejectUnauthorized: true,
+          signal: init.signal ?? undefined,
+        },
+        (response) => {
+          const chunks: Buffer[] = [];
+          response.on("data", (chunk: Buffer) => chunks.push(chunk));
+          response.on("end", () => {
+            resolve(
+              new Response(Buffer.concat(chunks), {
+                status: response.statusCode ?? 500,
+                headers: response.headers as Record<string, string>,
+              }),
+            );
+          });
+        },
+      );
+      request.on("error", reject);
+      request.end(init.body as string);
+    });
+}
+
+test("qualifies one exact request across a verified synthetic loopback TLS socket", async () => {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), "yukh-mcp-coordination-tls-"));
+  chmodSync(fixtureRoot, 0o700);
+  const keyPath = join(fixtureRoot, "key.pem");
+  const certificatePath = join(fixtureRoot, "certificate.pem");
+  try {
+    execFileSync(
+      "openssl",
+      [
+        "req",
+        "-x509",
+        "-newkey",
+        "rsa:2048",
+        "-nodes",
+        "-keyout",
+        keyPath,
+        "-out",
+        certificatePath,
+        "-days",
+        "1",
+        "-subj",
+        "/CN=127.0.0.1",
+        "-addext",
+        "subjectAltName=IP:127.0.0.1",
+      ],
+      { stdio: "ignore" },
+    );
+    chmodSync(keyPath, 0o600);
+    const certificate = readFileSync(certificatePath);
+    const server = createServer(
+      { key: readFileSync(keyPath), cert: certificate },
+      (request, response) => {
+        const chunks: Buffer[] = [];
+        request.on("data", (chunk: Buffer) => chunks.push(chunk));
+        request.on("end", () => {
+          assert.equal(request.method, "POST");
+          assert.equal(request.url, "/coordination-primitives/v1/leases:acquire");
+          assert.equal(request.headers.accept, COORDINATION_MEDIA_TYPE);
+          assert.equal(request.headers["content-type"], COORDINATION_MEDIA_TYPE);
+          assert.equal(request.headers.authorization, "synthetic-credential");
+          assert.equal(request.headers.dpop, "synthetic-proof");
+          const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<
+            string,
+            unknown
+          >;
+          assert.deepEqual(Object.keys(body), [
+            "epoch",
+            "expires_at",
+            "holder_digest",
+            "scope_digest",
+          ]);
+          const payload = JSON.stringify({
+            expires_at: binding.expires_at,
+            fencing_token: 11,
+            lease_capability: "opaque-loopback-capability",
+            outcome: "acquired",
+            specversion: "1",
+          });
+          response.writeHead(200, {
+            "cache-control": "no-store",
+            "content-type": COORDINATION_MEDIA_TYPE,
+          });
+          response.end(payload);
+        });
+      },
+    );
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    try {
+      const address = server.address();
+      assert(address && typeof address === "object");
+      const consumer = createHttpsCoordinationConsumer({
+        baseUri: `https://127.0.0.1:${address.port}/`,
+        deadlineMs: 1_000,
+        authenticate: async () => ({
+          credential: "synthetic-credential",
+          proof: "synthetic-proof",
+        }),
+        transport: loopbackTransport(certificate),
+      });
+      const acquired = await consumer.acquireLease({ request_version: 1, binding });
+      assert.equal(acquired.outcome, "acquired");
+      assert.equal(acquired.fencing_token, 11);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
 
 test("maps MCP bindings to one closed acquire request without raw identities", async () => {
   let calls = 0;


### PR DESCRIPTION
## Implemented

- revises the experimental MCP consumer port for trusted epoch/exact expiry and removes fabricated evidence references
- adds an independent MCP-native adapter for Coordination primitives v1 using Node platform APIs only
- derives domain-separated scope, nonce, and holder digests from exact MCP lifecycle bindings
- uses five fixed HTTPS routes, explicit authentication and injected transport
- validates canonical bounded streamed responses, media/cache headers, route outcomes and Problem Details
- enforces one deadline across authentication/transport/response and performs no retry
- wraps lease capabilities as redacted non-serializable runtime material
- qualifies an exact request across a verified TLS socket on synthetic loopback
- keeps the gateway completely disconnected

## TLS qualification

The test-only fixture invokes OpenSSL with fixed arguments and no shell. It creates a one-day certificate and private key in a mode-`0700` temporary directory, restricts the key to mode `0600`, trusts the certificate only in the injected test transport, leaves certificate verification enabled, and removes all fixture material in `finally`.

No key is committed, no dependency is added, and subprocess use is absent from the runtime and build output.

## Validation

- `npm run format:check`
- `npm run typecheck`
- `npm test` (50 contract/supply-chain and 24 runtime tests)
- `npm run build`
- `git diff --check`
- build-output scan confirms no `node:child_process`, `execFileSync`, or `openssl`

No Coordination component, real endpoint, credential, gateway wiring, provider execution, mutation, deployment, public listener, or live apply is included.

Refs #47
