### PR TITLE
Align documentation header and canonical logo

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,12 +7,12 @@ copyright: Copyright &copy; 2026 Yukh MCP contributors
 
 theme:
   name: material
-  logo: assets/logo.svg
-  favicon: assets/logo.svg
+  logo: assets/repository-mark.svg
+  favicon: assets/repository-mark.svg
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: deep purple
+      primary: black
       accent: deep purple
       toggle:
         icon: material/brightness-7

--- a/test/supply-chain/documentation.test.mjs
+++ b/test/supply-chain/documentation.test.mjs
@@ -12,6 +12,13 @@ test("documentation exposes the four reader intents", async () => {
   }
 });
 
+test("documentation uses the black header and canonical component mark", async () => {
+  const config = await read("mkdocs.yml");
+
+  assert.equal((config.match(/primary: black/g) ?? []).length, 2);
+  assert.match(config, /logo: assets\/repository-mark\.svg/);
+});
+
 test("documentation uses SVG and contains no Mermaid source", async () => {
   const [navigation, architecture] = await Promise.all([
     read("mkdocs.yml"),


### PR DESCRIPTION
Closes #61.

Uses a black Material header in both color schemes and switches the header/favicon to the canonical MCP repository mark. The violet accent remains unchanged.

Validated with the complete 84-test suite and `mkdocs build --strict`.