### PR TITLE
fix: enable bounded legacy shadow adapter

### DIFF
--- a/.context/sessions/SESSION-2026-08-03-16-yukh-projects-shadow-migration.md
+++ b/.context/sessions/SESSION-2026-08-03-16-yukh-projects-shadow-migration.md
@@ -8,7 +8,8 @@
 ## Outcome
 
 Added a manual, one-issue successor workflow pinned to immutable Yukh Projects
-v1.3.3. The workflow has read-only repository permissions, exposes no apply
+v1.3.4 with its explicit `legacy-shadow` adapter. The workflow has read-only
+repository permissions, exposes no apply
 input, uploads only the successor's redacted report for one day, and records
 bounded aggregate outputs. Existing legacy workflows remain untouched.
 

--- a/.github/workflows/yukh-projects-shadow.yml
+++ b/.github/workflows/yukh-projects-shadow.yml
@@ -22,14 +22,15 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out policy
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.2
         with:
           persist-credentials: false
 
       - name: Produce successor dry-run
         id: shadow
-        uses: nomed/yukh-projects@e086e89395808377845567325b3a0fa73ef6e926 # v1.3.3
+        uses: nomed/yukh-projects@21731941c96525802ee1e31c6df9e888ceab07e7 # v1.3.4
         with:
+          mode: legacy-shadow
           github-token: ${{ secrets.YUKH_PROJECT_TOKEN }}
           owner: nomed
           repository: yukh-mcp
@@ -57,7 +58,7 @@ jobs:
 
       - name: Retain redacted report briefly
         if: ${{ always() && steps.shadow.outputs.report-path != '' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: yukh-projects-shadow-${{ inputs.issue_number }}-${{ github.run_id }}
           path: ${{ steps.shadow.outputs.report-path }}

--- a/docs/guides/yukh-projects-shadow-migration.md
+++ b/docs/guides/yukh-projects-shadow-migration.md
@@ -1,8 +1,9 @@
 # Yukh Projects shadow migration
 
 The `Yukh Projects shadow reconciliation` workflow audits one Project 5 issue
-without mutation. It pins the immutable `yukh-projects` v1.3.3 commit
-`e086e89395808377845567325b3a0fa73ef6e926` and accepts no apply mode, approval
+without mutation. It pins the immutable `yukh-projects` v1.3.4 commit
+`21731941c96525802ee1e31c6df9e888ceab07e7` and selects the bounded
+`legacy-shadow` adapter. It accepts no apply mode, approval
 artifact, or write credential.
 
 Run it manually with the exact issue number selected for comparison. Review the

--- a/test/supply-chain/workflows.test.mjs
+++ b/test/supply-chain/workflows.test.mjs
@@ -85,7 +85,7 @@ test("Yukh Projects migration remains manual, immutable, and shadow-only", () =>
   const source = readFileSync(new URL("yukh-projects-shadow.yml", directory), "utf8");
   assert.match(
     source,
-    /nomed\/yukh-projects@e086e89395808377845567325b3a0fa73ef6e926/u,
+    /nomed\/yukh-projects@21731941c96525802ee1e31c6df9e888ceab07e7/u,
   );
   assert.match(source, /workflow_dispatch:/u);
   assert.equal(source.includes("issues:"), true);
@@ -94,6 +94,16 @@ test("Yukh Projects migration remains manual, immutable, and shadow-only", () =>
   assert.equal(source.includes("apply-enabled"), false);
   assert.equal(source.includes("github-write-token"), false);
   assert.equal(source.includes("mode:"), true);
+  assert.match(source, /^          mode: legacy-shadow$/mu);
   assert.match(source, /mode: read-only shadow/u);
   assert.match(source, /retention-days: 1/u);
+});
+
+test("Yukh Projects shadow policy is versioned with its workflow", () => {
+  const source = readFileSync(new URL("../../.yukh/project.yaml", import.meta.url), "utf8");
+  assert.match(source, /^version: 1$/mu);
+  assert.match(source, /^  repository: yukh-mcp$/mu);
+  assert.match(source, /^  marker: yukh$/mu);
+  assert.match(source, /^  status:\n    project_field: Status\n    derived: true$/mu);
+  assert.match(source, /^  overwrite_human_values: false$/mu);
 });


### PR DESCRIPTION
Continues #27 after the fail-closed first shadow run.

## What changed

- pins the manual shadow workflow to immutable `yukh-projects v1.3.4` commit `21731941c96525802ee1e31c6df9e888ceab07e7`;
- selects the explicit bounded `legacy-shadow` Action adapter;
- updates the workflow infrastructure Actions to the repository's reviewed Node 24 pins;
- adds a supply-chain guard proving the version-1 policy remains present and preserves Project-owned `Status` plus human values;
- updates the migration guide and session evidence.

## Why

The first manual run failed safely because the previous immutable Action exposed only the native parser. It produced a redacted policy diagnostic before snapshot evidence and performed no mutation. The new release exposes the accepted compatibility adapter directly through the Action.

## Validation

- `npm test` (59 contract/supply-chain tests and 24 runtime tests passed);
- `npm run format:check`;
- `npm run typecheck`;
- `git diff --check`.

This PR does not enable apply, deploy anything, remove the legacy workflows, or mutate Project state.
