### PR TITLE
Pin Yukh Projects v1.6.0 shadow

### DIFF
--- a/.github/workflows/yukh-projects-shadow.yml
+++ b/.github/workflows/yukh-projects-shadow.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Produce successor dry-run
         id: shadow
-        uses: nomed/yukh-projects@d58837397bc5856923e0e742458be34d8e5a27d6 # v1.5.1
+        uses: nomed/yukh-projects@aa1c3e0acde5618b7895ecd971b308a08b55219b # v1.6.0
         with:
           mode: legacy-shadow
           github-token: ${{ secrets.YUKH_PROJECT_TOKEN }}

--- a/docs/guides/yukh-projects-shadow-migration.md
+++ b/docs/guides/yukh-projects-shadow-migration.md
@@ -1,8 +1,8 @@
 # Yukh Projects shadow migration
 
 The `Yukh Projects shadow reconciliation` workflow audits one Project 5 issue
-without mutation. It pins the immutable `yukh-projects` v1.5.1 commit
-`d58837397bc5856923e0e742458be34d8e5a27d6` and selects the bounded
+without mutation. It pins the immutable `yukh-projects` v1.6.0 commit
+`aa1c3e0acde5618b7895ecd971b308a08b55219b` and selects the bounded
 `legacy-shadow` adapter. It accepts no apply mode, approval artifact, or write
 credential.
 
@@ -14,7 +14,7 @@ the migration pull request before requesting controlled apply.
 The distinct `Area` contract remains separate from `Component`. The current
 policy targets native Issue Type for `kind`; `project_field: Work Type` remains
 only the required declarative fallback for a user-owned repository. GitHub
-reports `nomed/yukh-mcp` as user-owned, so v1.5.1 must report the same Project
+reports `nomed/yukh-mcp` as user-owned, so v1.6.0 must report the same Project
 `Work Type` fallback as controlled planning. A fresh shadow must prove this
 parity while preserving human-owned `Status` and the existing `Component`
 value.

--- a/test/supply-chain/workflows.test.mjs
+++ b/test/supply-chain/workflows.test.mjs
@@ -85,7 +85,7 @@ test("Yukh Projects migration remains manual, immutable, and shadow-only", () =>
   const source = readFileSync(new URL("yukh-projects-shadow.yml", directory), "utf8");
   assert.match(
     source,
-    /nomed\/yukh-projects@d58837397bc5856923e0e742458be34d8e5a27d6/u,
+    /nomed\/yukh-projects@aa1c3e0acde5618b7895ecd971b308a08b55219b/u,
   );
   assert.match(source, /workflow_dispatch:/u);
   assert.equal(source.includes("issues:"), true);


### PR DESCRIPTION
Refs #27

## Outcome
- pins the immutable `yukh-projects v1.6.0` release at `aa1c3e0acde5618b7895ecd971b308a08b55219b`
- retains the one-issue manual `legacy-shadow` entrypoint
- retains read-only permissions, no apply input, no write credential and one-day redacted evidence
- updates the supply-chain pin assertion and migration guide

## Validation
- contract and supply-chain tests: 64 passed
- runtime tests: 26 passed
- formatting, typecheck and build: passed
- dependency audit: 0 vulnerabilities

## Authorization boundary
One new shadow run for issue #27 is authorized after this branch is available. This PR does not authorize merge, live apply, deployment, legacy removal, backfill, Project mutation or migration completion.