### PR TITLE
fix: preserve component governance during migration

### DIFF
--- a/.yukh/project.yaml
+++ b/.yukh/project.yaml
@@ -22,7 +22,7 @@ fields:
       bug: Bug
       technical_debt: Technical Debt
   area:
-    project_field: Component
+    project_field: Area
     ownership: extension
     required: true
     values:

--- a/test/supply-chain/workflows.test.mjs
+++ b/test/supply-chain/workflows.test.mjs
@@ -108,7 +108,8 @@ test("Yukh Projects shadow policy is versioned with its workflow", () => {
     source,
     /^  kind:\n    project_field: Work Type\n    target: issue_type$/mu,
   );
-  assert.match(source, /^  area:\n    project_field: Component$/mu);
+  assert.match(source, /^  area:\n    project_field: Area$/mu);
+  assert.doesNotMatch(source, /^  area:\n    project_field: Component$/mu);
   assert.match(source, /^  status:\n    project_field: Status\n    derived: true$/mu);
   assert.match(source, /^  overwrite_human_values: false$/mu);
 });


### PR DESCRIPTION
Corrects the policy alignment in #58 while continuing #27.

## What changed

- preserves the accepted native issue-type target for governed `kind`;
- restores governed `area` to its distinct `Area` target;
- adds a regression guard preventing `area` from being mapped to `Component`.

## Why

The post-merge shadow and a bounded REST-only semantic review proved that Project 5 `Component` currently represents the component identity (`MCP`), while the issue contract `area` represents delivery responsibility (`delivery`). Mapping those dimensions together would propose an incorrect Project-field update. No mutation occurred because all runs remain shadow-only.

Keeping `Area` explicit preserves the semantic contract and leaves its absent Project representation fail-closed for a later governance decision. It does not weaken the valid `kind -> issue_type` migration.

## Validation

- `npm test` (59 contract/supply-chain tests and 24 runtime tests passed);
- `npm run format:check`;
- `npm run typecheck`;
- `git diff --check`.

This PR does not apply, deploy, mutate Project state, remove legacy workflows, or approve creation of an `Area` field.
