### PR TITLE
Refresh official Actions for Node 24

### DIFF
--- a/.context/sessions/SESSION-2026-08-03-17-node24-actions.md
+++ b/.context/sessions/SESSION-2026-08-03-17-node24-actions.md
@@ -1,0 +1,38 @@
+# SESSION-2026-08-03-17 — Node 24 Actions refresh
+
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/54
+- Pull request: pending
+- Status: implementation complete
+
+## Objective
+
+Remove the Pages workflow Node 20 deprecation warning without weakening
+immutable pinning or workflow permissions.
+
+## Work completed
+
+- Updated official checkout, Python, Pages configuration, Pages artifact, and
+  Scorecard artifact Actions to current reviewed Node 24 releases.
+- Applied shared Action updates consistently across all workflows.
+- Added a regression test for the reviewed Node 24 pins.
+
+## Evidence and validation
+
+- Release tags and commit objects resolved through the GitHub API.
+- Each reviewed Action's `action.yml` declares `node24`; the Pages artifact
+  composite pins `actions/upload-artifact` v7 internally.
+- `npm run format:check`
+- `npm test`
+
+## Decisions discovered
+
+No architecture, runtime, permission, or trust boundary changed. External
+Actions remain pinned to full commit SHAs.
+
+## Context impact
+
+Supply-chain maintenance evidence only.
+
+## Risks and unresolved work
+
+The deprecation annotation must be checked on the first post-merge Pages run.

--- a/.context/sessions/SESSION-2026-08-03-17-node24-actions.md
+++ b/.context/sessions/SESSION-2026-08-03-17-node24-actions.md
@@ -1,7 +1,7 @@
 # SESSION-2026-08-03-17 — Node 24 Actions refresh
 
 - Governing issue: https://github.com/nomed/yukh-mcp/issues/54
-- Pull request: pending
+- Pull request: https://github.com/nomed/yukh-mcp/pull/55
 - Status: implementation complete
 
 ## Objective

--- a/.context/sessions/SESSION-2026-08-03-17-node24-actions.md
+++ b/.context/sessions/SESSION-2026-08-03-17-node24-actions.md
@@ -11,8 +11,9 @@ immutable pinning or workflow permissions.
 
 ## Work completed
 
-- Updated official checkout, Python, Pages configuration, Pages artifact, and
-  Scorecard artifact Actions to current reviewed Node 24 releases.
+- Updated official checkout, Node setup, Python setup, Pages configuration,
+  Pages artifact, and Scorecard artifact Actions to current reviewed Node 24
+  releases.
 - Applied shared Action updates consistently across all workflows.
 - Added a regression test for the reviewed Node 24 pins.
 

--- a/.context/sessions/SESSION-2026-08-03-17-node24-actions.md
+++ b/.context/sessions/SESSION-2026-08-03-17-node24-actions.md
@@ -14,6 +14,7 @@ immutable pinning or workflow permissions.
 - Updated official checkout, Node setup, Python setup, Pages configuration,
   Pages artifact, and Scorecard artifact Actions to current reviewed Node 24
   releases.
+- Updated CodeQL init, analyze, and SARIF upload from v3 to v4 on Node 24.
 - Applied shared Action updates consistently across all workflows.
 - Added a regression test for the reviewed Node 24 pins.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24.6.0"
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out source
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -47,7 +47,7 @@ jobs:
         run: npm audit --audit-level=moderate
 
       - name: Set up Python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
           cache: pip

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out source
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,12 +26,12 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@eb3cef721752a3421fe144a742539281bdf4df1a # v3
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           languages: javascript-typescript
           queries: security-extended
 
       - name: Analyze
-        uses: github/codeql-action/analyze@eb3cef721752a3421fe144a742539281bdf4df1a # v3
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           category: /language:javascript-typescript

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out source
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,12 +25,12 @@ jobs:
       contents: read
     steps:
       - name: Check out source
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
           cache: pip
@@ -43,10 +43,10 @@ jobs:
         run: mkdocs build --strict
 
       - name: Configure Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,7 +33,7 @@ jobs:
           publish_results: false
 
       - name: Upload analysis to code scanning
-        uses: github/codeql-action/upload-sarif@eb3cef721752a3421fe144a742539281bdf4df1a # v3
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           sarif_file: results.sarif
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out source
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -38,7 +38,7 @@ jobs:
           sarif_file: results.sarif
 
       - name: Retain bounded result artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: scorecard-results
           path: results.sarif

--- a/.github/workflows/yukh-bootstrap.yml
+++ b/.github/workflows/yukh-bootstrap.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out policy
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/yukh-reconcile.yml
+++ b/.github/workflows/yukh-reconcile.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out policy
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/test/supply-chain/workflows.test.mjs
+++ b/test/supply-chain/workflows.test.mjs
@@ -4,7 +4,16 @@ import { basename, join } from "node:path";
 import test from "node:test";
 
 const directory = new URL("../../.github/workflows/", import.meta.url);
