### PR TITLE
fix: align policy with native project governance

### DIFF
--- a/.yukh/project.yaml
+++ b/.yukh/project.yaml
@@ -12,6 +12,7 @@ contract:
 fields:
   kind:
     project_field: Work Type
+    target: issue_type
     required: true
     values:
       gate: Gate
@@ -21,7 +22,7 @@ fields:
       bug: Bug
       technical_debt: Technical Debt
   area:
-    project_field: Area
+    project_field: Component
     ownership: extension
     required: true
     values:

--- a/test/supply-chain/workflows.test.mjs
+++ b/test/supply-chain/workflows.test.mjs
@@ -104,6 +104,11 @@ test("Yukh Projects shadow policy is versioned with its workflow", () => {
   assert.match(source, /^version: 1$/mu);
   assert.match(source, /^  repository: yukh-mcp$/mu);
   assert.match(source, /^  marker: yukh$/mu);
+  assert.match(
+    source,
+    /^  kind:\n    project_field: Work Type\n    target: issue_type$/mu,
+  );
+  assert.match(source, /^  area:\n    project_field: Component$/mu);
   assert.match(source, /^  status:\n    project_field: Status\n    derived: true$/mu);
   assert.match(source, /^  overwrite_human_values: false$/mu);
 });


### PR DESCRIPTION
Advances #27 by resolving the two invalid Project-field shadow targets.

## What changed

- routes governed `kind` through the native issue-type target while retaining the existing explicit value map;
- maps governed `area` to Project 5's existing `Component` field;
- preserves the human-owned `Status` declaration and every safety setting;
- leaves the requested parent relationship unchanged for a fresh read-only review;
- adds deterministic supply-chain guards for all three policy boundaries.

## Why

The successful successor shadow reported two Project-field operations because the existing policy named absent fields (`Work Type` and `Area`). The current Project schema instead exposes native issue types and `Component`. Those invalid operation classes must be eliminated before any apply discussion.

## Validation

- `npm test` (59 contract/supply-chain tests and 24 runtime tests passed);
- `npm run format:check`;
- `npm run typecheck`;
- the `v1.3.4` compatibility parser accepts the complete policy;
- `git diff --check`.

This PR changes repository policy only. It does not run apply, mutate Project state, deploy anything, remove legacy workflows, or authorize the parent relationship.
