### PR TITLE
Propose private Coordination connection profile

### DIFF
--- a/.context/rfcs/RFC-0006-private-staging-coordination-connection.md
+++ b/.context/rfcs/RFC-0006-private-staging-coordination-connection.md
@@ -1,10 +1,19 @@
 # RFC-0006 — Private staging Coordination connection
 
-- Status: Draft
+- Status: Accepted
 - Authors: Codex
 - Created: 2026-08-03
+- Accepted: 2026-08-03
+- Decider: project owner
 - Governing issue: https://github.com/nomed/yukh-mcp/issues/50
-- Depends on: RFC-0002, RFC-0003, RFC-0004, RFC-0005 and proposed `nomed/yukh-coordination` RFC-0022
+- Depends on: RFC-0002, RFC-0003, RFC-0004, RFC-0005 and accepted `nomed/yukh-coordination` RFC-0022
+
+The project owner explicitly accepted this RFC on 2026-08-03 together with
+upstream Coordination RFC-0022. Acceptance authorizes implementation and
+hermetic interoperability qualification only. Endpoint configuration,
+provisioning, credential minting, live requests, gateway wiring, provider
+execution, mutation, deployment and production use retain their explicit later
+gates.
 
 ## Summary
 
@@ -34,7 +43,7 @@ credential, proof signing, clock, secret custody, startup and operational
 failure boundaries that must be frozen before source can obtain remote
 authority.
 
-The paired Coordination proposal under issue #90 defines the server side. This
+The paired accepted Coordination RFC-0022 under issue #90 defines the server side. This
 RFC defines only the MCP consumer side and cannot become implementable until
 the upstream record is accepted.
 

--- a/.context/rfcs/RFC-0006-private-staging-coordination-connection.md
+++ b/.context/rfcs/RFC-0006-private-staging-coordination-connection.md
@@ -1,0 +1,303 @@
+# RFC-0006 — Private staging Coordination connection
+
+- Status: Draft
+- Authors: Codex
+- Created: 2026-08-03
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/50
+- Depends on: RFC-0002, RFC-0003, RFC-0004, RFC-0005 and proposed `nomed/yukh-coordination` RFC-0022
+
+## Summary
+
+Define the first real Yukh MCP connection to Coordination as a disabled-by-
+default staging profile consuming
+`yukh-coordination/private-primitives-staging-v1`. The profile adds an
+MCP-native direct TLS transport, explicit private trust, descriptor-delivered
+short-lived credential and P-256 signing key, and an RFC 9449 DPoP
+authenticator behind the already accepted adapter ports.
+
+The connection is exercised only by a separate qualification runner using
+synthetic lifecycle bindings. It is not wired into the MCP gateway, capability
+provider or mutation lifecycle.
+
+Acceptance authorizes implementation and hermetic interoperability
+qualification only after the upstream RFC is accepted. It does not authorize
+an endpoint value, trust root, credential, provisioning, live request, gateway
+wiring, provider execution, mutation, deployment or production use.
+
+## Motivation
+
+RFC-0005 and merge `cb3e8f808a47c7c226ec414b2f1ed39351b4189e`
+provide an independent, synthetically TLS-qualified consumer adapter. They
+deliberately contain no real transport or authentication implementation. A
+real connection adds concrete server identity, private trust, workload
+credential, proof signing, clock, secret custody, startup and operational
+failure boundaries that must be frozen before source can obtain remote
+authority.
+
+The paired Coordination proposal under issue #90 defines the server side. This
+RFC defines only the MCP consumer side and cannot become implementable until
+the upstream record is accepted.
+
+## Goals
+
+- connect only to one exact qualified private staging HTTPS origin;
+- use a dedicated Node HTTPS transport with an explicit trust bundle and no
+  ambient proxy or system-root fallback;
+- authenticate every request with one short-lived opaque token and a fresh
+  ES256 DPoP proof from an ephemeral key;
+- receive secret inputs only through explicit inherited file descriptors;
+- preserve fixed routes, canonical bodies, one deadline and no retry from
+  RFC-0005;
+- keep errors, logs, audit projections and process inspection free of secret
+  material by construction;
+- qualify one real nonce and lease lifecycle with synthetic bindings and no
+  provider path;
+- make disablement immediate and the default configuration inert.
+
+## Non-goals
+
+- importing any Coordination source, client, schema, package or deployment
+  component;
+- provisioning Coordination, JetStream, TLS, policy, audit or credentials;
+- OAuth discovery, token exchange, refresh, cloud metadata, environment
+  credentials, generic key stores or command execution;
+- wiring the consumer into MCP request handling, policy, plan, approval,
+  provider, verification or audit execution;
+- public or production deployment, live apply or protected target mutation;
+- retries, polling, discovery, proxy use, redirects, fallback trust or
+  credential switching.
+
+## Detailed design
+
+### Profile boundary
+
+The profile identifier is `yukh-mcp/private-coordination-staging-v1`. It is
+constructed only by a dedicated qualification entry point. The ordinary
+gateway and demo retain their current behavior and cannot discover or activate
+the profile through MCP input, environment variables or default configuration.
+
+Construction requires one closed value containing:
+
+- the exact profile/version;
+- one exact HTTPS origin with no path, user information, query or fragment;
+- an absolute explicit private trust-bundle path and expected server name;
+- token and DPoP-key inherited descriptor numbers;
+- a trusted registration expiry and expected DPoP thumbprint;
+- one deadline from 1 to 2,000 milliseconds;
+- a positive restore epoch matching the approved deployment plan;
+- the exact synthetic environment reference permitted for qualification.
+
+There are no defaults. Unknown fields, duplicate keys, relative paths,
+symlinks, unsafe file permissions, wildcard names, system roots, environment
+overrides and caller-selected suffixes fail construction before secret reads or
+network access. Endpoint and trust values are deployment inputs and never enter
+public examples, logs, errors or durable context.
+
+### Secret acquisition and lifecycle
+
+The accountable supervisor delivers the uniformly random 256-bit opaque token
+and ephemeral P-256 PKCS#8 private key through two distinct already-open file
+descriptors. Each is read exactly once under an independent byte and time
+bound, then closed. The token and source key bytes are copied into redacted
+runtime wrappers; source buffers are zeroed immediately.
+
+The private key is parsed into a non-exported Node `KeyObject`. The public JWK
+thumbprint is derived locally and compared to the expected registration value
+before readiness. The private key, token and descriptor values are not
+serializable, inspectable, loggable or returnable. They never appear in command
+arguments, environment variables, generic configuration, crash diagnostics,
+audit events or model context.
+
+The trusted expiry is no more than 15 minutes after issuance. Readiness becomes
+false at expiry and no refresh occurs. Rotation is a complete process/profile
+replacement with new descriptors and an accepted server registration; there is
+no overlapping credential or fallback.
+
+### DPoP authenticator
+
+For every frozen adapter request the authenticator returns:
+
+```text
+credential = "DPoP " + opaque_token
+proof = compact ES256 DPoP JWS
+```
+
+The protected header contains exactly `typ=dpop+jwt`, `alg=ES256` and the public
+P-256 JWK. The claims contain exactly:
+
+- fresh random base64url `jti` with 128 bits of entropy;
+- exact adapter-supplied uppercase `htm`;
+- exact adapter-supplied HTTPS target as `htu`, without query or fragment;
+- integer current `iat` from an injected trusted UTC clock;
+- base64url SHA-256 `ath` over the exact ASCII token.
+
+No nonce, body claim, custom audience, key ID, certificate, private JWK member
+or additional claim is emitted. The proof is generated only after the adapter
+freezes the target and canonical request body. Signing has the same single
+request deadline and failure normalizes to `coordination_unavailable` without
+retry.
+
+The signer maintains no proof history; server-side durable replay reservation
+is authoritative. Local CSPRNG, clock or signing failure makes the profile
+unready and emits no request.
+
+### Direct HTTPS transport
+
+The transport uses Node platform `https` APIs directly. It creates one
+non-global agent with:
+
+- the exact supplied private CA bundle;
+- certificate and server-name verification enabled;
+- no client certificate;
+- no environment proxy, global dispatcher, redirect or DNS search fallback;
+- keep-alive disabled for the first profile;
+- explicit connect, TLS, response-header and whole-request deadlines bounded by
+  the adapter's one deadline;
+- response decompression disabled and the existing 4 KiB streamed bound.
+
+The transport accepts only adapter-generated `https` targets whose origin
+exactly equals the configured origin and whose path is one of the five fixed
+routes. It rejects informational responses, upgrade, redirect, multiple final
+responses, conflicting framing and every certificate/hostname error. It sends
+exactly one request and never retries connection, TLS, authentication or HTTP
+failure.
+
+Raw TLS, socket, certificate, DNS and operating-system errors are discarded and
+mapped through the accepted closed MCP taxonomy. The transport returns only the
+bounded `Response` abstraction already validated independently by RFC-0005.
+
+### Readiness, observability and disablement
+
+The qualification runner reports ready only when configuration is valid,
+trust material has safe ownership/mode, token/key descriptors were consumed,
+key thumbprint matches, credential is unexpired and clock is within the
+deployment's five-second fence. It does not probe a primitive route for
+readiness because every route has state semantics.
+
+Operational output is one closed record containing profile version, phase,
+ready/not-ready, sanitized outcome code and monotonic duration bucket. It
+contains no endpoint, path, descriptor, token, proof, JWK, thumbprint, TLS
+identity, body, binding digest, lease capability, fence or upstream text.
+
+The kill switch is absence of the explicit profile invocation. Termination
+aborts the one active request, destroys the private agent, drops token/key
+wrappers and zeroes mutable buffers. It cannot retry or infer remote state.
+
+### Qualification lifecycle
+
+The hermetic test composes the independent MCP transport/authenticator against
+the separately implemented upstream profile with generated private trust,
+descriptor-delivered ephemeral secrets, a disposable real JetStream service
+and synthetic bindings. It proves:
+
+- TLS trust and server-name success plus wrong-root/name/expiry negatives;
+- exact DPoP header/claims/signature, `ath`, target and thumbprint;
+- proof replay denial across server restart;
+- nonce first-consume and replay;
+- lease acquire, conflict, inspect, renew, stale capability, release and fence
+  monotonicity;
+- one-call timeout and ambiguous response with no hidden retry;
+- expired credential, policy denial, audit outage, epoch mismatch and key loss;
+- no secret in errors, logs, test diagnostics, process arguments or build
+  output;
+- gateway discovery and provider invocation remain unchanged and inert.
+
+Live staging qualification is a separate human-gated run after both
+implementations merge. It uses one pre-reviewed plan containing only public
+digests of implementation commits, profile versions, trust/registration
+artifacts, limits, epoch and teardown steps. The actual endpoint and secrets
+remain outside public evidence.
+
+The owner separately approves (1) provisioning and credential minting and (2)
+the single live qualification window. The runner performs only synthetic nonce
+and lease operations, releases or records ambiguous state, exits, and requires
+credential revocation plus server listener disablement. It cannot invoke the
+gateway or a provider.
+
+## Trust boundaries and threat analysis
+
+New boundaries are supervisor-to-MCP secret delivery, MCP-to-private trust
+bundle, token/key-to-DPoP signer, MCP-to-real TLS endpoint and qualification
+runner-to-remote coordination state.
+
+Threats include endpoint substitution, CA broadening, credential/key leakage,
+proof replay, target substitution, ambient proxy use, retry after ambiguity,
+secret-bearing diagnostics, credential persistence and treating Coordination
+success as MCP/provider authority.
+
+Controls are exact origin/name/private CA, descriptor-only short-lived secrets,
+thumbprint check, strict DPoP, fixed routes, platform-only dedicated transport,
+one deadline, no retry, redacted wrappers, closed output and complete separation
+from gateway/provider paths.
+
+Residual risk includes compromise of the MCP host/supervisor, plaintext secret
+presence in process memory, staging CA compromise, private-network denial of
+service and remote state left ambiguous after timeout. These are accepted only
+for the bounded staging qualification, not production.
+
+## Compatibility
+
+The existing consumer port and RFC-0005 wire mapping do not change. The direct
+transport and authenticator are optional implementations injected behind the
+same ports. Ordinary gateway, demo and provider behavior remain byte- and
+discovery-compatible.
+
+The implementation consumes only the immutable public Coordination wire
+contract and accepted deployment profile. It neither imports nor republishes
+upstream code, schemas, clients, storage or configuration.
+
+## Rollout and rollback
+
+1. Accept upstream Coordination RFC-0022.
+2. Accept this RFC explicitly.
+3. Implement and hermetically qualify the upstream staging service.
+4. Record its immutable commit and contract evidence in issue #50.
+5. Implement and hermetically qualify the MCP transport, signer and runner.
+6. Review a redacted provisioning plan and obtain explicit owner approval.
+7. Provision without traffic and review readiness evidence.
+8. Obtain separate owner approval for one live qualification window.
+9. Run synthetic-only qualification, revoke credentials and disable both
+   profiles.
+
+Acceptance authorizes steps 3–5 only after their dependencies. Steps 6–9 keep
+their explicit gates. Gateway wiring and provider/mutation use require a later
+RFC even after successful live qualification.
+
+Rollback omits the profile invocation, closes the agent, drops secrets and
+revokes the server registration. Remote nonce/lease state is preserved and
+never deleted to manufacture retry safety.
+
+## Alternatives
+
+### Use global `fetch`
+
+Rejected because the profile needs an exact private CA, server name, agent and
+proxy-independent transport boundary without ambient global configuration.
+
+### Store token or key in environment variables or files
+
+Rejected because those are ambient, inheritable and more likely to enter
+diagnostics or durable host state. Short-lived inherited descriptors provide a
+narrower staging boundary.
+
+### Reuse the upstream JavaScript client
+
+Rejected because MCP must preserve independent trust and compatibility
+validation and must not copy Coordination components.
+
+### Wire the gateway immediately
+
+Rejected because a real Coordination connection proves remote primitives, not
+MCP authentication, policy, approval, audit or provider admission.
+
+### Automatically retry transient failures
+
+Rejected because a timeout can conceal nonce consumption or a lease state
+transition. Reconciliation remains explicit and lifecycle-aware.
+
+## Open questions
+
+1. Which supervisor will supply inherited descriptors in the first staging
+   environment? The public MCP contract remains independent of that selection.
+2. Which exact origin, trust root and registration will be used? They are
+   private deployment evidence and are deliberately absent from this RFC.