-const workflows = readdirSync(directory).filter((name) => name.endsWith(".yml")).sort();
+const workflows = readdirSync(directory)
+  .filter((name) => name.endsWith(".yml"))
+  .sort();
+const node24ActionPins = new Set([
+  "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+  "actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d",
+  "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97",
+  "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+  "actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9",
+]);
 
 for (const filename of workflows) {
   const source = readFileSync(new URL(filename, directory), "utf8");
@@ -13,7 +22,10 @@ for (const filename of workflows) {
     const actionLines = source.split("\n").filter((line) => /^\s*uses:\s*/.test(line));
     assert(actionLines.length > 0, `${filename} has no inspectable action references`);
     for (const line of actionLines) {
-      const reference = line.replace(/^\s*uses:\s*/, "").split(/\s+#/, 1)[0]?.trim();
+      const reference = line
+        .replace(/^\s*uses:\s*/, "")
+        .split(/\s+#/, 1)[0]
+        ?.trim();
       assert.match(reference ?? "", /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.\/-]+@[a-f0-9]{40}$/, line);
     }
   });
@@ -27,6 +39,29 @@ for (const filename of workflows) {
     assert.match(source, /^\s+timeout-minutes:\s+[0-9]+$/m);
   });
 }
+
+test("JavaScript actions use reviewed Node 24 releases", () => {
+  for (const filename of workflows) {
+    const source = readFileSync(new URL(filename, directory), "utf8");
+    const references = source
+      .split("\n")
+      .filter((line) =>
+        /^\s*uses:\s+actions\/(checkout|configure-pages|setup-python|upload-artifact|upload-pages-artifact)@/.test(
+          line,
+        ),
+      )
+      .map((line) =>
+        line
+          .replace(/^\s*uses:\s*/, "")
+          .split(/\s+#/, 1)[0]
+          ?.trim(),
+      );
+
+    for (const reference of references) {
+      assert(node24ActionPins.has(reference), `${filename}: ${reference}`);
+    }
+  }
+});
 
 test("workflow inventory is explicit", () => {
   assert.deepEqual(workflows, [

--- a/test/supply-chain/workflows.test.mjs
+++ b/test/supply-chain/workflows.test.mjs
@@ -14,6 +14,9 @@ const node24ActionPins = new Set([
   "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97",
   "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
   "actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9",
+  "github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43",
+  "github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43",
+  "github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43",
 ]);
 
 for (const filename of workflows) {
@@ -47,7 +50,7 @@ test("JavaScript actions use reviewed Node 24 releases", () => {
     const references = source
       .split("\n")
       .filter((line) =>
-        /^\s*uses:\s+actions\/(checkout|configure-pages|setup-node|setup-python|upload-artifact|upload-pages-artifact)@/.test(
+        /^\s*uses:\s+(?:actions\/(?:checkout|configure-pages|setup-node|setup-python|upload-artifact|upload-pages-artifact)|github\/codeql-action\/(?:analyze|init|upload-sarif))@/.test(
           line,
         ),
       )

--- a/test/supply-chain/workflows.test.mjs
+++ b/test/supply-chain/workflows.test.mjs
@@ -10,6 +10,7 @@ const workflows = readdirSync(directory)
 const node24ActionPins = new Set([
   "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
   "actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d",
+  "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
   "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97",
   "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
   "actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9",
@@ -46,7 +47,7 @@ test("JavaScript actions use reviewed Node 24 releases", () => {
     const references = source
       .split("\n")
       .filter((line) =>
-        /^\s*uses:\s+actions\/(checkout|configure-pages|setup-python|upload-artifact|upload-pages-artifact)@/.test(
+        /^\s*uses:\s+actions\/(checkout|configure-pages|setup-node|setup-python|upload-artifact|upload-pages-artifact)@/.test(
           line,
         ),
       )


### PR DESCRIPTION
## What changed

- updates official JavaScript Actions to reviewed releases that declare the Node 24 runtime;
- keeps every Action pinned to a full commit SHA;
- updates shared pins consistently across CI, Pages, CodeQL, dependency review, Scorecard, and Yukh workflows;
- adds a regression test for the reviewed Node 24 pin set.

## Why

The Pages workflow succeeded but emitted GitHub’s Node 20 deprecation annotation for its checkout, Python setup, Pages configuration, and artifact steps.

## Impact

Supply-chain maintenance only. Workflow permissions, triggers, timeouts, runtime behavior, and security boundaries are unchanged.

## Validation

- official release tags and commit objects verified through the GitHub API
- reviewed Action metadata declares `node24`
- `npm run format:check`
- `npm test`

## Context impact

Session 17 records the immutable pins and verification evidence.

Closes #54.
