### PR TITLE
Make MCP documentation task-first

### DIFF
--- a/.context/sessions/SESSION-2026-08-03-16-task-first-documentation.md
+++ b/.context/sessions/SESSION-2026-08-03-16-task-first-documentation.md
@@ -1,7 +1,7 @@
 # SESSION-2026-08-03-16 — Task-first documentation
 
 - Governing issue: https://github.com/nomed/yukh-mcp/issues/52
-- Pull request: pending
+- Pull request: https://github.com/nomed/yukh-mcp/pull/53
 - Status: implementation complete
 
 ## Objective

--- a/.context/sessions/SESSION-2026-08-03-16-task-first-documentation.md
+++ b/.context/sessions/SESSION-2026-08-03-16-task-first-documentation.md
@@ -1,0 +1,50 @@
+# SESSION-2026-08-03-16 — Task-first documentation
+
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/52
+- Pull request: pending
+- Status: implementation complete
+
+## Objective
+
+Make the public documentation concise, task-first, and explicit about the
+foundation boundary. Remove Mermaid and use SVG only where a diagram improves
+the architecture explanation.
+
+## Work completed
+
+- Reorganized navigation into Tutorial, How-to, Reference, and Explanation.
+- Put the runnable synthetic demo and its two commands on the landing page.
+- Added expected output checks and a focused inert-gateway how-to.
+- Added a compact contract reference linking decisions to implementations.
+- Removed Mermaid configuration and replaced the architecture flow with one
+  accessible SVG.
+- Reduced repeated product, charter, and architecture copy.
+- Added documentation regression tests.
+
+## Evidence and validation
+
+- `npm run demo`
+- `mkdocs build --strict`
+- `npm run format:check`
+- `npm run typecheck`
+- `npm test`
+- `npm run build`
+- `npm audit --audit-level=moderate`
+
+All completed successfully. The demo proved one allowed and one denied
+`node.inspect` request; the denial recorded zero provider attempts.
+
+## Decisions discovered
+
+No architecture or security decision changed. Accepted RFCs remain canonical;
+reader documentation links to them instead of reproducing them.
+
+## Context impact
+
+This session records documentation delivery evidence only. It changes no trust
+boundary, capability, provider, deployment, release, or maturity claim.
+
+## Risks and unresolved work
+
+The documentation site remains foundation-only. Production installation and
+deployment guidance remain intentionally absent.

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 dist/
 coverage/
+site/
 *.log

--- a/README.md
+++ b/README.md
@@ -8,56 +8,38 @@
 
 > **Give agents capability, not custody.**
 
-Yukh MCP is an open-source, policy-governed capability gateway for safe, auditable, and verifiable AI operations.
+Yukh MCP is a policy-governed capability gateway for bounded AI operations.
 
-It is designed around a strict lifecycle:
+## Try the supported demo
 