--- a/.context/sessions/SESSION-2026-08-03-15-private-coordination-connection-rfc.md
+++ b/.context/sessions/SESSION-2026-08-03-15-private-coordination-connection-rfc.md
@@ -1,0 +1,26 @@
+# Session — private staging Coordination connection proposal
+
+- Date: 2026-08-03
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/50
+- Branch: `agent/issue-50-real-coordination-profile`
+- Status: proposal ready for owner review; upstream RFC dependency unresolved
+
+## Outcome
+
+Proposed RFC-0006 for a disabled-by-default MCP-native connection to the paired
+private staging Coordination profile. The design selects explicit private TLS
+trust, a dedicated Node HTTPS transport, descriptor-delivered short-lived token
+and P-256 key, strict DPoP signing, closed readiness/output and a separate
+synthetic-only qualification runner.
+
+## Dependency and boundary
+
+The proposal depends on acceptance and implementation of Coordination RFC-0022
+under `nomed/yukh-coordination#90`. MCP continues to import no Coordination
+component and the ordinary gateway remains inert.
+
+No endpoint, trust root, credential, private key, provisioning, request,
+gateway wiring, provider execution, mutation, deployment or live apply was
+introduced. RFC acceptance would authorize implementation and hermetic
+qualification only; provisioning and live traffic retain later explicit human
+gates.

--- a/.context/sessions/SESSION-2026-08-03-15-private-coordination-connection-rfc.md
+++ b/.context/sessions/SESSION-2026-08-03-15-private-coordination-connection-rfc.md
@@ -2,6 +2,7 @@
 
 - Date: 2026-08-03
 - Governing issue: https://github.com/nomed/yukh-mcp/issues/50
+- Pull request: https://github.com/nomed/yukh-mcp/pull/51
 - Branch: `agent/issue-50-real-coordination-profile`
 - Status: proposal ready for owner review; upstream RFC dependency unresolved
 

--- a/.context/sessions/SESSION-2026-08-03-15-private-coordination-connection-rfc.md
+++ b/.context/sessions/SESSION-2026-08-03-15-private-coordination-connection-rfc.md
@@ -1,10 +1,10 @@
-# Session — private staging Coordination connection proposal
+# Session — private staging Coordination connection decision
 
 - Date: 2026-08-03
 - Governing issue: https://github.com/nomed/yukh-mcp/issues/50
 - Pull request: https://github.com/nomed/yukh-mcp/pull/51
 - Branch: `agent/issue-50-real-coordination-profile`
-- Status: proposal ready for owner review; upstream RFC dependency unresolved
+- Status: RFC-0006 and upstream RFC-0022 accepted by project owner
 
 ## Outcome
 
@@ -16,12 +16,12 @@ synthetic-only qualification runner.
 
 ## Dependency and boundary
 
-The proposal depends on acceptance and implementation of Coordination RFC-0022
-under `nomed/yukh-coordination#90`. MCP continues to import no Coordination
-component and the ordinary gateway remains inert.
+The accepted profile depends on implementation of accepted Coordination
+RFC-0022 under `nomed/yukh-coordination#90`. MCP continues to import no
+Coordination component and the ordinary gateway remains inert.
 
 No endpoint, trust root, credential, private key, provisioning, request,
 gateway wiring, provider execution, mutation, deployment or live apply was
-introduced. RFC acceptance would authorize implementation and hermetic
+introduced. The paired RFC acceptance authorizes implementation and hermetic
 qualification only; provisioning and live traffic retain later explicit human
 gates.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -39,14 +39,15 @@ is not wired into the gateway. Nonces and lease handles are sensitive runtime
 material: they must never enter logs, audit evidence, errors, model context, or
 durable repository context.
 
-Real integration remains blocked until `nomed/yukh-coordination#71` is merged
-and its stable consumer contract is reviewed. That future increment must adapt
-the stable contract at this port; it must not copy Coordination components into
-Yukh MCP.
-
 RFC-0005 now governs an MCP-native adapter implementation behind this port. The
 adapter uses fixed Coordination primitives v1 routes, exact lifecycle-derived
 digests, explicit authentication and an injected fetch-compatible transport.
-It remains disconnected from the gateway. The current implementation candidate
-has synthetic transport conformance evidence; its required ephemeral loopback
-TLS qualification is still pending and no real endpoint profile exists.
+It is merged and qualified over verified synthetic loopback TLS, and remains
+disconnected from the gateway.
+
+Issue #50 and draft RFC-0006 propose the first disabled-by-default real staging
+connection. It depends on the separate deployable server profile proposed by
+`nomed/yukh-coordination#90`, uses explicit private trust and short-lived DPoP
+material, and permits only a synthetic qualification runner. Until both RFCs
+are accepted and separately implemented, no endpoint, credential, real request,
+gateway wiring, provider execution, mutation or live apply is authorized.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -45,9 +45,10 @@ digests, explicit authentication and an injected fetch-compatible transport.
 It is merged and qualified over verified synthetic loopback TLS, and remains
 disconnected from the gateway.
 
