### PR TITLE
Qualify Yukh Projects v1.4 shadow routing

### DIFF
--- a/.context/sessions/SESSION-2026-08-05-01-yukh-projects-v1.4-shadow.md
+++ b/.context/sessions/SESSION-2026-08-05-01-yukh-projects-v1.4-shadow.md
@@ -9,8 +9,10 @@
 
 The manual one-issue shadow workflow now pins immutable Yukh Projects v1.4.0
 at `d1f787ca82c085b215146949d039aa217b399c27`. The repository policy routes
-`kind` to native Issue Type. For this organization-owned repository, the
-owner-aware provider must not propose a redundant Project `Work Type` field.
+`kind` to native Issue Type while retaining `project_field: Work Type` as the
+required declarative fallback for user-owned repositories. For this
+organization-owned repository, the owner-aware provider must not propose a
+redundant Project `Work Type` field.
 
 The workflow remains manually dispatched, read-only, bounded to one issue, and
 structurally exposes no apply input or write credential. The legacy workflows

--- a/.context/sessions/SESSION-2026-08-05-01-yukh-projects-v1.4-shadow.md
+++ b/.context/sessions/SESSION-2026-08-05-01-yukh-projects-v1.4-shadow.md
@@ -1,0 +1,35 @@
+# Session — Yukh Projects v1.4 shadow qualification
+
+- Date: 2026-08-05
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/27
+- Branch: `agent/issue-27-v1.4-shadow`
+- Status: shadow-only update prepared for review
+
+## Outcome
+
+The manual one-issue shadow workflow now pins immutable Yukh Projects v1.4.0
+at `d1f787ca82c085b215146949d039aa217b399c27`. The repository policy routes
+`kind` to native Issue Type. For this organization-owned repository, the
+owner-aware provider must not propose a redundant Project `Work Type` field.
+
+The workflow remains manually dispatched, read-only, bounded to one issue, and
+structurally exposes no apply input or write credential. The legacy workflows
+remain unchanged as the rollback surface.
+
+## Required evidence
+
+A fresh issue #27 shadow must demonstrate zero GraphQL requests, no retry, no
+schema creation for `Work Type`, preservation of Project-owned `Status` and
+`Component`, and a redacted exact operation summary. Any remaining drift must
+be reviewed separately before controlled apply.
+
+## Context impact
+
+No MCP capability, provider, authentication, authorization, deployment, or
+mutation boundary changes. The accepted read-only migration boundary remains
+unchanged, so no RFC or threat-model delta is required.
+
+## Exclusions
+
+No Project mutation, live apply, legacy removal, deployment, field removal,
+backfill, or completion of the consumer migration is authorized.

--- a/.github/workflows/yukh-projects-shadow.yml
+++ b/.github/workflows/yukh-projects-shadow.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Produce successor dry-run
         id: shadow
-        uses: nomed/yukh-projects@21731941c96525802ee1e31c6df9e888ceab07e7 # v1.3.4
+        uses: nomed/yukh-projects@d1f787ca82c085b215146949d039aa217b399c27 # v1.4.0
         with:
           mode: legacy-shadow
           github-token: ${{ secrets.YUKH_PROJECT_TOKEN }}

--- a/.yukh/project.yaml
+++ b/.yukh/project.yaml
@@ -11,6 +11,7 @@ contract:
 
 fields:
   kind:
+    project_field: Work Type
     target: issue_type
     required: true
     values:

--- a/.yukh/project.yaml
+++ b/.yukh/project.yaml
@@ -11,7 +11,7 @@ contract:
 
 fields:
   kind:
-    project_field: Work Type
+    target: issue_type
     required: true
     values:
       gate: Gate

--- a/docs/guides/yukh-projects-shadow-migration.md
+++ b/docs/guides/yukh-projects-shadow-migration.md
@@ -1,21 +1,21 @@
 # Yukh Projects shadow migration
 
 The `Yukh Projects shadow reconciliation` workflow audits one Project 5 issue
-without mutation. It pins the immutable `yukh-projects` v1.3.4 commit
-`21731941c96525802ee1e31c6df9e888ceab07e7` and selects the bounded
-`legacy-shadow` adapter. It accepts no apply mode, approval
-artifact, or write credential.
+without mutation. It pins the immutable `yukh-projects` v1.4.0 commit
+`d1f787ca82c085b215146949d039aa217b399c27` and selects the bounded
+`legacy-shadow` adapter. It accepts no apply mode, approval artifact, or write
+credential.
 
 Run it manually with the exact issue number selected for comparison. Review the
 bounded step summary and the one-day redacted report artifact against the last
 verified legacy dry-run. Explain every operation or diagnostic difference in
 the migration pull request before requesting controlled apply.
 
-The current migration has one explicit schema blocker: `area` requires the
-distinct `Area` contract and must never be mapped to `Component`. The accepted
-read-only contract and non-executable Phase A plan are recorded in the
-[Project 5 Area contract](../reference/project-5-area-contract.md). Creating the
-field remains a separately authorized Phase B operation.
+The distinct `Area` contract remains separate from `Component`. The current
+policy targets native Issue Type for `kind`; because `yukh-mcp` is owned by an
+organization, v1.4.0 must not propose or create a redundant Project `Work Type`
+field. A fresh shadow must prove that routing while preserving human-owned
+`Status` and the existing `Component` value.
 
 Do not trigger a fresh legacy backlog audit merely to populate comparison
 evidence. Reuse the last verified legacy result unless a reviewer identifies a