-```text
-intent → capability → policy → plan → approval → execution → verification → audit
+Requires Node.js 22 or newer:
+
+```sh
+npm ci --ignore-scripts
+npm run demo
 ```
 
-Yukh MCP does not aim to be an unrestricted remote shell broker. It exposes typed capabilities, evaluates explicit policy, plans mutations before execution, verifies outcomes, and produces structured evidence.
+The demo runs locally with synthetic data and no credentials. It discovers
+`node.inspect`, shows one allowed read, one denied read, and the resulting
+in-memory evidence.
+
+[Follow the tutorial](https://nomed.github.io/yukh-mcp/guides/read-only-demo/)
+· [Read the documentation](https://nomed.github.io/yukh-mcp/)
 
 ## Status
 
-Yukh MCP is in its foundation phase. Public contracts and security boundaries are being designed in the open before operational capabilities are implemented.
+**Foundation; not production-ready.** The ordinary gateway is inert: it exposes
+no operational tools, providers, credentials, persistence, or mutation path.
+Only the synthetic local demo exposes `node.inspect`.
 
-The versioned capability contract is governed by accepted
-[RFC-0001](.context/rfcs/RFC-0001-versioned-capability-contract.md). Its
-[network-free reference package](contracts/capability/v1/README.md) validates
-synthetic contract records without exposing a provider or MCP runtime.
+Accepted contracts and their executable, network-free reference packages:
 
-The deny-by-default authorization contract is governed by accepted
-[RFC-0002](.context/rfcs/RFC-0002-deny-by-default-authorization.md). Its
-[network-free reference package](contracts/authorization/v1/README.md) binds
-policy evaluation to the exact request, combines deny-overrides deterministically,
-and rejects decision replay without implementing identity, policy, or provider
-integrations.
+- [capability contract](contracts/capability/v1/README.md);
+- [deny-by-default authorization](contracts/authorization/v1/README.md).
 
-The [inert runtime skeleton](docs/architecture/runtime-skeleton.md) initializes
-the official MCP Streamable HTTP transport and supports empty capability
-discovery. It exposes no operational tool, resource, prompt, provider, or
-credential path.
-
-## Principles
-
-- Capability, not custody.
-- Deny by default.
-- No mutation without a plan.
-- No success without verification.
-- Structured evidence over opaque output.
-- Security decisions are public and reviewable.
-- Vendor-neutral MCP interoperability.
-
-The [project charter](docs/concepts/project-charter.md) defines these principles
-operationally, identifies the intended audience and use cases, and supplies the
-review questions and terminology used to keep the boundary testable.
-
-## Project
-
-Work is coordinated through [GitHub Issues](https://github.com/nomed/yukh-mcp/issues) and the [Yukh project](https://github.com/users/nomed/projects/5).
-
-Documentation source lives under `docs/` and will be published with GitHub Pages.
+The complete lifecycle is `intent → capability → policy → plan → approval →
+execution → verification → audit`. See the [architecture](https://nomed.github.io/yukh-mcp/architecture/overview/)
+and [contract reference](https://nomed.github.io/yukh-mcp/reference/contracts/).
 
 ## Security
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,54 +1,32 @@
 # Architecture
 
-Yukh MCP separates reasoning, authorization, execution, and evidence.
+Yukh MCP keeps client intent, policy, provider authority, and evidence in
+separate boundaries.
 
-```mermaid
-flowchart TD
-    A["MCP client"] --> B["Yukh gateway"]
-    B --> C["Identity and policy"]
-    C --> D["Capability planner"]
-    D --> E["Approval boundary"]
-    E --> F["Capability provider"]
-    F --> G["Target node"]
-    F --> H["Verification"]
-    H --> I["Audit evidence"]
-```
+![Yukh MCP boundaries: client intent enters the gateway, policy gates a typed provider operation, and verification produces evidence.](../assets/architecture-boundaries.svg)
 
 ## Boundaries
 
-- The MCP client proposes intent; it is not an authorization authority.
-- The gateway authenticates the caller and evaluates policy.
-- Providers translate typed capabilities into target-specific operations.
-- Credentials remain behind the execution boundary.
-- Verification evaluates declared postconditions.
-- Audit records are structured, redacted, and tamper-evident by design.
+- **Client:** proposes intent; never supplies execution authority.
+- **Gateway:** validates the capability and enforces identity and policy.
+- **Provider:** holds bounded target authority; credentials stay here.
+- **Verifier:** evaluates declared postconditions independently from execution.
+- **Evidence:** records decisions and outcomes in closed, redacted structures.
 
-The architecture remains under public RFC review during foundation.
+Mutations add a bound plan and approval between policy and provider invocation.
+The current public demo is read-only.
 
 ## Inert coordination consumer port
 
-The MCP-owned coordination consumer contract is a provider-neutral application
-port for the nonce-consumption and fenced-lease semantics required by the
-accepted lifecycle RFCs. It validates closed, bounded requests and treats every
-driver response as untrusted. Unknown versions or fields, binding substitution,
-stale leases, timeout, and dependency failure stop progression without retry.
+The Coordination consumer port supports nonce consumption and fenced leases
+required by accepted mutation lifecycle contracts. It treats every response as
+untrusted and stops on invalid data, stale state, timeout, or dependency failure.
 
-The port selects no protocol, endpoint, credential, deployment, or upstream
-implementation. Its current driver is exercised only by network-free fakes and
-is not wired into the gateway. Nonces and lease handles are sensitive runtime
-material: they must never enter logs, audit evidence, errors, model context, or
-durable repository context.
+The reviewed HTTPS adapter is qualified only against synthetic loopback TLS. It
+is not wired into the gateway and has no real endpoint or credential. Nonces
+and lease handles never enter logs, evidence, errors, model context, or the
+repository.
 
-RFC-0005 now governs an MCP-native adapter implementation behind this port. The
-adapter uses fixed Coordination primitives v1 routes, exact lifecycle-derived
-digests, explicit authentication and an injected fetch-compatible transport.
-It is merged and qualified over verified synthetic loopback TLS, and remains
-disconnected from the gateway.
-
-Issue #50 and accepted RFC-0006 govern the first disabled-by-default real
-staging connection. It depends on accepted Coordination RFC-0022 under
-`nomed/yukh-coordination#90`, uses explicit private trust and short-lived DPoP
-material, and permits only a synthetic qualification runner. Until both RFCs
-are separately implemented and hermetically qualified, no endpoint, credential,
-real request, gateway wiring, provider execution, mutation or live apply is
-authorized.
+RFC-0005 governs the adapter. RFC-0006 and issue #50 govern the first
+disabled-by-default staging qualification. They authorize no production
+endpoint, gateway wiring, provider execution, mutation, or live apply.