-Issue #50 and draft RFC-0006 propose the first disabled-by-default real staging
-connection. It depends on the separate deployable server profile proposed by
+Issue #50 and accepted RFC-0006 govern the first disabled-by-default real
+staging connection. It depends on accepted Coordination RFC-0022 under
 `nomed/yukh-coordination#90`, uses explicit private trust and short-lived DPoP
 material, and permits only a synthetic qualification runner. Until both RFCs
-are accepted and separately implemented, no endpoint, credential, real request,
-gateway wiring, provider execution, mutation or live apply is authorized.
+are separately implemented and hermetically qualified, no endpoint, credential,
+real request, gateway wiring, provider execution, mutation or live apply is
+authorized.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -44,14 +44,14 @@ availability guarantees require later accepted provider profiles.
 
 ## Trust boundaries
 
-| Boundary | Principal threats | Initial controls | Residual Foundation risk |
-| --- | --- | --- | --- |
-| MCP client → gateway | prompt injection, forged identity context, schema abuse, oversized or repeated input, capability enumeration | authenticated transport profile, server-derived subject, exact versioned capability allowlist, strict schemas, input and request bounds, deny before disclosure | concrete authentication and rate-limit profiles are not yet selected |
-| Gateway → identity and policy services | authentication confused with authorization, stale or substituted policy, dependency failure, cross-resource confused deputy | canonical subject/action/resource/environment request, policy version binding, explicit deny, fail-closed timeout/error handling, decision evidence | policy-engine protocol and freshness bounds require an RFC |
-| Gateway → capability provider | provider selected by untrusted input, argument injection, excessive authority, unsafe retry, result confusion | server-side provider registry, typed arguments, least-privilege credential profile, bounded time/output, idempotency and retry declaration, correlation binding | no operational provider is implemented yet |
-| Provider → target node | traversal or symlink escape, command injection, target substitution, credential disclosure, malicious output, partial effect | configured canonical roots and target identity, no unrestricted shell interface, argument allowlists, credential isolation, output sanitization, postcondition verification | provider-specific sandbox and target identity require separate review |
-| Runtime → audit storage | secret retention, prompt retention, event forgery, deletion, reordering, correlation substitution, storage exhaustion | allowlisted redacted event schemas, bounded records, correlation and causation identifiers, integrity metadata, restricted writer/reader roles | storage, retention, export, and tamper-evidence implementation are not yet selected |
-| Source → workflow → release | malicious dependency or contributor, mutable action reference, artifact substitution, secret exposure, untrusted-PR publication | reviewed changes, immutable action pins, least-privilege workflow permissions, deterministic checks, dependency review, SBOM/provenance roadmap, protected release | repository settings and release signing require qualification evidence |
+| Boundary                               | Principal threats                                                                                                               | Initial controls                                                                                                                                                            | Residual Foundation risk                                                            |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| MCP client → gateway                   | prompt injection, forged identity context, schema abuse, oversized or repeated input, capability enumeration                    | authenticated transport profile, server-derived subject, exact versioned capability allowlist, strict schemas, input and request bounds, deny before disclosure             | concrete authentication and rate-limit profiles are not yet selected                |
+| Gateway → identity and policy services | authentication confused with authorization, stale or substituted policy, dependency failure, cross-resource confused deputy     | canonical subject/action/resource/environment request, policy version binding, explicit deny, fail-closed timeout/error handling, decision evidence                         | policy-engine protocol and freshness bounds require an RFC                          |
+| Gateway → capability provider          | provider selected by untrusted input, argument injection, excessive authority, unsafe retry, result confusion                   | server-side provider registry, typed arguments, least-privilege credential profile, bounded time/output, idempotency and retry declaration, correlation binding             | no operational provider is implemented yet                                          |
+| Provider → target node                 | traversal or symlink escape, command injection, target substitution, credential disclosure, malicious output, partial effect    | configured canonical roots and target identity, no unrestricted shell interface, argument allowlists, credential isolation, output sanitization, postcondition verification | provider-specific sandbox and target identity require separate review               |
+| Runtime → audit storage                | secret retention, prompt retention, event forgery, deletion, reordering, correlation substitution, storage exhaustion           | allowlisted redacted event schemas, bounded records, correlation and causation identifiers, integrity metadata, restricted writer/reader roles                              | storage, retention, export, and tamper-evidence implementation are not yet selected |
+| Source → workflow → release            | malicious dependency or contributor, mutable action reference, artifact substitution, secret exposure, untrusted-PR publication | reviewed changes, immutable action pins, least-privilege workflow permissions, deterministic checks, dependency review, SBOM/provenance roadmap, protected release          | repository settings and release signing require qualification evidence              |
 
 ## Abuse cases and required response
 
@@ -171,14 +171,14 @@ hold credentials, persist audit events, or mutate a target.
 
 Implementation-specific threats and controls are:
 
-| Threat | Control | Residual risk |
-| --- | --- | --- |
-| schema bombs or recursive references | node/depth/property limits; remote and cyclic references rejected before compilation | complex but acyclic schemas still consume bounded local CPU |
-| regular-expression denial of service | pattern length and construct restrictions; provider schema review remains mandatory | the conservative filter is not a formal regex complexity proof |
-| prototype or credential channel through property names | closed objects; dangerous and credential-shaped names rejected; input values excluded from diagnostics | semantic intent still requires human provider review |
-| diagnostic disclosure or nondeterminism | allowlisted messages without values; stable path/code ordering; 64-item cap; repeatability tests | paths reveal only submitted field names |
-| malicious or incompatible dependency | exact Ajv version and lockfile; install scripts disabled in validation; dependency audit evidence | registry and build-environment integrity remain governed by #10 |
-| invalid provider output represented as success | result and output validation; mutating success requires verified postconditions | real verification semantics remain governed by #4 and evidence uses RFC-0004 |
+| Threat                                                 | Control                                                                                                | Residual risk                                                                |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| schema bombs or recursive references                   | node/depth/property limits; remote and cyclic references rejected before compilation                   | complex but acyclic schemas still consume bounded local CPU                  |
+| regular-expression denial of service                   | pattern length and construct restrictions; provider schema review remains mandatory                    | the conservative filter is not a formal regex complexity proof               |
+| prototype or credential channel through property names | closed objects; dangerous and credential-shaped names rejected; input values excluded from diagnostics | semantic intent still requires human provider review                         |
+| diagnostic disclosure or nondeterminism                | allowlisted messages without values; stable path/code ordering; 64-item cap; repeatability tests       | paths reveal only submitted field names                                      |
+| malicious or incompatible dependency                   | exact Ajv version and lockfile; install scripts disabled in validation; dependency audit evidence      | registry and build-environment integrity remain governed by #10              |
+| invalid provider output represented as success         | result and output validation; mutating success requires verified postconditions                        | real verification semantics remain governed by #4 and evidence uses RFC-0004 |
 
 No operational capability is authorized by this review. A first provider,
 listener, authentication profile, policy adapter, plan executor, or audit store
@@ -194,15 +194,15 @@ requires another threat-model impact review under its governing issue and RFC.
 
 RFC-0003 proposes controls before any mutating implementation exists:
 
-| Threat | Proposed control | Residual risk / dependency |
-| --- | --- | --- |
-| plan or approval substitution | canonical digests bind subject, capability, input, target, environment, policy, observations, plan, and approval | approval identity and assertion integrity profile is not selected |
-| stale-plan execution | fresh authorization and immediate server-side precondition re-observation before apply | observation source integrity is provider/deployment specific |
-| duplicate or unsafe retry | durable exact-binding reservation, capability attempt ceiling, no retry from ambiguous completion | durable storage and distributed atomicity are not designed |
-| provider reports false success | declared postconditions and independent verification where required | verifier independence and target identity need provider review |
-| partial effect is hidden | append-only per-step outcomes, aggregate `partial_effect`, and operator-review state | operator response process is not defined |
-| rollback overwrites newer state | rollback is a new authorized lifecycle with current preconditions | safe compensation may be unavailable |
-| evidence omission or reordering | RFC-0004 event registry, durable pre-effect commit, causal correlation, hash chaining, and checkpoints | durable writer, journal, and checkpoint deployment profiles remain unselected |
+| Threat                          | Proposed control                                                                                                 | Residual risk / dependency                                                    |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| plan or approval substitution   | canonical digests bind subject, capability, input, target, environment, policy, observations, plan, and approval | approval identity and assertion integrity profile is not selected             |
+| stale-plan execution            | fresh authorization and immediate server-side precondition re-observation before apply                           | observation source integrity is provider/deployment specific                  |
+| duplicate or unsafe retry       | durable exact-binding reservation, capability attempt ceiling, no retry from ambiguous completion                | durable storage and distributed atomicity are not designed                    |
+| provider reports false success  | declared postconditions and independent verification where required                                              | verifier independence and target identity need provider review                |
+| partial effect is hidden        | append-only per-step outcomes, aggregate `partial_effect`, and operator-review state                             | operator response process is not defined                                      |
+| rollback overwrites newer state | rollback is a new authorized lifecycle with current preconditions                                                | safe compensation may be unavailable                                          |
+| evidence omission or reordering | RFC-0004 event registry, durable pre-effect commit, causal correlation, hash chaining, and checkpoints           | durable writer, journal, and checkpoint deployment profiles remain unselected |
 
 This review changes no operational boundary and authorizes no implementation.
 RFC-0004 now satisfies the audit-contract dependency; RFC-0003 still requires
@@ -219,15 +219,15 @@ explicit project-owner acceptance before it can authorize implementation.
 
 RFC-0004 proposes the following controls before an audit backend exists:
 
