### PR TITLE
Use Project field for work type

### DIFF
--- a/.yukh/project.yaml
+++ b/.yukh/project.yaml
@@ -12,7 +12,6 @@ contract:
 fields:
   kind:
     project_field: Work Type
-    target: issue_type
     required: true
     values:
       gate: Gate

--- a/test/supply-chain/workflows.test.mjs
+++ b/test/supply-chain/workflows.test.mjs
@@ -106,8 +106,9 @@ test("Yukh Projects shadow policy is versioned with its workflow", () => {
   assert.match(source, /^  marker: yukh$/mu);
   assert.match(
     source,
-    /^  kind:\n    project_field: Work Type\n    target: issue_type$/mu,
+    /^  kind:\n    project_field: Work Type\n    required: true$/mu,
   );
+  assert.doesNotMatch(source, /^    target: issue_type$/mu);
   assert.match(source, /^  area:\n    project_field: Area$/mu);
   assert.doesNotMatch(source, /^  area:\n    project_field: Component$/mu);
   assert.match(source, /^  status:\n    project_field: Status\n    derived: true$/mu);


### PR DESCRIPTION
Closes #27.

Removes the unsupported GitHub Issue Type binding for this personal-account repository. `kind` remains mapped to the Project `Work Type` field.

A live read-only dry-run against Project 5 and issue #27 produced executable plan `23b4b1b0d380317e84386f24610c694f76d9a965674f7a09e29645ee8d2cd661`: five operations, zero diagnostics, and no mutations.

Checks: `npm test`; `npm run typecheck`.