### PR TITLE
Pin Yukh Projects v1.5.1 parity fix

### DIFF
--- a/.context/sessions/SESSION-2026-08-05-02-yukh-projects-v1.5.1-parity.md
+++ b/.context/sessions/SESSION-2026-08-05-02-yukh-projects-v1.5.1-parity.md
@@ -1,0 +1,25 @@
+# Session — Yukh Projects v1.5.1 planning parity
+
+- Date: 2026-08-05
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/27
+- Producer fix: https://github.com/nomed/yukh-projects/issues/121
+- Status: read-only qualification prepared
+
+## Outcome
+
+The manual one-issue shadow workflow pins immutable Yukh Projects v1.5.1 at
+`d58837397bc5856923e0e742458be34d8e5a27d6`. This release makes single-issue
+legacy shadow use the exact owner-aware controlled planner. For this user-owned
+repository, `kind` must route to the Project `Work Type` fallback.
+
+## Required evidence
+
+The issue #27 run must return the same plan ID and operation count as a fresh
+controlled read, use zero GraphQL requests, preserve `Component` and
+Project-owned `Status`, and perform no mutation.
+
+## Context impact
+
+This is an immutable dependency-pin correction inside the accepted read-only
+migration boundary. It adds no capability, credential, deployment or mutation
+authority; no RFC or threat-model change is required.

--- a/.github/workflows/yukh-projects-shadow.yml
+++ b/.github/workflows/yukh-projects-shadow.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Produce successor dry-run
         id: shadow
-        uses: nomed/yukh-projects@d1f787ca82c085b215146949d039aa217b399c27 # v1.4.0
+        uses: nomed/yukh-projects@d58837397bc5856923e0e742458be34d8e5a27d6 # v1.5.1
         with:
           mode: legacy-shadow
           github-token: ${{ secrets.YUKH_PROJECT_TOKEN }}

--- a/docs/guides/yukh-projects-shadow-migration.md
+++ b/docs/guides/yukh-projects-shadow-migration.md
@@ -1,8 +1,8 @@
 # Yukh Projects shadow migration
 
 The `Yukh Projects shadow reconciliation` workflow audits one Project 5 issue
-without mutation. It pins the immutable `yukh-projects` v1.4.0 commit
-`d1f787ca82c085b215146949d039aa217b399c27` and selects the bounded
+without mutation. It pins the immutable `yukh-projects` v1.5.1 commit
+`d58837397bc5856923e0e742458be34d8e5a27d6` and selects the bounded
 `legacy-shadow` adapter. It accepts no apply mode, approval artifact, or write
 credential.
 
@@ -12,11 +12,11 @@ verified legacy dry-run. Explain every operation or diagnostic difference in
 the migration pull request before requesting controlled apply.
 
 The distinct `Area` contract remains separate from `Component`. The current
-policy targets native Issue Type for `kind`; `project_field: Work Type` remains
-only the required declarative fallback for a user-owned repository. Because
-`yukh-mcp` is organization-owned, v1.4.0 must not propose or create that Project
-field. A fresh shadow must prove this routing while preserving human-owned
-`Status` and the existing `Component` value.
+policy expresses the logical Issue Type target for `kind`; the provider is
+selected from observed repository ownership. Because `nomed/yukh-mcp` is
+user-owned, v1.5.1 must plan the Project `Work Type` fallback. The shadow emits
+the exact plan ID and ordered operation count used by controlled planning while
+preserving human-owned `Status` and the existing `Component` value.
 
 Do not trigger a fresh legacy backlog audit merely to populate comparison
 evidence. Reuse the last verified legacy result unless a reviewer identifies a

--- a/test/supply-chain/workflows.test.mjs
+++ b/test/supply-chain/workflows.test.mjs
@@ -85,7 +85,7 @@ test("Yukh Projects migration remains manual, immutable, and shadow-only", () =>
   const source = readFileSync(new URL("yukh-projects-shadow.yml", directory), "utf8");
   assert.match(
     source,
-    /nomed\/yukh-projects@d1f787ca82c085b215146949d039aa217b399c27/u,
+    /nomed\/yukh-projects@d58837397bc5856923e0e742458be34d8e5a27d6/u,
   );
   assert.match(source, /workflow_dispatch:/u);
   assert.equal(source.includes("issues:"), true);
@@ -111,7 +111,7 @@ test("Yukh Projects shadow policy is versioned with its workflow", () => {
   assert.equal(
     source.match(/^    target: issue_type$/gmu)?.length,
     1,
-    "organization-owned repository must select the native Issue Type target",
+    "the logical work type target must remain explicit for owner-aware routing",
   );
   assert.match(source, /^  area:\n    project_field: Area$/mu);
   assert.doesNotMatch(source, /^  area:\n    project_field: Component$/mu);


### PR DESCRIPTION
Governing issue: #27

## Outcome

Pins the manual one-issue shadow workflow to immutable Yukh Projects v1.5.1 at
`d58837397bc5856923e0e742458be34d8e5a27d6`.

This release fixes #121 by making single-issue legacy shadow emit the exact
owner-aware controlled plan ID and operation count. Documentation now correctly
records that `nomed/yukh-mcp` is user-owned and must use the Project `Work Type`
fallback.

## Safety

- manual dispatch only;
- read-only permissions and credential;
- zero apply input or write token;
- legacy workflows retained as rollback;
- no Project mutation or migration authority.

## Validation

- contracts and supply-chain: 64 passed;
- runtime: 26 passed;
- typecheck, build and format check passed;
- npm audit: 0 vulnerabilities.

A branch-scoped issue #27 shadow will provide the plan-parity evidence.