-| Threat | Proposed control | Residual risk / dependency |
-| --- | --- | --- |
-| secret or prompt retention | closed typed payloads, structural allowlist projections, forbidden-content registry, no raw fallback | producer semantic bugs and side channels still require review |
-| identity or target disclosure | opaque references, protected resource-set digests, separately controlled resolvers | low-entropy digests and resolver misuse require deployment privacy controls |
-| event substitution or reorder | canonical digest binding, per-stream sequence, previous hash, causal references | compromised writer can omit facts before emission |
-| deletion or chain replacement | periodic checkpoints and optional independent witnessing | unwitnessed tail truncation remains possible |
-| misleading immutability claim | contract says hash-chained/integrity-verifiable; deployment must prove stronger properties | storage and checkpoint profile not selected |
-| audit outage hides an effect | fail closed before provider start; durable recovery fact and withheld success after start | recovery journal and atomicity require deployment design |
-| over-retention or unsafe export | registered retention classes, explicit holds, deterministic projections, bounded integrity-bound manifests | legal durations and jurisdictions are deployment-specific |
+| Threat                          | Proposed control                                                                                           | Residual risk / dependency                                                  |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| secret or prompt retention      | closed typed payloads, structural allowlist projections, forbidden-content registry, no raw fallback       | producer semantic bugs and side channels still require review               |
+| identity or target disclosure   | opaque references, protected resource-set digests, separately controlled resolvers                         | low-entropy digests and resolver misuse require deployment privacy controls |
+| event substitution or reorder   | canonical digest binding, per-stream sequence, previous hash, causal references                            | compromised writer can omit facts before emission                           |
+| deletion or chain replacement   | periodic checkpoints and optional independent witnessing                                                   | unwitnessed tail truncation remains possible                                |
+| misleading immutability claim   | contract says hash-chained/integrity-verifiable; deployment must prove stronger properties                 | storage and checkpoint profile not selected                                 |
+| audit outage hides an effect    | fail closed before provider start; durable recovery fact and withheld success after start                  | recovery journal and atomicity require deployment design                    |
+| over-retention or unsafe export | registered retention classes, explicit holds, deterministic projections, bounded integrity-bound manifests | legal durations and jurisdictions are deployment-specific                   |
 
 This review authorizes no store, key, identity resolver, export service,
 provider, mutation, or production integrity claim. Each deployment profile must
@@ -245,15 +245,15 @@ The runtime exposes no operational capability, provider, credential, target
 resolver, policy adapter, approval service, task API, audit store, or mutation
 path. Its controls and residual risks are:
 
-| Threat | Control | Residual risk |
-| --- | --- | --- |
-| DNS rebinding or virtual-host confusion | exact host allowlist on `/mcp`; wildcard bind requires explicit configuration | reverse-proxy host rewriting requires a future deployment profile |
-| cross-origin browser invocation | any `Origin` is denied unless exactly allowlisted | non-browser clients have no Origin and authentication is not implemented |
-| oversized or slow request | content-length and streamed byte bound before SDK parsing; request/header/keep-alive timeouts, connection and per-socket request ceilings | distributed rate limiting still needs a deployment edge profile |
-| protocol parser or SDK defect | official modular SDK pinned to 2.0.0; strict TypeScript; protocol integration tests; empty registries | dependency compromise and future protocol drift remain possible |
-| accidental operational authority | empty tools/resources/prompts; no provider or credential modules; discovery test asserts empty lists | later capability registration requires its own review |
-| log disclosure or injection | closed records, server-generated correlation, no headers/body/URL/error text | stdout transport, retention, and integrity are not RFC-0004 audit |
-| container privilege or exhaustion | non-root user, read-only Compose filesystem, dropped capabilities, no-new-privileges, CPU/memory/PID bounds | base image is tag-pinned, not digest-qualified; #10 remains open |
+| Threat                                  | Control                                                                                                                                   | Residual risk                                                            |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| DNS rebinding or virtual-host confusion | exact host allowlist on `/mcp`; wildcard bind requires explicit configuration                                                             | reverse-proxy host rewriting requires a future deployment profile        |
+| cross-origin browser invocation         | any `Origin` is denied unless exactly allowlisted                                                                                         | non-browser clients have no Origin and authentication is not implemented |
+| oversized or slow request               | content-length and streamed byte bound before SDK parsing; request/header/keep-alive timeouts, connection and per-socket request ceilings | distributed rate limiting still needs a deployment edge profile          |
+| protocol parser or SDK defect           | official modular SDK pinned to 2.0.0; strict TypeScript; protocol integration tests; empty registries                                     | dependency compromise and future protocol drift remain possible          |
+| accidental operational authority        | empty tools/resources/prompts; no provider or credential modules; discovery test asserts empty lists                                      | later capability registration requires its own review                    |
+| log disclosure or injection             | closed records, server-generated correlation, no headers/body/URL/error text                                                              | stdout transport, retention, and integrity are not RFC-0004 audit        |
+| container privilege or exhaustion       | non-root user, read-only Compose filesystem, dropped capabilities, no-new-privileges, CPU/memory/PID bounds                               | base image is tag-pinned, not digest-qualified; #10 remains open         |
 
 This review authorizes only the inert development skeleton. Non-loopback
 deployment, authentication, authorization integration, a real capability,
@@ -268,15 +268,15 @@ separate accepted threat-model impact review.
 - New trust boundaries: third-party workflow actions, dependency registries,
   hosted runners, code-scanning ingestion, and retained analysis artifacts
 
-| Threat | Control | Residual risk |
-| --- | --- | --- |
-| untrusted PR obtains authority | `pull_request` only, read-only default permissions, no secrets/OIDC/publication, no persisted checkout credential | hosted runner and action compromise remain possible |
-| action tag or dependency substitution | actions pinned to full SHA; npm lock and install scripts disabled; exact direct versions; automated pin test | Python transitive dependencies and Node base image lack full digest locks |
-| vulnerable dependency enters source | dependency review and npm audit fail at moderate severity; Dependabot coverage | advisory databases can lag and malicious packages may have no advisory |
-| vulnerable source reaches main | always-on formatting/type/test/build/docs/container gate plus CodeQL security-extended | static analysis and tests are incomplete proofs |
-| workflow gains excess token authority | explicit workflow/job permissions; publication separated from validation | repository setting changes require periodic external audit |
-| Scorecard or scanner publishes sensitive data | source contains no secrets; Scorecard public publishing disabled; bounded five-day SARIF artifact | filenames and findings remain repository-visible security metadata |
-| unsupported release-integrity claim | documented evidence gates; no release workflow; SBOM/signing/SLSA are roadmap only | issue #13 and deployment controls remain incomplete |
+| Threat                                        | Control                                                                                                           | Residual risk                                                             |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| untrusted PR obtains authority                | `pull_request` only, read-only default permissions, no secrets/OIDC/publication, no persisted checkout credential | hosted runner and action compromise remain possible                       |
+| action tag or dependency substitution         | actions pinned to full SHA; npm lock and install scripts disabled; exact direct versions; automated pin test      | Python transitive dependencies and Node base image lack full digest locks |
+| vulnerable dependency enters source           | dependency review and npm audit fail at moderate severity; Dependabot coverage                                    | advisory databases can lag and malicious packages may have no advisory    |
+| vulnerable source reaches main                | always-on formatting/type/test/build/docs/container gate plus CodeQL security-extended                            | static analysis and tests are incomplete proofs                           |
+| workflow gains excess token authority         | explicit workflow/job permissions; publication separated from validation                                          | repository setting changes require periodic external audit                |
+| Scorecard or scanner publishes sensitive data | source contains no secrets; Scorecard public publishing disabled; bounded five-day SARIF artifact                 | filenames and findings remain repository-visible security metadata        |
+| unsupported release-integrity claim           | documented evidence gates; no release workflow; SBOM/signing/SLSA are roadmap only                                | issue #13 and deployment controls remain incomplete                       |
 
 This baseline authorizes source validation and security-analysis uploads only.
 It does not authorize package/container publication, a signing identity, release
@@ -289,14 +289,14 @@ credentials, OIDC federation, or a production release.
   authorization-enforced invocation boundary, bounded metadata result, and tests
 - New trust boundary: capability invocation to a local read-only filesystem provider
 
-| Threat | Control | Residual risk |
-| --- | --- | --- |
-| traversal or absolute-path escape | relative path grammar, canonical configured roots, containment checks before observation | platform path semantics require qualification on every supported OS |
-| symbolic-link escape | every path component is inspected and any symlink is rejected; canonical target is checked again | filesystem replacement races remain possible without an OS-level directory-handle sandbox |
-| authorization bypass | malformed requests fail before authorization; denied requests record zero provider attempts | the injected authorizer is not yet connected to an authenticated transport or durable decision enforcer |
-| malicious or oversized provider output | closed runtime schema, 4 KiB serialized bound, invalid output withheld as `provider_protocol_error` | metadata such as requested relative paths may still be sensitive in a deployment-specific root |
-| content or credential disclosure | capability returns file type, size, modification time, source, and freshness only; no contents or directory listing | file names supplied by an authorized caller remain visible in its own result |
-| accidental public authority | inert MCP discovery remains empty and no provider configuration is loaded by the listener | a future MCP binding requires identity, policy, configuration, and audit review |
+| Threat                                 | Control                                                                                                             | Residual risk                                                                                           |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| traversal or absolute-path escape      | relative path grammar, canonical configured roots, containment checks before observation                            | platform path semantics require qualification on every supported OS                                     |
+| symbolic-link escape                   | every path component is inspected and any symlink is rejected; canonical target is checked again                    | filesystem replacement races remain possible without an OS-level directory-handle sandbox               |
+| authorization bypass                   | malformed requests fail before authorization; denied requests record zero provider attempts                         | the injected authorizer is not yet connected to an authenticated transport or durable decision enforcer |
+| malicious or oversized provider output | closed runtime schema, 4 KiB serialized bound, invalid output withheld as `provider_protocol_error`                 | metadata such as requested relative paths may still be sensitive in a deployment-specific root          |
+| content or credential disclosure       | capability returns file type, size, modification time, source, and freshness only; no contents or directory listing | file names supplied by an authorized caller remain visible in its own result                            |
+| accidental public authority            | inert MCP discovery remains empty and no provider configuration is loaded by the listener                           | a future MCP binding requires identity, policy, configuration, and audit review                         |
 
 This review authorizes the network-free experimental provider boundary and its
 tests only. It does not authorize MCP exposure, production roots, credentials,