--- a/docs/architecture/runtime-skeleton.md
+++ b/docs/architecture/runtime-skeleton.md
@@ -50,23 +50,7 @@ messages, stack traces, client identity, and MCP payloads are excluded.
 These logs are operational diagnostics, not RFC-0004 protected audit evidence.
 No audit durability or integrity claim is made.
 
-## Local use
-
-```sh
-npm ci --ignore-scripts
-npm run typecheck
-npm test
-npm run build
-npm start
-```
-
-The Compose path publishes only to host loopback and applies a read-only root
-filesystem, non-root runtime user, dropped Linux capabilities, no-new-privileges,
-and CPU, memory, PID, and temporary-filesystem bounds:
-
-```sh
-docker compose up --build
-```
+For local commands, use [Run the inert gateway](../how-to/run-inert-gateway.md).
 
 The base-image tag is version-pinned but not digest-pinned. Image provenance,
 digest selection, SBOM, signing, and release qualification remain governed by

--- a/docs/assets/architecture-boundaries.svg
+++ b/docs/assets/architecture-boundaries.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 390" role="img" aria-labelledby="title desc">
+  <title id="title">Yukh MCP authority boundaries</title>
+  <desc id="desc">Client intent enters the gateway. Identity and policy gate a typed provider operation. The provider reaches the target without exposing credentials. Verification produces structured evidence.</desc>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="5" orient="auto">
+      <path d="M0 0 10 5 0 10Z" fill="#7C3AED"/>
+    </marker>
+    <style>
+      .box{fill:#fff;stroke:#18181b;stroke-width:2}.gate{fill:#f3e8ff;stroke:#7c3aed;stroke-width:3}.label{font:600 22px system-ui,sans-serif;fill:#18181b}.note{font:16px system-ui,sans-serif;fill:#52525b}.flow{fill:none;stroke:#7c3aed;stroke-width:4;marker-end:url(#arrow)}
+    </style>
+  </defs>
+  <rect width="1200" height="390" rx="24" fill="#fafafa"/>
+  <rect class="box" x="35" y="80" width="190" height="110" rx="14"/>
+  <text class="label" x="130" y="125" text-anchor="middle">MCP client</text>
+  <text class="note" x="130" y="155" text-anchor="middle">intent only</text>
+  <rect class="gate" x="285" y="45" width="250" height="180" rx="14"/>
+  <text class="label" x="410" y="105" text-anchor="middle">Yukh gateway</text>
+  <text class="note" x="410" y="140" text-anchor="middle">identity + policy</text>
+  <text class="note" x="410" y="170" text-anchor="middle">typed capability</text>
+  <rect class="box" x="595" y="80" width="210" height="110" rx="14"/>
+  <text class="label" x="700" y="125" text-anchor="middle">Provider</text>
+  <text class="note" x="700" y="155" text-anchor="middle">holds credentials</text>
+  <rect class="box" x="865" y="80" width="210" height="110" rx="14"/>
+  <text class="label" x="970" y="125" text-anchor="middle">Target</text>
+  <text class="note" x="970" y="155" text-anchor="middle">bounded resource</text>
+  <rect class="box" x="595" y="270" width="210" height="85" rx="14"/>
+  <text class="label" x="700" y="307" text-anchor="middle">Verification</text>
+  <text class="note" x="700" y="335" text-anchor="middle">postconditions</text>
+  <rect class="box" x="865" y="270" width="210" height="85" rx="14"/>
+  <text class="label" x="970" y="307" text-anchor="middle">Evidence</text>
+  <text class="note" x="970" y="335" text-anchor="middle">closed + redacted</text>
+  <path class="flow" d="M225 135H275"/>
+  <path class="flow" d="M535 135H585"/>
+  <path class="flow" d="M805 135H855"/>
+  <path class="flow" d="M970 200V250H815"/>
+  <path class="flow" d="M805 312H855"/>
+</svg>

--- a/docs/concepts/project-charter.md
+++ b/docs/concepts/project-charter.md
@@ -1,128 +1,79 @@
 # Project charter
 
-Yukh MCP gives agents governed capability without giving them custody of
-credentials, unrestricted command execution, or infrastructure control.
-
 ## Mission
 
-Build a secure, vendor-neutral MCP gateway through which an authenticated
-subject can request a typed operation against an explicitly scoped resource and
-environment. The gateway evaluates policy, keeps credentials behind the
-execution boundary, and returns structured evidence of the decision and the
-verified outcome.
+Give an authenticated subject a typed, policy-governed capability for one
+explicit resource and environment. Keep credentials behind the provider
+boundary and return structured evidence of the decision and verified outcome.
 
-"Capability, not custody" is an operational boundary:
-
-- the client selects only a published, versioned capability and supplies input
-  that passes its schema;
-- the server independently binds subject, action, resource, environment, and
-  current policy before a provider is invoked;
-- credentials and provider authority remain outside model context;
-- a mutation is represented by an inspectable plan before approval or apply;
-- approval is bound to the exact plan and target, not to a reusable prompt;
-- success requires declared verification evidence, not merely a successful
-  process exit;
-- decisions and results produce structured, redacted audit evidence.
-
-Authentication alone never grants a capability. Missing, uncertain, invalid,
+Authentication never grants a capability. Missing, invalid, uncertain, stale,
 or unavailable authorization information resolves to deny.
 
-## Audience
+## Scope
 
-Yukh MCP is intended for:
+Foundation proves four bounded behaviors:
 
-- operators who need to let agents inspect or change bounded resources without
-  disclosing infrastructure credentials;
-- platform teams that need one policy and evidence boundary across multiple
-  vendors or execution providers;
-- capability authors who need typed, versioned contracts with explicit risk,
-  retry, verification, and rollback semantics;
-- auditors and reviewers who need to reconstruct what was requested, allowed,
-  executed, and verified without retaining raw prompts or secrets.
+1. discover an allowed capability;
+2. inspect a configured local node through `node.inspect`;
+3. deny an unauthorized resource before provider invocation;
+4. correlate request, decision, result, verification, and redacted evidence.
 
-## Primary use cases
+Yukh MCP is not a shell broker, credential vault, orchestrator, project tracker,
+coordination relay, or conversational approval mechanism.
 
-The Foundation milestone covers only production-shaped, bounded behavior:
+## Operating rules
 
-1. Discover the capabilities authorized for a subject and environment.
-2. Inspect a configured local node through a typed, read-only provider.
-3. Observe a deterministic denial for an unauthorized or out-of-scope request.
-4. Correlate the request, policy decision, provider result, and verification
-   evidence without exposing credentials or sensitive output.
+- Clients select only published, versioned capabilities.
+- The server binds subject, action, resource, environment, and current policy.
+- Providers receive bounded authority; clients never receive credentials.
+- Mutations require an inspectable plan and any plan-bound approval.
+- Verification checks declared postconditions independently from execution.
+- Evidence is structured and redacted; raw prompts and secrets are excluded.
 
-Later milestones may introduce bounded mutations, remote-node providers, and a
-provider SDK only after their contracts, trust boundaries, and failure semantics
-have been reviewed.
+## Design gate
 
-## Non-goals
+Every public capability or boundary change must pass these questions:
 
-Yukh MCP is not:
-
-- an unrestricted shell, command proxy, or generic remote administration
-  surface;
-- a credential vault exposed to models or prompts;
-- a replacement for configuration management, orchestration, or provider-native
-  control planes;
-- a system in which authentication implies authorization;
-- an approval mechanism implemented only through conversational consent;
-- an agent supervisor, task scheduler, project tracker, or coordination relay;
-- a system that equates provider acceptance or exit code zero with verified
-  success.
-
-## Design-review principles
-
-Every proposed public capability or boundary change must answer these questions.
-A negative or unproven answer blocks acceptance.
-
-| Principle | Review question |
+| Requirement | Acceptance question |
 | --- | --- |
-| Capability, not custody | Can the operation be invoked without exposing credentials or accepting unrestricted command text? |
-| Deny by default | Are subject, action, resource, environment, and policy evaluated server-side, with uncertainty resolving to deny? |
-| Typed and bounded | Are input, output, scope, time, resource use, and failure behavior explicitly bounded? |
-| Plan before mutation | Is every prospective effect represented by an immutable, inspectable plan before apply? |
-| Approval is specific | Is required approval bound to the exact identity, plan, target, policy decision, and validity window? |
-| Verify the outcome | Are postconditions declared and evaluated independently from execution success? |
-| Safe failure | Are retries, idempotency, partial failure, rollback, and destructive-operation stop conditions explicit? |
-| Evidence without secrets | Can an investigation correlate intent, decision, execution, and verification using redacted structured records? |
-| Vendor neutrality | Does the public contract describe domain behavior without leaking provider-specific authority into clients? |
-| Reviewable evolution | Does a public-contract or trust-boundary change have the required RFC and threat-model update? |
+| Capability, not custody | Does the operation avoid credentials and unrestricted command text? |
+| Deny by default | Does uncertainty stop before provider invocation? |
+| Typed and bounded | Are input, output, scope, time, retries, and failures explicit? |
+| Plan before mutation | Are effects and preconditions inspectable before apply? |
+| Specific approval | Is approval bound to the exact plan, identity, target, and policy? |
+| Verification | Are postconditions distinct from execution success? |
+| Safe failure | Are partial effects, retry, rollback, and stop conditions explicit? |
+| Redacted evidence | Can an investigation proceed without prompts or secrets? |
+| Vendor neutrality | Does the public contract avoid provider-specific authority? |
+| Reviewable evolution | Do trust-boundary changes have an RFC and threat review? |
+
+An unproven answer blocks acceptance.
 
 ## Terms
 
 **Capability**
-: A named, versioned, typed operation with explicit scope, risk, mutation,
-  policy, timeout, retry, verification, and rollback semantics.
+: A named, versioned operation with typed input, output, scope, risk, timeout,
+  retry, verification, and rollback semantics.
 
 **Provider**
 : A server-side adapter that translates an authorized capability into bounded
-  target-specific operations. A provider does not decide authorization.
-
-**Node**
-: A resource endpoint that a provider may inspect or operate on within an
-  explicitly configured scope. A node is not implicitly trusted or authorized.
+  target operations. It does not decide authorization.
 
 **Plan**
-: An immutable description of intended effects, preconditions, target, policy
-  binding, validity window, verification requirements, and applicable rollback
-  behavior.
+: An immutable description of intended effects, preconditions, bindings,
+  validity, verification, and rollback behavior.
 
 **Approval**
-: An explicit authorization to apply one exact plan under its bound identity,
-  target, policy decision, and validity conditions. It is not transferable or
-  replayable.
+: Permission to apply one exact plan. It is neither transferable nor replayable.
 
 **Verification**
-: Evaluation of declared postconditions using evidence distinct from the fact
-  that execution was attempted or accepted.
+: Evaluation of declared postconditions, separate from execution success.
 
 **Evidence**
-: Structured, correlated, redacted records that explain the request, decision,
-  plan, execution result, and verification result without retaining secrets or
-  raw private reasoning.
+: Correlated, redacted records of request, decision, execution, and verification.
 
-## Relationship to the Yukh system
+## Yukh boundary
 
-Yukh MCP governs operational capabilities. Yukh Projects reconciles roadmap and
-delivery state. Yukh Coordination makes cross-session work legible. They may
-integrate through explicit contracts, but none owns the others and neither
-project state nor coordination statements grant execution authority.
+Yukh MCP governs operational capability. Yukh Projects owns durable delivery
+state. Yukh Coordination carries non-authoritative work signals. Neither
+project state nor coordination messages grant execution authority.

--- a/docs/concepts/why-yukh.md
+++ b/docs/concepts/why-yukh.md
@@ -1,22 +1,22 @@
-# Why Yukh
+# Why Yukh MCP
 
-Most remote-operation MCP servers expose command execution. That approach gives a model syntax-level power while leaving policy, intent, verification, and evidence to prompts.
+Generic command execution gives a model broad syntax-level power. Prompts then
+carry responsibilities that belong at the server boundary: authorization,
+scope, approval, verification, and evidence.
 
-Yukh MCP takes a different position:
+Yukh MCP exposes a smaller interface:
 
-> An agent receives a governed capability, not custody of credentials or infrastructure.
+- a named, versioned capability;
+- typed input and output;
+- an exact subject, resource, environment, and policy binding;
+- server-side provider authority;
+- explicit verification and redacted evidence.
 
-A capability is typed, versioned, scoped to resources and environments, evaluated by policy, and paired with evidence. Mutations follow plan, approval, apply, verification, and rollback semantics.
+For mutations, the server adds a bound plan and any required approval before
+apply. Execution success alone is never verification.
 
-The [project charter](project-charter.md) turns this position into explicit
-audience, scope, terminology, and design-review criteria.
+This boundary makes clients replaceable and keeps credentials outside model
+context. It does not make Yukh MCP an orchestrator, project tracker, or agent
+supervisor.
 
-## Non-goals
-
-Yukh MCP is not:
-
-- an unrestricted remote shell broker;
-- a replacement for configuration management or orchestration systems;
-- a credential vault exposed to models;
-- an approval mechanism implemented only in prompts;
-- a system that treats successful process termination as verified intent.
+See the [project charter](project-charter.md) for formal scope and terminology.

--- a/docs/guides/read-only-demo.md
+++ b/docs/guides/read-only-demo.md
@@ -1,21 +1,46 @@
-# Five-minute read-only demo
+# Run the read-only demo
 
-This synthetic demo proves the Yukh flow without credentials, elevated
-privileges, production targets, or persistent state.
+Use this tutorial to see capability discovery, allow, deny, verification, and
+evidence in one local run.
 
-From a clean checkout with Node.js 22 or newer:
+## Prerequisites
+
+- Node.js 22 or newer;
+- a local checkout of `nomed/yukh-mcp`.
+
+No token, service, container, or configuration is required.
+
+## Run it
 
 ```sh
 npm ci --ignore-scripts
 npm run demo
 ```
 
-The command starts a loopback gateway on an ephemeral port, connects an MCP
-client, discovers `node.inspect`, performs one explicitly allowed read and one
-explicitly denied read, prints structured results and sanitized evidence, then
-removes its temporary fixture and stops the gateway.
+The process exits by itself. In the JSON output, check these fields:
 
-The output is labelled `synthetic_local_demo`. Its evidence projection is
-classified `protected` and marked `in_memory_demo_only`: it demonstrates
-structure and correlation but is not a durable RFC-0004 audit record. The
-ordinary gateway remains inert and exposes no operational tools.
+```text
+mode: synthetic_local_demo
+discovery.tools: [node.inspect]
+allowed.structuredContent.result.status: succeeded
+allowed.structuredContent.result.verification.status: verified
+denied.structuredContent.result.status: denied
+denied.structuredContent.result.attempts: 0
+evidence_projection[*].durability: in_memory_demo_only
+```
+
+The allowed request reads metadata from a temporary fixture. The denied request
+never invokes the provider (`attempts: 0`). Cleanup runs before exit.
+
+## What this proves
+
+- MCP discovery can expose one reviewed capability;
+- authorization is enforced before provider invocation;
+- results and denials use closed structured records;
+- verification and evidence are separate from execution.
+
+## What it does not prove
+
+The demo is not an installation profile. It uses no production identity,
+policy service, credential, target, or durable audit store. The ordinary
+gateway remains inert.

--- a/docs/how-to/run-inert-gateway.md
+++ b/docs/how-to/run-inert-gateway.md
@@ -1,0 +1,42 @@
+# Run the inert gateway
+
+Use this process to inspect the MCP transport and health surface. It publishes
+no tools, resources, prompts, providers, or credentials.
+
+## Node.js
+
+Requires Node.js 22 or newer:
+
+```sh
+npm ci --ignore-scripts
+npm run build
+npm start
+```
+
+In another terminal:
+
+```sh
+curl --fail http://127.0.0.1:3000/healthz
+curl --fail http://127.0.0.1:3000/readyz
+```
+
+Stop the process with `Ctrl-C`.
+
+## Container
+
+```sh
+docker compose up --build
+```
+
+The container binds to host loopback and uses a read-only root filesystem,
+non-root user, dropped Linux capabilities, resource limits, and
+`no-new-privileges`. Stop it with `Ctrl-C`.
+
+## Do not expose it
+
+This is a development skeleton, not a deployment profile. It has no
+authentication adapter, operational capability, durable audit store, or
+production security claim.
+
+See [Runtime surface](../architecture/runtime-skeleton.md) for routes and
+configuration.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,41 +3,49 @@ title: Yukh MCP
 description: A zero-trust capability gateway for safe agent operations.
 ---
 
-# Give agents capability, not custody.
+# Run Yukh MCP locally
 
-**Yukh MCP is a policy-governed gateway for safe, auditable, and verifiable AI operations.**
+Yukh MCP gives agents typed, policy-governed capabilities without exposing
+credentials or unrestricted shell access.
 
-Agents should not need custody of infrastructure credentials or unrestricted shell access. Yukh exposes typed capabilities, evaluates explicit policy, produces a deterministic plan, requires the appropriate approval, verifies the outcome, and records structured evidence.
+!!! warning "Foundation"
 
-[Explore the concepts](concepts/why-yukh.md){ .md-button .md-button--primary }
-[Read the security model](security/security-model.md){ .md-button }
+    Yukh MCP is not production-ready. The ordinary gateway is inert. The
+    supported demo uses only synthetic local data and in-memory evidence.
 
-## The operating contract
+Requires Node.js 22 or newer:
 
-```text
-intent → capability → policy → plan → approval → execution → verification → audit
+```sh
+npm ci --ignore-scripts
+npm run demo
 ```
 
-<div class="grid cards" markdown>
+The command needs no credentials or configuration. It runs one allowed
+`node.inspect` request and one denial, then exits.
 
--   :material-shield-lock-outline:{ .lg .middle } **Deny by default**
+[Run the demo](guides/read-only-demo.md){ .md-button .md-button--primary }
+[Understand the architecture](architecture/overview.md){ .md-button }
 
-    Authorization is explicit, scoped, contextual, and independently enforced.
+## Choose a path
 
--   :material-file-tree-outline:{ .lg .middle } **Plan first**
+- **Evaluate it:** run the [read-only demo](guides/read-only-demo.md).
+- **Inspect the process:** start the [inert gateway](how-to/run-inert-gateway.md).
+- **Integrate contracts:** use the [contract reference](reference/contracts.md).
+- **Review safety:** read the [security model](security/security-model.md).
 
-    Mutations become inspectable plans before they become effects.
+## Current boundary
 
--   :material-check-decagram-outline:{ .lg .middle } **Verify outcomes**
+Available today:
 
-    Exit code zero is not proof that the intended state exists.
+- versioned capability and authorization contracts;
+- network-free validators and fixtures;
+- an inert MCP Streamable HTTP gateway;
+- a synthetic `node.inspect` demo.
 
--   :material-text-box-search-outline:{ .lg .middle } **Produce evidence**
+Not available:
 
-    Decisions, approvals, execution, verification, and rollback remain auditable.
-
-</div>
-
-## Status
-
-Yukh MCP is in foundation. Security boundaries and public contracts are being designed openly before operational capabilities are implemented.
+- production deployment;
+- real credentials or targets;
+- operational tools on the ordinary gateway;
+- persistent audit storage;
+- mutating capabilities.

--- a/docs/reference/contracts.md
+++ b/docs/reference/contracts.md
@@ -1,0 +1,25 @@
+# Contracts and implementations
+
+Use these sources when building or testing an integration. Accepted RFCs define
+semantics; reference packages validate records without network or provider
+access.
+
+| Contract | Accepted decision | Executable reference |
+| --- | --- | --- |
+| Capability v1 | [RFC-0001](https://github.com/nomed/yukh-mcp/blob/main/.context/rfcs/RFC-0001-versioned-capability-contract.md) | [Package and API](https://github.com/nomed/yukh-mcp/tree/main/contracts/capability/v1) |
+| Authorization v1 | [RFC-0002](https://github.com/nomed/yukh-mcp/blob/main/.context/rfcs/RFC-0002-deny-by-default-authorization.md) | [Package and API](https://github.com/nomed/yukh-mcp/tree/main/contracts/authorization/v1) |
+| Mutation lifecycle | [RFC-0003](https://github.com/nomed/yukh-mcp/blob/main/.context/rfcs/RFC-0003-bound-plan-approval-apply-lifecycle.md) | No public runtime |
+| Audit evidence | [RFC-0004](https://github.com/nomed/yukh-mcp/blob/main/.context/rfcs/RFC-0004-structured-redacted-audit-evidence.md) | No durable backend |
+| Coordination adapter | [RFC-0005](https://github.com/nomed/yukh-mcp/blob/main/.context/rfcs/RFC-0005-stable-coordination-consumer-adapter.md) | Synthetic loopback qualification only |
+
+## Validate the repository
+
+```sh
+npm ci --ignore-scripts
+npm run typecheck
+npm test
+npm run build
+```
+
+Unknown versions, fields, bindings, or policy outcomes fail closed. Reference
+packages do not authorize a provider, credential, target, or deployment.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,11 +43,7 @@ markdown_extensions:
   - md_in_html
   - tables
   - pymdownx.details
-  - pymdownx.superfences:
-      custom_fences:
-        - name: mermaid
-          class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true
 
@@ -56,18 +52,21 @@ extra_css:
 
 nav:
   - Home: index.md
-  - Concepts:
-      - Why Yukh: concepts/why-yukh.md
+  - Tutorial:
+      - Run the read-only demo: guides/read-only-demo.md
+  - How-to:
+      - Run the inert gateway: how-to/run-inert-gateway.md
+  - Reference:
+      - Contracts and implementations: reference/contracts.md
+      - Runtime surface: architecture/runtime-skeleton.md
+  - Explanation:
+      - Why Yukh MCP: concepts/why-yukh.md
+      - Architecture: architecture/overview.md
       - Project charter: concepts/project-charter.md
-  - Architecture:
-      - Overview: architecture/overview.md
-      - Inert runtime skeleton: architecture/runtime-skeleton.md
-  - Guides:
-      - Five-minute read-only demo: guides/read-only-demo.md
   - Security:
       - Security model: security/security-model.md
       - Threat model: security/threat-model.md
       - Supply-chain baseline: security/supply-chain.md
-  - Community:
+  - Project:
       - Roadmap: community/roadmap.md
-      - Brand: community/brand.md
+      - Brand assets: community/brand.md

--- a/test/supply-chain/documentation.test.mjs
+++ b/test/supply-chain/documentation.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../../${path}`, import.meta.url), "utf8");
+
+test("documentation exposes the four reader intents", async () => {
+  const navigation = await read("mkdocs.yml");
+
+  for (const section of ["Tutorial", "How-to", "Reference", "Explanation"]) {
+    assert.match(navigation, new RegExp(`^  - ${section}:`, "m"));
+  }
+});
+
+test("documentation uses SVG and contains no Mermaid source", async () => {
+  const [navigation, architecture] = await Promise.all([
+    read("mkdocs.yml"),
+    read("docs/architecture/overview.md"),
+  ]);
+
+  assert.doesNotMatch(`${navigation}\n${architecture}`, /mermaid/i);
+  assert.match(architecture, /assets\/architecture-boundaries\.svg/);
+});
+
+test("the landing page starts with the runnable synthetic demo", async () => {
+  const home = await read("docs/index.md");
+
+  assert.match(home, /npm ci --ignore-scripts/);
+  assert.match(home, /npm run demo/);
+  assert.match(home, /not production-ready/i);
+  assert.match(home, /ordinary gateway is inert/i);
+});


### PR DESCRIPTION
## What changed

- reorganizes the site around Tutorial, How-to, Reference, and Explanation;
- puts the runnable synthetic demo and expected output on the landing path;
- adds a focused inert-gateway how-to and contract reference;
- removes Mermaid and its build configuration;
- replaces the architecture flow with one accessible SVG;
- removes repeated product, charter, and architecture copy;
- adds regression tests for navigation, readiness language, and diagram policy.

## Why

Readers should reach a supported command immediately and should not have to reconstruct current readiness from repeated conceptual prose.

## Impact

Documentation only. No capability, trust boundary, deployment, release, or maturity state changes. Production installation guidance remains intentionally absent.

## Context impact

Session 16 records validation evidence. Accepted RFCs remain canonical and are linked rather than duplicated.

## Validation

- `npm run demo`
- `mkdocs build --strict`
- `npm run format:check`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm audit --audit-level=moderate`

Closes #52.
