### PR TITLE
chore: add yukh-projects shadow migration

### DIFF
--- a/.context/sessions/SESSION-2026-08-03-16-yukh-projects-shadow-migration.md
+++ b/.context/sessions/SESSION-2026-08-03-16-yukh-projects-shadow-migration.md
@@ -1,0 +1,32 @@
+# Session — Yukh Projects shadow migration
+
+- Date: 2026-08-03
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/27
+- Branch: `agent/issue-27-yukh-projects-shadow`
+- Status: shadow-only migration implementation prepared
+
+## Outcome
+
+Added a manual, one-issue successor workflow pinned to immutable Yukh Projects
+v1.3.3. The workflow has read-only repository permissions, exposes no apply
+input, uploads only the successor's redacted report for one day, and records
+bounded aggregate outputs. Existing legacy workflows remain untouched.
+
+## Validation and boundary
+
+Supply-chain tests bind the exact successor commit and reject an apply surface
+or automatic issue trigger. A local authorized shadow probe uses GraphQL-zero
+behavior and records only aggregate evidence. No Project mutation, controlled
+apply, legacy removal, deployment, private consumer reference, or credential is
+introduced.
+
+## Context impact
+
+No architecture, public MCP capability, authentication, authorization, runtime,
+provider, or deployment trust boundary changes. No RFC or threat-model delta is
+required for this read-only repository-governance workflow.
+
+## Remaining work
+
+Review the exact successor report against the last verified legacy dry-run.
+Controlled apply and a second zero-operation apply remain separately gated.

--- a/.github/workflows/yukh-projects-shadow.yml
+++ b/.github/workflows/yukh-projects-shadow.yml
@@ -1,0 +1,65 @@
+name: Yukh Projects shadow reconciliation
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Exact issue number to audit without mutation
+        type: number
+        required: true
+
+permissions:
+  contents: read
+  issues: read
+
+concurrency:
+  group: yukh-projects-shadow-${{ inputs.issue_number }}
+  cancel-in-progress: false
+
+jobs:
+  shadow:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out policy
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Produce successor dry-run
+        id: shadow
+        uses: nomed/yukh-projects@e086e89395808377845567325b3a0fa73ef6e926 # v1.3.3
+        with:
+          github-token: ${{ secrets.YUKH_PROJECT_TOKEN }}
+          owner: nomed
+          repository: yukh-mcp
+          project-number: 5
+          issue-number: ${{ inputs.issue_number }}
+          policy-path: .yukh/project.yaml
+
+      - name: Record bounded result
+        if: ${{ always() }}
+        shell: bash
+        env:
+          STATUS: ${{ steps.shadow.outputs.status }}
+          EXECUTABLE: ${{ steps.shadow.outputs.executable }}
+          OPERATION_COUNT: ${{ steps.shadow.outputs.operation-count }}
+        run: |
+          set -euo pipefail
+          {
+            echo '## Yukh Projects shadow result'
+            echo
+            echo "- status: ${STATUS:-unavailable}"
+            echo "- executable: ${EXECUTABLE:-unavailable}"
+            echo "- operation count: ${OPERATION_COUNT:-unavailable}"
+            echo '- mode: read-only shadow'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Retain redacted report briefly
+        if: ${{ always() && steps.shadow.outputs.report-path != '' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: yukh-projects-shadow-${{ inputs.issue_number }}-${{ github.run_id }}
+          path: ${{ steps.shadow.outputs.report-path }}
+          if-no-files-found: error
+          retention-days: 1

--- a/docs/guides/yukh-projects-shadow-migration.md
+++ b/docs/guides/yukh-projects-shadow-migration.md
@@ -1,0 +1,21 @@
+# Yukh Projects shadow migration
+
+The `Yukh Projects shadow reconciliation` workflow audits one Project 5 issue
+without mutation. It pins the immutable `yukh-projects` v1.3.3 commit
+`e086e89395808377845567325b3a0fa73ef6e926` and accepts no apply mode, approval
+artifact, or write credential.
+
+Run it manually with the exact issue number selected for comparison. Review the
+bounded step summary and the one-day redacted report artifact against the last
+verified legacy dry-run. Explain every operation or diagnostic difference in
+the migration pull request before requesting controlled apply.
+
+Do not trigger a fresh legacy backlog audit merely to populate comparison
+evidence. Reuse the last verified legacy result unless a reviewer identifies a
+specific missing observation. This avoids returning development automation to
+the legacy GraphQL-heavy path.
+
+The existing legacy reconciliation and bootstrap workflows remain unchanged as
+the rollback surface. Their presence does not authorize apply. Removing them,
+running controlled apply, or changing Project state requires a later explicit
+approval under issue #27.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - Run the read-only demo: guides/read-only-demo.md
   - How-to:
       - Run the inert gateway: how-to/run-inert-gateway.md
+      - Run a Yukh Projects shadow migration: guides/yukh-projects-shadow-migration.md
   - Reference:
       - Contracts and implementations: reference/contracts.md
       - Runtime surface: architecture/runtime-skeleton.md

--- a/test/supply-chain/workflows.test.mjs
+++ b/test/supply-chain/workflows.test.mjs
@@ -36,7 +36,25 @@ test("workflow inventory is explicit", () => {
     "pages.yml",
     "scorecard.yml",
     "yukh-bootstrap.yml",
+    "yukh-projects-shadow.yml",
     "yukh-reconcile.yml",
   ]);
   assert.equal(basename(join(".github", "workflows")), "workflows");
+});
+
+test("Yukh Projects migration remains manual, immutable, and shadow-only", () => {
+  const source = readFileSync(new URL("yukh-projects-shadow.yml", directory), "utf8");
+  assert.match(
+    source,
+    /nomed\/yukh-projects@e086e89395808377845567325b3a0fa73ef6e926/u,
+  );
+  assert.match(source, /workflow_dispatch:/u);
+  assert.equal(source.includes("issues:"), true);
+  assert.equal(source.includes("types: [opened"), false);
+  assert.equal(source.includes("apply-action"), false);
+  assert.equal(source.includes("apply-enabled"), false);
+  assert.equal(source.includes("github-write-token"), false);
+  assert.equal(source.includes("mode:"), true);
+  assert.match(source, /mode: read-only shadow/u);
+  assert.match(source, /retention-days: 1/u);
 });


### PR DESCRIPTION
Advances #27 with the first bounded successor shadow surface.

## What changed

- adds a manual, one-issue `yukh-projects` shadow workflow pinned to immutable `v1.3.3` commit `e086e89395808377845567325b3a0fa73ef6e926`;
- grants only `contents: read` and `issues: read`, exposes no apply inputs, and retains the redacted report for one day;
- adds supply-chain tests that bind the immutable pin and reject automatic triggers or apply authority;
- documents comparison and rollback boundaries while leaving the legacy workflows unchanged.

## Validation

- `npm test` (57 contract/supply-chain tests and 24 runtime tests passed);
- `npm run format:check`;
- `npm run typecheck`;
- `git diff --check`.

The qualified successor probe uses 4 REST requests, 0 GraphQL requests, and no retries for one issue. This PR does not run controlled apply, deploy anything, remove the legacy workflows, or mutate Project state.