@@ -331,14 +331,14 @@ identity, policy, audit-writer, and deployment profiles.
 - New live trust boundary: none; the driver is not connected to the gateway or
   to a transport
 
-| Threat | Control | Residual risk / dependency |
-| --- | --- | --- |
-| malformed or substituted coordination receipt advances lifecycle | strict closed schemas plus exact operation and binding-digest checks | the future canonical digest implementation must be reviewed against the stable upstream contract |
-| stale lease is treated as current | expiry is checked against an injected trusted clock and equality is stale | clock source and skew policy remain deployment-specific |
-| dependency detail leaks through errors | all driver exceptions and timeouts normalize to one bounded code | future observability must retain the closed error surface |
-| hidden retry duplicates nonce or lease operations | the consumer performs one bounded driver call and never retries | a future transport adapter must prove it does not retry, redirect, or poll internally |
-| nonce or sealed lease handle enters evidence | sensitive values are absent from receipts intended for evidence and explicitly forbidden from logs, audit, errors, model context, and repository context | future adapter memory handling and crash diagnostics require review |
-| Coordination implementation becomes coupled into MCP | only an MCP-owned port and fake driver exist; no source, bundle, client, schema, or transport is imported | compatibility cannot be claimed until PR #71 merges and an adapter is separately reviewed |
+| Threat                                                           | Control                                                                                                                                                  | Residual risk / dependency                                                                       |
+| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| malformed or substituted coordination receipt advances lifecycle | strict closed schemas plus exact operation and binding-digest checks                                                                                     | the future canonical digest implementation must be reviewed against the stable upstream contract |
+| stale lease is treated as current                                | expiry is checked against an injected trusted clock and equality is stale                                                                                | clock source and skew policy remain deployment-specific                                          |
+| dependency detail leaks through errors                           | all driver exceptions and timeouts normalize to one bounded code                                                                                         | future observability must retain the closed error surface                                        |
+| hidden retry duplicates nonce or lease operations                | the consumer performs one bounded driver call and never retries                                                                                          | a future transport adapter must prove it does not retry, redirect, or poll internally            |
+| nonce or sealed lease handle enters evidence                     | sensitive values are absent from receipts intended for evidence and explicitly forbidden from logs, audit, errors, model context, and repository context | future adapter memory handling and crash diagnostics require review                              |
+| Coordination implementation becomes coupled into MCP             | only an MCP-owned port and fake driver exist; no source, bundle, client, schema, or transport is imported                                                | compatibility cannot be claimed until PR #71 merges and an adapter is separately reviewed        |
 
 This review authorizes only the inert consumer contract. It does not authorize
 an HTTP adapter, Coordination client import, endpoint, credential,
@@ -354,14 +354,14 @@ provider invocation, mutation, deployment, or release claim.
 - New implementation trust boundaries: MCP to request authenticator; MCP across TLS to
   untrusted Coordination framing and responses
 
-| Threat | Accepted control | Residual risk / dependency |
-| --- | --- | --- |
-| lifecycle binding is substituted or narrowed | one canonical MCP scope digest covers subject, capability, resources, environment, plan, approval, operation, expiry and epoch | canonical vectors require review before implementation |
-| attacker redirects requests or abuses ambient network configuration | exact HTTPS base URI and fixed routes; redirects, proxy discovery and caller-selected targets forbidden | DNS and TLS trust remain deployment-specific |
-| credential or lease capability leaks | explicit bounded authenticator, private redacted capability wrapper, closed errors and no raw-body diagnostics | concrete key custody and runtime memory handling need deployment review |
-| timeout causes unsafe replay | one bounded request, abort once, no retry; ambiguous outcomes deny and require lifecycle reconciliation | availability loss can stop protected operations |
-| malformed response becomes authority | independent closed response validation and route-specific outcomes; transport success never implies MCP authorization or provider success | upstream compatibility drift requires immutable re-review |
-| copied client couples trust domains | platform APIs and public wire contract only; no upstream source, bundle, schema or client import | independent implementation may contain semantic defects requiring conformance tests |
+| Threat                                                              | Accepted control                                                                                                                          | Residual risk / dependency                                                          |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| lifecycle binding is substituted or narrowed                        | one canonical MCP scope digest covers subject, capability, resources, environment, plan, approval, operation, expiry and epoch            | canonical vectors require review before implementation                              |
+| attacker redirects requests or abuses ambient network configuration | exact HTTPS base URI and fixed routes; redirects, proxy discovery and caller-selected targets forbidden                                   | DNS and TLS trust remain deployment-specific                                        |
+| credential or lease capability leaks                                | explicit bounded authenticator, private redacted capability wrapper, closed errors and no raw-body diagnostics                            | concrete key custody and runtime memory handling need deployment review             |
+| timeout causes unsafe replay                                        | one bounded request, abort once, no retry; ambiguous outcomes deny and require lifecycle reconciliation                                   | availability loss can stop protected operations                                     |
+| malformed response becomes authority                                | independent closed response validation and route-specific outcomes; transport success never implies MCP authorization or provider success | upstream compatibility drift requires immutable re-review                           |
+| copied client couples trust domains                                 | platform APIs and public wire contract only; no upstream source, bundle, schema or client import                                          | independent implementation may contain semantic defects requiring conformance tests |
 
 Coordination RFC-0021, merged in PR #85 at
 `91c1e5097e47026f63c34126a379949833bb7e00`, resolves acquisition contention as
@@ -395,3 +395,26 @@ absent from runtime and build output. This evidence does not select or qualify
 production trust, DNS, identity, key custody, or endpoint configuration. No real
 endpoint, credential, gateway wiring, provider execution, mutation, deployment,
 public listener or live apply is authorized.
+
+## Proposed private staging Coordination connection — 2026-08-03
+
+- Governing issue: #50
+- Proposed architecture: RFC-0006 and upstream Coordination RFC-0022
+- Scope: disabled-by-default direct TLS transport, explicit private trust,
+  descriptor-delivered short-lived DPoP credential/key and synthetic-only real
+  staging qualification
+
+| Threat                                | Proposed control                                                                                                                | Residual risk / dependency                                                          |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| endpoint or trust substitution        | exact HTTPS origin/server name, explicit private CA, dedicated verified Node HTTPS agent, no proxy/system-root fallback         | staging CA or supervisor compromise can still redirect the consumer                 |
+| credential or signing-key disclosure  | separate inherited descriptors, bounded one-time reads, redacted wrappers, source-buffer zeroing and 15-minute maximum lifetime | plaintext exists in process memory and host compromise defeats this staging control |
+| proof replay or target confusion      | fresh ES256 DPoP with exact `htu`/`htm`/`ath`, expected thumbprint and server-side durable replay reservation                   | server replay-store availability is an upstream dependency                          |
+| hidden network retry after ambiguity  | one fixed request under the adapter deadline, keep-alive off, no redirect/retry/polling                                         | ambiguous remote state requires explicit lifecycle reconciliation                   |
+| remote success elevates MCP authority | qualification runner is separate from gateway/provider paths and uses synthetic bindings only                                   | later gateway wiring still requires identity, policy, audit and provider reviews    |
+| secret-bearing diagnostics            | closed error/output schemas omit endpoint, TLS, credential, proof, key, capability, body and upstream text                      | process/core-dump controls remain deployment-specific                               |
+| accidental activation                 | no defaults or environment activation; explicit profile entry point is the kill switch                                          | supervisor control of process arguments remains trusted for staging activation      |
+
+Acceptance would authorize only implementation and hermetic interoperability
+qualification after upstream RFC acceptance. Endpoint configuration,
+provisioning, credential minting, live requests, gateway wiring, provider
+execution, mutation, deployment and production use remain separately gated.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -44,14 +44,14 @@ availability guarantees require later accepted provider profiles.
 
 ## Trust boundaries
 
