### PR TITLE
Pin corrected Yukh Projects v1.5.1 shadow

### DIFF
--- a/.context/sessions/SESSION-2026-08-05-02-yukh-projects-v1.5.1-shadow.md
+++ b/.context/sessions/SESSION-2026-08-05-02-yukh-projects-v1.5.1-shadow.md
@@ -1,0 +1,40 @@
+# Session — Yukh Projects v1.5.1 shadow qualification
+
+- Date: 2026-08-05
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/27
+- Related migration gate: https://github.com/nomed/yukh-projects/issues/125
+- Branch: `agent/issue-27-yukh-projects-v151`
+- Status: shadow-only pin update prepared for review
+
+## Objective
+
+Replace the v1.4.0 shadow pin with immutable corrected release v1.5.1 and rerun one bounded read-only comparison before any controlled plan approval.
+
+## Work completed
+
+- Verified release tag `v1.5.1` resolves to commit `d58837397bc5856923e0e742458be34d8e5a27d6`.
+- Verified the protected publisher completed and published checksums, SPDX SBOM, and provenance attestations.
+- Updated only the manual shadow workflow pin, its supply-chain assertion, and migration guidance.
+- Preserved `workflow_dispatch`, read-only permissions, one-issue scope, one-day redacted evidence, and the absence of apply inputs or write credentials.
+
+## Evidence and validation
+
+- Producer correction: https://github.com/nomed/yukh-projects/pull/126
+- Producer issue: https://github.com/nomed/yukh-projects/issues/121
+- Immutable release: https://github.com/nomed/yukh-projects/releases/tag/v1.5.1
+- Publication run: https://github.com/nomed/yukh-projects/actions/runs/30999840785
+- Consumer tests and PR checks are recorded in the governing pull request.
+
+## Decisions discovered
+
+No new architecture or security decision. This change applies the existing owner-aware routing and read-only shadow contracts. GitHub reports the repository as user-owned, so Project `Work Type` fallback must match controlled planning.
+
+## Context impact
+
+No MCP capability, authentication, authorization, deployment, or mutation boundary changes. No RFC or threat-model update is required.
+
+## Risks and unresolved work
+
+- The shadow must be manually rerun for issue #27 after merge and compared with a fresh controlled plan.
+- No Project mutation, apply, legacy removal, deployment, or migration completion is authorized.
+- A GitHub Actions job is not durable coordination; resumable apply requires a separately governed host.

--- a/.github/workflows/yukh-projects-shadow.yml
+++ b/.github/workflows/yukh-projects-shadow.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Produce successor dry-run
         id: shadow
-        uses: nomed/yukh-projects@d1f787ca82c085b215146949d039aa217b399c27 # v1.4.0
+        uses: nomed/yukh-projects@d58837397bc5856923e0e742458be34d8e5a27d6 # v1.5.1
         with:
           mode: legacy-shadow
           github-token: ${{ secrets.YUKH_PROJECT_TOKEN }}

--- a/docs/guides/yukh-projects-shadow-migration.md
+++ b/docs/guides/yukh-projects-shadow-migration.md
@@ -1,8 +1,8 @@
 # Yukh Projects shadow migration
 
 The `Yukh Projects shadow reconciliation` workflow audits one Project 5 issue
-without mutation. It pins the immutable `yukh-projects` v1.4.0 commit
-`d1f787ca82c085b215146949d039aa217b399c27` and selects the bounded
+without mutation. It pins the immutable `yukh-projects` v1.5.1 commit
+`d58837397bc5856923e0e742458be34d8e5a27d6` and selects the bounded
 `legacy-shadow` adapter. It accepts no apply mode, approval artifact, or write
 credential.
 
@@ -13,10 +13,16 @@ the migration pull request before requesting controlled apply.
 
 The distinct `Area` contract remains separate from `Component`. The current
 policy targets native Issue Type for `kind`; `project_field: Work Type` remains
-only the required declarative fallback for a user-owned repository. Because
-`yukh-mcp` is organization-owned, v1.4.0 must not propose or create that Project
-field. A fresh shadow must prove this routing while preserving human-owned
-`Status` and the existing `Component` value.
+only the required declarative fallback for a user-owned repository. GitHub
+reports `nomed/yukh-mcp` as user-owned, so v1.5.1 must report the same Project
+`Work Type` fallback as controlled planning. A fresh shadow must prove this
+parity while preserving human-owned `Status` and the existing `Component`
+value.
+
+If deferral occurs, the workflow terminates and exposes only the redacted
+receipt supported by the pinned producer. This Actions job is not a durable
+coordinator and must not sleep, poll, self-dispatch, or retain execution
+ownership. A separately governed host is required before resumable apply.
 
 Do not trigger a fresh legacy backlog audit merely to populate comparison
 evidence. Reuse the last verified legacy result unless a reviewer identifies a

--- a/test/supply-chain/workflows.test.mjs
+++ b/test/supply-chain/workflows.test.mjs
@@ -85,7 +85,7 @@ test("Yukh Projects migration remains manual, immutable, and shadow-only", () =>
   const source = readFileSync(new URL("yukh-projects-shadow.yml", directory), "utf8");
   assert.match(
     source,
-    /nomed\/yukh-projects@d1f787ca82c085b215146949d039aa217b399c27/u,
+    /nomed\/yukh-projects@d58837397bc5856923e0e742458be34d8e5a27d6/u,
   );
   assert.match(source, /workflow_dispatch:/u);
   assert.equal(source.includes("issues:"), true);


### PR DESCRIPTION
## Outcome

Pins the manual read-only Yukh Projects shadow workflow to corrected immutable release `v1.5.1`.

## Why

The prior `v1.4.0` shadow and controlled planner disagreed for this user-owned repository. Producer issue `nomed/yukh-projects#121` was fixed by PR `nomed/yukh-projects#126` and published at exact commit `d58837397bc5856923e0e742458be34d8e5a27d6`.

## Changes

- updates only the Yukh Projects shadow Action pin
- updates the exact supply-chain assertion
- corrects owner-aware migration guidance and documents the deferral boundary
- records durable session evidence

## Safety boundary

The workflow remains manual, read-only, one-issue bounded, and exposes no apply input or write credential. This PR performs no Project mutation, apply, legacy removal, deployment, or migration completion.

## Validation

- `npm test`: 64 contract/supply-chain tests and 26 runtime tests passed
- `npm ci`: 0 vulnerabilities
- `git diff --check`

Governing issue: #27
Related consumer gate: `nomed/yukh-projects#125`