--- a/docs/guides/yukh-projects-shadow-migration.md
+++ b/docs/guides/yukh-projects-shadow-migration.md
@@ -12,9 +12,10 @@ verified legacy dry-run. Explain every operation or diagnostic difference in
 the migration pull request before requesting controlled apply.
 
 The distinct `Area` contract remains separate from `Component`. The current
-policy targets native Issue Type for `kind`; because `yukh-mcp` is owned by an
-organization, v1.4.0 must not propose or create a redundant Project `Work Type`
-field. A fresh shadow must prove that routing while preserving human-owned
+policy targets native Issue Type for `kind`; `project_field: Work Type` remains
+only the required declarative fallback for a user-owned repository. Because
+`yukh-mcp` is organization-owned, v1.4.0 must not propose or create that Project
+field. A fresh shadow must prove this routing while preserving human-owned
 `Status` and the existing `Component` value.
 
 Do not trigger a fresh legacy backlog audit merely to populate comparison

--- a/test/supply-chain/workflows.test.mjs
+++ b/test/supply-chain/workflows.test.mjs
@@ -106,9 +106,13 @@ test("Yukh Projects shadow policy is versioned with its workflow", () => {
   assert.match(source, /^  marker: yukh$/mu);
   assert.match(
     source,
-    /^  kind:\n    target: issue_type\n    required: true$/mu,
+    /^  kind:\n    project_field: Work Type\n    target: issue_type\n    required: true$/mu,
   );
-  assert.doesNotMatch(source, /^  kind:\n    project_field: Work Type$/mu);
+  assert.equal(
+    source.match(/^    target: issue_type$/gmu)?.length,
+    1,
+    "organization-owned repository must select the native Issue Type target",
+  );
   assert.match(source, /^  area:\n    project_field: Area$/mu);
   assert.doesNotMatch(source, /^  area:\n    project_field: Component$/mu);
   assert.match(source, /^  status:\n    project_field: Status\n    derived: true$/mu);

--- a/test/supply-chain/workflows.test.mjs
+++ b/test/supply-chain/workflows.test.mjs
@@ -85,7 +85,7 @@ test("Yukh Projects migration remains manual, immutable, and shadow-only", () =>
   const source = readFileSync(new URL("yukh-projects-shadow.yml", directory), "utf8");
   assert.match(
     source,
-    /nomed\/yukh-projects@21731941c96525802ee1e31c6df9e888ceab07e7/u,
+    /nomed\/yukh-projects@d1f787ca82c085b215146949d039aa217b399c27/u,
   );
   assert.match(source, /workflow_dispatch:/u);
   assert.equal(source.includes("issues:"), true);
@@ -106,9 +106,9 @@ test("Yukh Projects shadow policy is versioned with its workflow", () => {
   assert.match(source, /^  marker: yukh$/mu);
   assert.match(
     source,
-    /^  kind:\n    project_field: Work Type\n    required: true$/mu,
+    /^  kind:\n    target: issue_type\n    required: true$/mu,
   );
-  assert.doesNotMatch(source, /^    target: issue_type$/mu);
+  assert.doesNotMatch(source, /^  kind:\n    project_field: Work Type$/mu);
   assert.match(source, /^  area:\n    project_field: Area$/mu);
   assert.doesNotMatch(source, /^  area:\n    project_field: Component$/mu);
   assert.match(source, /^  status:\n    project_field: Status\n    derived: true$/mu);


### PR DESCRIPTION
Governing issue: #27
Parent qualification: nomed/yukh-projects#54 and nomed/yukh-projects#101

## Outcome

Updates the existing manual, one-issue shadow workflow to immutable `nomed/yukh-projects@d1f787ca82c085b215146949d039aa217b399c27` (`v1.4.0`).

The repository policy now maps `kind` to native `issue_type`. Because `nomed/yukh-mcp` is organization-owned, the v1.4 owner-aware provider must route to native GitHub Issue Type and must not propose a redundant Project `Work Type` field.

## Safety boundary

- manual `workflow_dispatch` only;
- one exact issue per run;
- read-only repository permissions;
- `legacy-shadow` mode only;
- no apply input, approval artifact, or write credential;
- existing legacy workflows remain unchanged as rollback;
- no Project mutation, live apply, legacy removal, deployment, backfill, field removal, or completed consumer migration.

## Local validation

- contract and supply-chain tests: 64/64 pass;
- runtime tests: 26/26 pass;
- typecheck: pass;
- build: pass;
- formatting: pass;
- npm audit: 0 vulnerabilities.

A single branch-scoped shadow for issue #27 will be attached as review evidence. The expected evidence is zero GraphQL requests, no retries, no `Work Type` schema creation, and preservation of Project-owned `Status` and `Component`.