-| Boundary                               | Principal threats                                                                                                               | Initial controls                                                                                                                                                            | Residual Foundation risk                                                            |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| MCP client → gateway                   | prompt injection, forged identity context, schema abuse, oversized or repeated input, capability enumeration                    | authenticated transport profile, server-derived subject, exact versioned capability allowlist, strict schemas, input and request bounds, deny before disclosure             | concrete authentication and rate-limit profiles are not yet selected                |
-| Gateway → identity and policy services | authentication confused with authorization, stale or substituted policy, dependency failure, cross-resource confused deputy     | canonical subject/action/resource/environment request, policy version binding, explicit deny, fail-closed timeout/error handling, decision evidence                         | policy-engine protocol and freshness bounds require an RFC                          |
-| Gateway → capability provider          | provider selected by untrusted input, argument injection, excessive authority, unsafe retry, result confusion                   | server-side provider registry, typed arguments, least-privilege credential profile, bounded time/output, idempotency and retry declaration, correlation binding             | no operational provider is implemented yet                                          |
-| Provider → target node                 | traversal or symlink escape, command injection, target substitution, credential disclosure, malicious output, partial effect    | configured canonical roots and target identity, no unrestricted shell interface, argument allowlists, credential isolation, output sanitization, postcondition verification | provider-specific sandbox and target identity require separate review               |
-| Runtime → audit storage                | secret retention, prompt retention, event forgery, deletion, reordering, correlation substitution, storage exhaustion           | allowlisted redacted event schemas, bounded records, correlation and causation identifiers, integrity metadata, restricted writer/reader roles                              | storage, retention, export, and tamper-evidence implementation are not yet selected |
-| Source → workflow → release            | malicious dependency or contributor, mutable action reference, artifact substitution, secret exposure, untrusted-PR publication | reviewed changes, immutable action pins, least-privilege workflow permissions, deterministic checks, dependency review, SBOM/provenance roadmap, protected release          | repository settings and release signing require qualification evidence              |
+| Boundary | Principal threats | Initial controls | Residual Foundation risk |
+| --- | --- | --- | --- |
+| MCP client → gateway | prompt injection, forged identity context, schema abuse, oversized or repeated input, capability enumeration | authenticated transport profile, server-derived subject, exact versioned capability allowlist, strict schemas, input and request bounds, deny before disclosure | concrete authentication and rate-limit profiles are not yet selected |
+| Gateway → identity and policy services | authentication confused with authorization, stale or substituted policy, dependency failure, cross-resource confused deputy | canonical subject/action/resource/environment request, policy version binding, explicit deny, fail-closed timeout/error handling, decision evidence | policy-engine protocol and freshness bounds require an RFC |
+| Gateway → capability provider | provider selected by untrusted input, argument injection, excessive authority, unsafe retry, result confusion | server-side provider registry, typed arguments, least-privilege credential profile, bounded time/output, idempotency and retry declaration, correlation binding | no operational provider is implemented yet |
+| Provider → target node | traversal or symlink escape, command injection, target substitution, credential disclosure, malicious output, partial effect | configured canonical roots and target identity, no unrestricted shell interface, argument allowlists, credential isolation, output sanitization, postcondition verification | provider-specific sandbox and target identity require separate review |
+| Runtime → audit storage | secret retention, prompt retention, event forgery, deletion, reordering, correlation substitution, storage exhaustion | allowlisted redacted event schemas, bounded records, correlation and causation identifiers, integrity metadata, restricted writer/reader roles | storage, retention, export, and tamper-evidence implementation are not yet selected |
+| Source → workflow → release | malicious dependency or contributor, mutable action reference, artifact substitution, secret exposure, untrusted-PR publication | reviewed changes, immutable action pins, least-privilege workflow permissions, deterministic checks, dependency review, SBOM/provenance roadmap, protected release | repository settings and release signing require qualification evidence |
 
 ## Abuse cases and required response
 
@@ -171,14 +171,14 @@ hold credentials, persist audit events, or mutate a target.
 
 Implementation-specific threats and controls are:
 
-| Threat                                                 | Control                                                                                                | Residual risk                                                                |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
-| schema bombs or recursive references                   | node/depth/property limits; remote and cyclic references rejected before compilation                   | complex but acyclic schemas still consume bounded local CPU                  |
-| regular-expression denial of service                   | pattern length and construct restrictions; provider schema review remains mandatory                    | the conservative filter is not a formal regex complexity proof               |
-| prototype or credential channel through property names | closed objects; dangerous and credential-shaped names rejected; input values excluded from diagnostics | semantic intent still requires human provider review                         |
-| diagnostic disclosure or nondeterminism                | allowlisted messages without values; stable path/code ordering; 64-item cap; repeatability tests       | paths reveal only submitted field names                                      |
-| malicious or incompatible dependency                   | exact Ajv version and lockfile; install scripts disabled in validation; dependency audit evidence      | registry and build-environment integrity remain governed by #10              |
-| invalid provider output represented as success         | result and output validation; mutating success requires verified postconditions                        | real verification semantics remain governed by #4 and evidence uses RFC-0004 |
+| Threat | Control | Residual risk |
+| --- | --- | --- |
+| schema bombs or recursive references | node/depth/property limits; remote and cyclic references rejected before compilation | complex but acyclic schemas still consume bounded local CPU |
+| regular-expression denial of service | pattern length and construct restrictions; provider schema review remains mandatory | the conservative filter is not a formal regex complexity proof |
+| prototype or credential channel through property names | closed objects; dangerous and credential-shaped names rejected; input values excluded from diagnostics | semantic intent still requires human provider review |
+| diagnostic disclosure or nondeterminism | allowlisted messages without values; stable path/code ordering; 64-item cap; repeatability tests | paths reveal only submitted field names |
+| malicious or incompatible dependency | exact Ajv version and lockfile; install scripts disabled in validation; dependency audit evidence | registry and build-environment integrity remain governed by #10 |
+| invalid provider output represented as success | result and output validation; mutating success requires verified postconditions | real verification semantics remain governed by #4 and evidence uses RFC-0004 |
 
 No operational capability is authorized by this review. A first provider,
 listener, authentication profile, policy adapter, plan executor, or audit store
@@ -194,15 +194,15 @@ requires another threat-model impact review under its governing issue and RFC.
 
 RFC-0003 proposes controls before any mutating implementation exists:
 
-| Threat                          | Proposed control                                                                                                 | Residual risk / dependency                                                    |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| plan or approval substitution   | canonical digests bind subject, capability, input, target, environment, policy, observations, plan, and approval | approval identity and assertion integrity profile is not selected             |
-| stale-plan execution            | fresh authorization and immediate server-side precondition re-observation before apply                           | observation source integrity is provider/deployment specific                  |
-| duplicate or unsafe retry       | durable exact-binding reservation, capability attempt ceiling, no retry from ambiguous completion                | durable storage and distributed atomicity are not designed                    |
-| provider reports false success  | declared postconditions and independent verification where required                                              | verifier independence and target identity need provider review                |
-| partial effect is hidden        | append-only per-step outcomes, aggregate `partial_effect`, and operator-review state                             | operator response process is not defined                                      |
-| rollback overwrites newer state | rollback is a new authorized lifecycle with current preconditions                                                | safe compensation may be unavailable                                          |
-| evidence omission or reordering | RFC-0004 event registry, durable pre-effect commit, causal correlation, hash chaining, and checkpoints           | durable writer, journal, and checkpoint deployment profiles remain unselected |
+| Threat | Proposed control | Residual risk / dependency |
+| --- | --- | --- |
+| plan or approval substitution | canonical digests bind subject, capability, input, target, environment, policy, observations, plan, and approval | approval identity and assertion integrity profile is not selected |
+| stale-plan execution | fresh authorization and immediate server-side precondition re-observation before apply | observation source integrity is provider/deployment specific |
+| duplicate or unsafe retry | durable exact-binding reservation, capability attempt ceiling, no retry from ambiguous completion | durable storage and distributed atomicity are not designed |
+| provider reports false success | declared postconditions and independent verification where required | verifier independence and target identity need provider review |
+| partial effect is hidden | append-only per-step outcomes, aggregate `partial_effect`, and operator-review state | operator response process is not defined |
+| rollback overwrites newer state | rollback is a new authorized lifecycle with current preconditions | safe compensation may be unavailable |
+| evidence omission or reordering | RFC-0004 event registry, durable pre-effect commit, causal correlation, hash chaining, and checkpoints | durable writer, journal, and checkpoint deployment profiles remain unselected |
 
 This review changes no operational boundary and authorizes no implementation.
 RFC-0004 now satisfies the audit-contract dependency; RFC-0003 still requires
@@ -219,15 +219,15 @@ explicit project-owner acceptance before it can authorize implementation.
 
 RFC-0004 proposes the following controls before an audit backend exists:
 
-| Threat                          | Proposed control                                                                                           | Residual risk / dependency                                                  |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| secret or prompt retention      | closed typed payloads, structural allowlist projections, forbidden-content registry, no raw fallback       | producer semantic bugs and side channels still require review               |
-| identity or target disclosure   | opaque references, protected resource-set digests, separately controlled resolvers                         | low-entropy digests and resolver misuse require deployment privacy controls |
-| event substitution or reorder   | canonical digest binding, per-stream sequence, previous hash, causal references                            | compromised writer can omit facts before emission                           |
-| deletion or chain replacement   | periodic checkpoints and optional independent witnessing                                                   | unwitnessed tail truncation remains possible                                |
-| misleading immutability claim   | contract says hash-chained/integrity-verifiable; deployment must prove stronger properties                 | storage and checkpoint profile not selected                                 |
-| audit outage hides an effect    | fail closed before provider start; durable recovery fact and withheld success after start                  | recovery journal and atomicity require deployment design                    |
-| over-retention or unsafe export | registered retention classes, explicit holds, deterministic projections, bounded integrity-bound manifests | legal durations and jurisdictions are deployment-specific                   |
+| Threat | Proposed control | Residual risk / dependency |
+| --- | --- | --- |
+| secret or prompt retention | closed typed payloads, structural allowlist projections, forbidden-content registry, no raw fallback | producer semantic bugs and side channels still require review |
+| identity or target disclosure | opaque references, protected resource-set digests, separately controlled resolvers | low-entropy digests and resolver misuse require deployment privacy controls |
+| event substitution or reorder | canonical digest binding, per-stream sequence, previous hash, causal references | compromised writer can omit facts before emission |
+| deletion or chain replacement | periodic checkpoints and optional independent witnessing | unwitnessed tail truncation remains possible |
+| misleading immutability claim | contract says hash-chained/integrity-verifiable; deployment must prove stronger properties | storage and checkpoint profile not selected |
+| audit outage hides an effect | fail closed before provider start; durable recovery fact and withheld success after start | recovery journal and atomicity require deployment design |
+| over-retention or unsafe export | registered retention classes, explicit holds, deterministic projections, bounded integrity-bound manifests | legal durations and jurisdictions are deployment-specific |
 
 This review authorizes no store, key, identity resolver, export service,
 provider, mutation, or production integrity claim. Each deployment profile must
@@ -245,15 +245,15 @@ The runtime exposes no operational capability, provider, credential, target
 resolver, policy adapter, approval service, task API, audit store, or mutation
 path. Its controls and residual risks are:
 
-| Threat                                  | Control                                                                                                                                   | Residual risk                                                            |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| DNS rebinding or virtual-host confusion | exact host allowlist on `/mcp`; wildcard bind requires explicit configuration                                                             | reverse-proxy host rewriting requires a future deployment profile        |
-| cross-origin browser invocation         | any `Origin` is denied unless exactly allowlisted                                                                                         | non-browser clients have no Origin and authentication is not implemented |
-| oversized or slow request               | content-length and streamed byte bound before SDK parsing; request/header/keep-alive timeouts, connection and per-socket request ceilings | distributed rate limiting still needs a deployment edge profile          |
-| protocol parser or SDK defect           | official modular SDK pinned to 2.0.0; strict TypeScript; protocol integration tests; empty registries                                     | dependency compromise and future protocol drift remain possible          |
-| accidental operational authority        | empty tools/resources/prompts; no provider or credential modules; discovery test asserts empty lists                                      | later capability registration requires its own review                    |
-| log disclosure or injection             | closed records, server-generated correlation, no headers/body/URL/error text                                                              | stdout transport, retention, and integrity are not RFC-0004 audit        |
-| container privilege or exhaustion       | non-root user, read-only Compose filesystem, dropped capabilities, no-new-privileges, CPU/memory/PID bounds                               | base image is tag-pinned, not digest-qualified; #10 remains open         |
+| Threat | Control | Residual risk |
+| --- | --- | --- |
+| DNS rebinding or virtual-host confusion | exact host allowlist on `/mcp`; wildcard bind requires explicit configuration | reverse-proxy host rewriting requires a future deployment profile |
+| cross-origin browser invocation | any `Origin` is denied unless exactly allowlisted | non-browser clients have no Origin and authentication is not implemented |
+| oversized or slow request | content-length and streamed byte bound before SDK parsing; request/header/keep-alive timeouts, connection and per-socket request ceilings | distributed rate limiting still needs a deployment edge profile |
+| protocol parser or SDK defect | official modular SDK pinned to 2.0.0; strict TypeScript; protocol integration tests; empty registries | dependency compromise and future protocol drift remain possible |
+| accidental operational authority | empty tools/resources/prompts; no provider or credential modules; discovery test asserts empty lists | later capability registration requires its own review |
+| log disclosure or injection | closed records, server-generated correlation, no headers/body/URL/error text | stdout transport, retention, and integrity are not RFC-0004 audit |
+| container privilege or exhaustion | non-root user, read-only Compose filesystem, dropped capabilities, no-new-privileges, CPU/memory/PID bounds | base image is tag-pinned, not digest-qualified; #10 remains open |
 
 This review authorizes only the inert development skeleton. Non-loopback
 deployment, authentication, authorization integration, a real capability,
@@ -268,15 +268,15 @@ separate accepted threat-model impact review.
 - New trust boundaries: third-party workflow actions, dependency registries,
   hosted runners, code-scanning ingestion, and retained analysis artifacts
 
-| Threat                                        | Control                                                                                                           | Residual risk                                                             |
-| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| untrusted PR obtains authority                | `pull_request` only, read-only default permissions, no secrets/OIDC/publication, no persisted checkout credential | hosted runner and action compromise remain possible                       |
-| action tag or dependency substitution         | actions pinned to full SHA; npm lock and install scripts disabled; exact direct versions; automated pin test      | Python transitive dependencies and Node base image lack full digest locks |
-| vulnerable dependency enters source           | dependency review and npm audit fail at moderate severity; Dependabot coverage                                    | advisory databases can lag and malicious packages may have no advisory    |
-| vulnerable source reaches main                | always-on formatting/type/test/build/docs/container gate plus CodeQL security-extended                            | static analysis and tests are incomplete proofs                           |
-| workflow gains excess token authority         | explicit workflow/job permissions; publication separated from validation                                          | repository setting changes require periodic external audit                |
-| Scorecard or scanner publishes sensitive data | source contains no secrets; Scorecard public publishing disabled; bounded five-day SARIF artifact                 | filenames and findings remain repository-visible security metadata        |
-| unsupported release-integrity claim           | documented evidence gates; no release workflow; SBOM/signing/SLSA are roadmap only                                | issue #13 and deployment controls remain incomplete                       |
+| Threat | Control | Residual risk |
+| --- | --- | --- |
+| untrusted PR obtains authority | `pull_request` only, read-only default permissions, no secrets/OIDC/publication, no persisted checkout credential | hosted runner and action compromise remain possible |
+| action tag or dependency substitution | actions pinned to full SHA; npm lock and install scripts disabled; exact direct versions; automated pin test | Python transitive dependencies and Node base image lack full digest locks |
+| vulnerable dependency enters source | dependency review and npm audit fail at moderate severity; Dependabot coverage | advisory databases can lag and malicious packages may have no advisory |
+| vulnerable source reaches main | always-on formatting/type/test/build/docs/container gate plus CodeQL security-extended | static analysis and tests are incomplete proofs |
+| workflow gains excess token authority | explicit workflow/job permissions; publication separated from validation | repository setting changes require periodic external audit |
+| Scorecard or scanner publishes sensitive data | source contains no secrets; Scorecard public publishing disabled; bounded five-day SARIF artifact | filenames and findings remain repository-visible security metadata |
+| unsupported release-integrity claim | documented evidence gates; no release workflow; SBOM/signing/SLSA are roadmap only | issue #13 and deployment controls remain incomplete |
 
 This baseline authorizes source validation and security-analysis uploads only.
 It does not authorize package/container publication, a signing identity, release
@@ -289,14 +289,14 @@ credentials, OIDC federation, or a production release.
   authorization-enforced invocation boundary, bounded metadata result, and tests
 - New trust boundary: capability invocation to a local read-only filesystem provider
 
-| Threat                                 | Control                                                                                                             | Residual risk                                                                                           |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| traversal or absolute-path escape      | relative path grammar, canonical configured roots, containment checks before observation                            | platform path semantics require qualification on every supported OS                                     |
-| symbolic-link escape                   | every path component is inspected and any symlink is rejected; canonical target is checked again                    | filesystem replacement races remain possible without an OS-level directory-handle sandbox               |
-| authorization bypass                   | malformed requests fail before authorization; denied requests record zero provider attempts                         | the injected authorizer is not yet connected to an authenticated transport or durable decision enforcer |
-| malicious or oversized provider output | closed runtime schema, 4 KiB serialized bound, invalid output withheld as `provider_protocol_error`                 | metadata such as requested relative paths may still be sensitive in a deployment-specific root          |
-| content or credential disclosure       | capability returns file type, size, modification time, source, and freshness only; no contents or directory listing | file names supplied by an authorized caller remain visible in its own result                            |
-| accidental public authority            | inert MCP discovery remains empty and no provider configuration is loaded by the listener                           | a future MCP binding requires identity, policy, configuration, and audit review                         |
+| Threat | Control | Residual risk |
+| --- | --- | --- |
+| traversal or absolute-path escape | relative path grammar, canonical configured roots, containment checks before observation | platform path semantics require qualification on every supported OS |
+| symbolic-link escape | every path component is inspected and any symlink is rejected; canonical target is checked again | filesystem replacement races remain possible without an OS-level directory-handle sandbox |
+| authorization bypass | malformed requests fail before authorization; denied requests record zero provider attempts | the injected authorizer is not yet connected to an authenticated transport or durable decision enforcer |
+| malicious or oversized provider output | closed runtime schema, 4 KiB serialized bound, invalid output withheld as `provider_protocol_error` | metadata such as requested relative paths may still be sensitive in a deployment-specific root |
+| content or credential disclosure | capability returns file type, size, modification time, source, and freshness only; no contents or directory listing | file names supplied by an authorized caller remain visible in its own result |
+| accidental public authority | inert MCP discovery remains empty and no provider configuration is loaded by the listener | a future MCP binding requires identity, policy, configuration, and audit review |
 
 This review authorizes the network-free experimental provider boundary and its
 tests only. It does not authorize MCP exposure, production roots, credentials,
@@ -331,14 +331,14 @@ identity, policy, audit-writer, and deployment profiles.
 - New live trust boundary: none; the driver is not connected to the gateway or
   to a transport
 
-| Threat                                                           | Control                                                                                                                                                  | Residual risk / dependency                                                                       |
-| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| malformed or substituted coordination receipt advances lifecycle | strict closed schemas plus exact operation and binding-digest checks                                                                                     | the future canonical digest implementation must be reviewed against the stable upstream contract |
-| stale lease is treated as current                                | expiry is checked against an injected trusted clock and equality is stale                                                                                | clock source and skew policy remain deployment-specific                                          |
-| dependency detail leaks through errors                           | all driver exceptions and timeouts normalize to one bounded code                                                                                         | future observability must retain the closed error surface                                        |
-| hidden retry duplicates nonce or lease operations                | the consumer performs one bounded driver call and never retries                                                                                          | a future transport adapter must prove it does not retry, redirect, or poll internally            |
-| nonce or sealed lease handle enters evidence                     | sensitive values are absent from receipts intended for evidence and explicitly forbidden from logs, audit, errors, model context, and repository context | future adapter memory handling and crash diagnostics require review                              |
-| Coordination implementation becomes coupled into MCP             | only an MCP-owned port and fake driver exist; no source, bundle, client, schema, or transport is imported                                                | compatibility cannot be claimed until PR #71 merges and an adapter is separately reviewed        |
+| Threat | Control | Residual risk / dependency |
+| --- | --- | --- |
+| malformed or substituted coordination receipt advances lifecycle | strict closed schemas plus exact operation and binding-digest checks | the future canonical digest implementation must be reviewed against the stable upstream contract |
+| stale lease is treated as current | expiry is checked against an injected trusted clock and equality is stale | clock source and skew policy remain deployment-specific |
+| dependency detail leaks through errors | all driver exceptions and timeouts normalize to one bounded code | future observability must retain the closed error surface |
+| hidden retry duplicates nonce or lease operations | the consumer performs one bounded driver call and never retries | a future transport adapter must prove it does not retry, redirect, or poll internally |
+| nonce or sealed lease handle enters evidence | sensitive values are absent from receipts intended for evidence and explicitly forbidden from logs, audit, errors, model context, and repository context | future adapter memory handling and crash diagnostics require review |
+| Coordination implementation becomes coupled into MCP | only an MCP-owned port and fake driver exist; no source, bundle, client, schema, or transport is imported | compatibility cannot be claimed until PR #71 merges and an adapter is separately reviewed |
 
 This review authorizes only the inert consumer contract. It does not authorize
 an HTTP adapter, Coordination client import, endpoint, credential,
@@ -354,14 +354,14 @@ provider invocation, mutation, deployment, or release claim.
 - New implementation trust boundaries: MCP to request authenticator; MCP across TLS to
   untrusted Coordination framing and responses
 
-| Threat                                                              | Accepted control                                                                                                                          | Residual risk / dependency                                                          |
-| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| lifecycle binding is substituted or narrowed                        | one canonical MCP scope digest covers subject, capability, resources, environment, plan, approval, operation, expiry and epoch            | canonical vectors require review before implementation                              |
-| attacker redirects requests or abuses ambient network configuration | exact HTTPS base URI and fixed routes; redirects, proxy discovery and caller-selected targets forbidden                                   | DNS and TLS trust remain deployment-specific                                        |
-| credential or lease capability leaks                                | explicit bounded authenticator, private redacted capability wrapper, closed errors and no raw-body diagnostics                            | concrete key custody and runtime memory handling need deployment review             |
-| timeout causes unsafe replay                                        | one bounded request, abort once, no retry; ambiguous outcomes deny and require lifecycle reconciliation                                   | availability loss can stop protected operations                                     |
-| malformed response becomes authority                                | independent closed response validation and route-specific outcomes; transport success never implies MCP authorization or provider success | upstream compatibility drift requires immutable re-review                           |
-| copied client couples trust domains                                 | platform APIs and public wire contract only; no upstream source, bundle, schema or client import                                          | independent implementation may contain semantic defects requiring conformance tests |
+| Threat | Accepted control | Residual risk / dependency |
+| --- | --- | --- |
+| lifecycle binding is substituted or narrowed | one canonical MCP scope digest covers subject, capability, resources, environment, plan, approval, operation, expiry and epoch | canonical vectors require review before implementation |
+| attacker redirects requests or abuses ambient network configuration | exact HTTPS base URI and fixed routes; redirects, proxy discovery and caller-selected targets forbidden | DNS and TLS trust remain deployment-specific |
+| credential or lease capability leaks | explicit bounded authenticator, private redacted capability wrapper, closed errors and no raw-body diagnostics | concrete key custody and runtime memory handling need deployment review |
+| timeout causes unsafe replay | one bounded request, abort once, no retry; ambiguous outcomes deny and require lifecycle reconciliation | availability loss can stop protected operations |
+| malformed response becomes authority | independent closed response validation and route-specific outcomes; transport success never implies MCP authorization or provider success | upstream compatibility drift requires immutable re-review |
+| copied client couples trust domains | platform APIs and public wire contract only; no upstream source, bundle, schema or client import | independent implementation may contain semantic defects requiring conformance tests |
 
 Coordination RFC-0021, merged in PR #85 at
 `91c1e5097e47026f63c34126a379949833bb7e00`, resolves acquisition contention as
@@ -404,15 +404,15 @@ public listener or live apply is authorized.
   descriptor-delivered short-lived DPoP credential/key and synthetic-only real
   staging qualification
 
-| Threat                                | Proposed control                                                                                                                | Residual risk / dependency                                                          |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| endpoint or trust substitution        | exact HTTPS origin/server name, explicit private CA, dedicated verified Node HTTPS agent, no proxy/system-root fallback         | staging CA or supervisor compromise can still redirect the consumer                 |
-| credential or signing-key disclosure  | separate inherited descriptors, bounded one-time reads, redacted wrappers, source-buffer zeroing and 15-minute maximum lifetime | plaintext exists in process memory and host compromise defeats this staging control |
-| proof replay or target confusion      | fresh ES256 DPoP with exact `htu`/`htm`/`ath`, expected thumbprint and server-side durable replay reservation                   | server replay-store availability is an upstream dependency                          |
-| hidden network retry after ambiguity  | one fixed request under the adapter deadline, keep-alive off, no redirect/retry/polling                                         | ambiguous remote state requires explicit lifecycle reconciliation                   |
-| remote success elevates MCP authority | qualification runner is separate from gateway/provider paths and uses synthetic bindings only                                   | later gateway wiring still requires identity, policy, audit and provider reviews    |
-| secret-bearing diagnostics            | closed error/output schemas omit endpoint, TLS, credential, proof, key, capability, body and upstream text                      | process/core-dump controls remain deployment-specific                               |
-| accidental activation                 | no defaults or environment activation; explicit profile entry point is the kill switch                                          | supervisor control of process arguments remains trusted for staging activation      |
+| Threat | Proposed control | Residual risk / dependency |
+| --- | --- | --- |
+| endpoint or trust substitution | exact HTTPS origin/server name, explicit private CA, dedicated verified Node HTTPS agent, no proxy/system-root fallback | staging CA or supervisor compromise can still redirect the consumer |
+| credential or signing-key disclosure | separate inherited descriptors, bounded one-time reads, redacted wrappers, source-buffer zeroing and 15-minute maximum lifetime | plaintext exists in process memory and host compromise defeats this staging control |
+| proof replay or target confusion | fresh ES256 DPoP with exact `htu`/`htm`/`ath`, expected thumbprint and server-side durable replay reservation | server replay-store availability is an upstream dependency |
+| hidden network retry after ambiguity | one fixed request under the adapter deadline, keep-alive off, no redirect/retry/polling | ambiguous remote state requires explicit lifecycle reconciliation |
+| remote success elevates MCP authority | qualification runner is separate from gateway/provider paths and uses synthetic bindings only | later gateway wiring still requires identity, policy, audit and provider reviews |
+| secret-bearing diagnostics | closed error/output schemas omit endpoint, TLS, credential, proof, key, capability, body and upstream text | process/core-dump controls remain deployment-specific |
+| accidental activation | no defaults or environment activation; explicit profile entry point is the kill switch | supervisor control of process arguments remains trusted for staging activation |
 
 Acceptance would authorize only implementation and hermetic interoperability
 qualification after upstream RFC acceptance. Endpoint configuration,

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -396,15 +396,15 @@ production trust, DNS, identity, key custody, or endpoint configuration. No real
 endpoint, credential, gateway wiring, provider execution, mutation, deployment,
 public listener or live apply is authorized.
 
-## Proposed private staging Coordination connection — 2026-08-03
+## Accepted private staging Coordination connection — 2026-08-03
 
 - Governing issue: #50
-- Proposed architecture: RFC-0006 and upstream Coordination RFC-0022
+- Accepted architecture: RFC-0006 and upstream Coordination RFC-0022
 - Scope: disabled-by-default direct TLS transport, explicit private trust,
   descriptor-delivered short-lived DPoP credential/key and synthetic-only real
   staging qualification
 
-| Threat | Proposed control | Residual risk / dependency |
+| Threat | Accepted control | Residual risk / dependency |
 | --- | --- | --- |
 | endpoint or trust substitution | exact HTTPS origin/server name, explicit private CA, dedicated verified Node HTTPS agent, no proxy/system-root fallback | staging CA or supervisor compromise can still redirect the consumer |
 | credential or signing-key disclosure | separate inherited descriptors, bounded one-time reads, redacted wrappers, source-buffer zeroing and 15-minute maximum lifetime | plaintext exists in process memory and host compromise defeats this staging control |
@@ -414,7 +414,7 @@ public listener or live apply is authorized.
 | secret-bearing diagnostics | closed error/output schemas omit endpoint, TLS, credential, proof, key, capability, body and upstream text | process/core-dump controls remain deployment-specific |
 | accidental activation | no defaults or environment activation; explicit profile entry point is the kill switch | supervisor control of process arguments remains trusted for staging activation |
 
-Acceptance would authorize only implementation and hermetic interoperability
-qualification after upstream RFC acceptance. Endpoint configuration,
-provisioning, credential minting, live requests, gateway wiring, provider
-execution, mutation, deployment and production use remain separately gated.
+RFC-0006 authorizes only implementation and hermetic interoperability
+qualification. Endpoint configuration, provisioning, credential minting, live
+requests, gateway wiring, provider execution, mutation, deployment and
+production use remain separately gated.


### PR DESCRIPTION
## Proposal

- adds draft RFC-0006 for a disabled-by-default real private staging Coordination connection
- selects explicit private TLS trust and a dedicated Node HTTPS transport with no ambient proxy or system-root fallback
- defines short-lived token and P-256 DPoP key delivery through inherited descriptors
- freezes strict DPoP proof generation, readiness, redaction and kill-switch behavior
- defines hermetic interoperability and separately approved live staging qualification gates
- updates the architecture, threat model and durable session record

## Why

The independent adapter is merged and synthetically TLS-qualified, but concrete endpoint trust, credential custody, proof signing and real transport remain deliberately absent. This proposal defines the MCP consumer half and depends on the server profile proposed in `nomed/yukh-coordination#90`.

## Validation

- `npm run format:check`
- focused Prettier check for changed documentation
- `npm run typecheck`
- `npm test` (50 contract/supply-chain and 24 runtime tests)
- `npm run build`
- `git diff --check`

## Authorization boundary

This PR is design-only. Acceptance would authorize implementation and hermetic qualification after upstream RFC acceptance. It does not authorize an endpoint, trust root, credential, provisioning, live request, gateway wiring, provider execution, mutation, deployment or production use.

Refs #50
Depends on nomed/yukh-coordination#90
