### PR TITLE
docs: adopt GH token controlled apply delivery

### DIFF
--- a/.context/rfcs/RFC-0008-gh-token-controlled-apply-credential-delivery.md
+++ b/.context/rfcs/RFC-0008-gh-token-controlled-apply-credential-delivery.md
@@ -1,0 +1,173 @@
+# RFC-0008 — GH_TOKEN credential delivery for Project 5 controlled apply
+
+- Status: Accepted
+- Authors: project owner
+- Created: 2026-08-05
+- Accepted: 2026-08-05
+- Decider: project owner
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/27
+- Supersedes: RFC-0007 only for credential delivery
+- Depends on: RFC-0002, RFC-0003, RFC-0004, RFC-0005, RFC-0006, RFC-0007
+
+## Summary
+
+Permanently replace the deferred materializer and GitHub OIDC credential
+delivery model from RFC-0007 with a GitHub Actions secret named `GH_TOKEN` for
+the first controlled-apply profile only:
+`yukh-mcp/project-5-issue-27-legacy-apply-v1`.
+
+`GH_TOKEN` must be configured manually as a GitHub Actions secret. It must
+never be committed, printed, placed in workflow inputs, outputs, artifacts,
+caches, step summaries, logs, repository configuration, or documentation
+examples. This RFC does not configure or retrieve the secret.
+
+This RFC supersedes RFC-0007 only where it specifies credential delivery. All
+other RFC-0007 controls remain in force: fresh exact planning, independent
+approval, fixed scope, one attempt with no retry, verification, redacted
+evidence, and separately scoped read and write authority where technically
+available.
+
+## Motivation
+
+The deferred materializer/OIDC model introduced additional unavailable
+operational dependencies: an identity federation configuration, materializer,
+sealed package, approval transport, and Coordination host capsule. The project
+owner has permanently selected manually managed GitHub Actions secret delivery
+instead. Retaining the former path would leave two conflicting credential
+delivery models for the same mutation boundary.
+
+## Goals
+
+- use only the manually configured `GH_TOKEN` secret for future producer
+  credential delivery in this profile;
+- remove the workflow's OIDC permission while it remains inert;
+- preserve the exact profile: `nomed/yukh-mcp`, Project `5`, issue `27`,
+  `.yukh/project.yaml`, `legacy-apply-v1`, producer
+  `nomed/yukh-projects@e3285c6994edd8fad1666da6ca48386522c9e90f`, and the
+  reviewed protected environment;
+- retain a fresh, exact plan and an approval independently issued for that
+  plan before any mutation;
+- keep `run_attempt == 1`, a single request attempt, no polling, sleep,
+  self-dispatch, fallback, refresh, or retry;
+- require targeted verification and a final zero-operation observation;
+- retain only redacted, allowlisted evidence;
+- separate checkout read authority from producer authority and preserve
+  distinct producer read/write credentials if the reviewed producer interface
+  technically supports them.
+
+## Non-goals
+
+- enabling the workflow;
+- creating, configuring, retrieving, rotating, or validating `GH_TOKEN`;
+- invoking the producer or any provider, applying a plan, or changing Project
+  state;
+- removing the existing synthetic materializer-package reference implementation;
+  it has no permitted workflow or credential-delivery use under this profile;
+- treating secret presence, workflow dispatch, issue state, or environment
+  approval as independent approval;
+- generalizing the profile, adding a batch scope, removing legacy automation,
+  or authorizing a second apply.
+
+## Detailed design
+
+### Profile and credential authority
+
+The workflow remains a `workflow_dispatch` contract with exactly the bounded
+`plan_digest` and `policy_commit` inputs, fixed concurrency, protected
+environment, ten-minute timeout, and a permanently false job condition. It
+retains only `contents: read` workflow permission; `id-token: write` is
+removed. While inert, it has no steps and accesses no secret.
+
+Before any separately authorized activation, a repository administrator must
+manually configure `GH_TOKEN` as a GitHub Actions secret. The value is external
+to source control and must not be copied into a file, command line, diagnostic,
+or evidence record. A future reviewed activation may pass
+`${{ secrets.GH_TOKEN }}` directly to the immutable producer action's supported
+credential input, and only for this fixed profile. It must not export the value
+as a job or workflow environment variable.
+
+The automatic workflow `GITHUB_TOKEN` remains restricted to `contents: read`
+for checkout and must never be passed to the producer. `GH_TOKEN` is the
+producer credential for the fixed scope. If the reviewed immutable producer
+interface supports independently supplied read and write credentials, they must
+remain separately scoped and the activation must preserve that separation. If
+that interface accepts only one credential, no claim of independent provider
+read/write credentials may be made; the separate read-only checkout authority
+remains mandatory.
+
+### Plan, approval, apply, and verification
+
+The existing manual shadow workflow remains the only planner. Before any apply,
+the producer must freshly recreate the approved exact plan at the exact approved
+policy commit. An approval authority independent of the workflow must approve
+the exact plan, ordered operation-set digest, profile, scope, environment,
+expiry, and unique nonce. A workflow dispatch, secret, GitHub environment
+review, or GitHub issue state is not approval.
+
+The producer is invoked at most once. Any mismatch, expired approval, replay,
+scope or permission failure, unavailable dependency, budget deferral, provider
+ambiguity, or verification failure stops without retry. Success requires
+targeted verification and a final zero-operation observation. Public evidence
+is limited to status, plan digest, aggregate counts, remaining drift, and stable
+diagnostic codes; it excludes all secret values and sensitive provider data.
+
+## Trust boundaries and threat analysis
+
+`GH_TOKEN` crosses from GitHub's Actions secret store to a future protected
+runner only after explicit workflow activation. It is a high-value provider
+credential and must be masked by GitHub, supplied only to the reviewed producer
+input, and excluded from every retained channel. The GitHub secret store,
+protected environment, runner, and producer remain dependencies; compromise of
+any may expose or misuse the token.
+
+The former OIDC token, materializer, package receipt, approval-envelope
+transport, host capsule, DPoP key, and Coordination credential are no longer
+credential-delivery controls for this profile. They must not be reintroduced
+through redirects, fallbacks, hidden steps, helper scripts, artifacts, or
+runtime files. A future proposal to use them needs a new RFC.
+
+## Compatibility
+
+RFC-0007 remains accepted and governs every control other than credential
+delivery. The manual read-only shadow workflow, legacy workflows, ordinary
+inert MCP runtime, fixed profile inputs, concurrency, approval semantics, and
+verification requirements remain unchanged. This introduces no MCP capability
+or provider invocation.
+
+## Rollout and rollback
+
+1. Record this accepted credential-delivery decision and remove OIDC permission
+   from the permanently skipped workflow.
+2. A repository administrator manually configures `GH_TOKEN` outside source
+   control; this RFC does not authorize that action.
+3. A separate review must authorize any workflow activation and prove secret
+   non-disclosure, fixed scope, independent approval, single-attempt behavior,
+   and verification before a provider can be invoked.
+4. A separate explicit human authorization is required for one exact live
+   apply. A subsequent zero-operation apply and legacy removal each require
+   their own authorization.
+
+Emergency disablement keeps the workflow skipped and removes its protected
+environment admission or the manually configured secret through repository
+administration. It does not authorize a compensating mutation or rollback of
+provider state.
+
+## Alternatives
+
+- **Deferred materializer and GitHub OIDC:** permanently rejected for this
+  profile by the explicit human decision recorded here.
+- **Commit a token or pass it as an input:** rejected because repository
+  history, dispatch records, logs, and inputs are disclosure channels.
+- **Use the ambient `GITHUB_TOKEN` for the producer:** rejected because its
+  read-only checkout authority must remain separate from producer authority.
+- **Treat secret availability or environment review as approval:** rejected
+  because neither binds an exact fresh plan and operation digest.
+
+## Open questions
+
+- What exact least-privilege permissions and expiry policy will the manually
+  configured `GH_TOKEN` use?
+- Does the immutable producer interface support independent read and write
+  credential inputs for this profile?
+- What approval authority and protected audit integration will be qualified
+  before any activation?

--- a/.github/workflows/yukh-projects-apply.yml
+++ b/.github/workflows/yukh-projects-apply.yml
@@ -14,7 +14,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 env:
   YUKH_PROJECTS_PROFILE: yukh-mcp/project-5-issue-27-legacy-apply-v1

--- a/docs/guides/yukh-projects-shadow-migration.md
+++ b/docs/guides/yukh-projects-shadow-migration.md
@@ -34,10 +34,16 @@ the rollback surface. Their presence does not authorize apply. Removing them,
 running controlled apply, or changing Project state requires a later explicit
 approval under issue #27.
 
-The accepted protected apply design is tracked by issue #70 and RFC-0007.
+The protected apply boundary is tracked by issue #70, RFC-0007, and RFC-0008.
+RFC-0008 permanently supersedes RFC-0007 only for credential delivery:
+controlled apply must use a GitHub Actions secret named `GH_TOKEN`, configured
+manually outside repository content. `GH_TOKEN` must never be committed,
+printed, added to outputs, artifacts, caches, step summaries, or logs. The
+former materializer and GitHub OIDC delivery model is not permitted.
+
 `nomed/yukh-projects#131` is resolved in v1.6.1, but controlled apply still
 requires a fresh shadow, an independently approved exact plan, and separately
 gated operational dependencies. The repository contains only a permanently
-skipped contract shape with no steps, endpoint, materializer request,
-credentials, outputs, or producer invocation. No executable apply workflow or
-runtime authority may be added by design acceptance alone.
+skipped contract shape with no steps, secret access, outputs, or producer
+invocation. It has no OIDC permission. No executable apply workflow or runtime
+authority may be added by either RFC without separate explicit authorization.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,8 +1,8 @@
 # Threat model
 
 - Status: Initial
-- Last reviewed: 2026-08-03
-- Scope: Foundation architecture and read-only vertical slice
+- Last reviewed: 2026-08-05
+- Scope: Foundation architecture, read-only vertical slice, and inert Project 5 controlled-apply credential boundary
 - Security owner: Yukh MCP maintainers
 - Review authority: an independent maintainer for security-boundary changes
 
@@ -484,30 +484,31 @@ This increment grants no endpoint, trust material, credential, provisioning,
 bootstrap execution, live request, gateway wiring, provider execution,
 protected mutation, deployment or production authority.
 
-## Accepted protected Yukh Projects apply boundary — 2026-08-05
+## Accepted Project 5 controlled-apply credential delivery — 2026-08-05
 
-- Governing issue: #70
-- Accepted architecture: RFC-0007
-- Scope: manual plan, independent approval, OIDC-bound just-in-time material,
-  one exact controlled apply and redacted result handling
-- New trust boundaries: GitHub protected environment and OIDC identity,
-  approval authority, materializer, GitHub App credential profiles, Yukh
-  Projects apply Action and a real Coordination deployment
+- Governing issue: #27
+- Accepted architecture: RFC-0008; it supersedes RFC-0007 only for credential
+  delivery
+- Scope: manual planning, independent approval, one fixed controlled apply, and
+  redacted result handling
+- Credential boundary: a manually configured GitHub Actions secret named
+  `GH_TOKEN`; neither OIDC nor a materializer is a permitted delivery path
 
-RFC-0007 authorizes no live implementation. Its principal threats and controls
-are:
+RFC-0008 retains RFC-0007's exact fresh-plan, independent-approval, fixed-scope,
+single-attempt, verification, and redacted-evidence controls. It authorizes no
+live implementation. Its principal threats and controls are:
 
-| Threat | Proposed control | Residual risk / dependency |
+| Threat | Required control | Residual risk / dependency |
 | --- | --- | --- |
-| dispatch, issue state or environment review becomes approval | independent Ed25519 approval bound to the exact plan, operation digest, scope, policy commit and environment | approval identity and custody profile is not selected |
-| static or replayed authority reaches a runner | exact OIDC run binding, one-shot package, fifteen-minute maximum and `run_attempt == 1` | GitHub identity and materializer compromise remain trusted dependencies |
-| one credential silently gains all authority | distinct short-lived read and write installation profiles plus exact permission attestation | concrete GitHub App installations are not provisioned or qualified |
-| approval, DPoP key, token or host capsule leaks | bounded closed package, immediate masking, exclusive runtime files, no artifact/cache/output and unconditional cleanup | hosted-runner compromise can observe process memory |
-| changed or ambiguous state is mutated or retried | fresh exact replan, nonce consumption, fenced lease, one attempt, no retry and final zero convergence | unknown completion still requires operator reconciliation |
+| dispatch, issue state, secret presence, or environment review becomes approval | independent approval bound to the exact plan, operation digest, scope, policy commit, and environment | approval identity and custody profile still require separate qualification |
+| `GH_TOKEN` is committed, printed, or retained | configure it manually as a GitHub Actions secret; pass it only to the reviewed pinned action; no output, artifact, cache, summary, log, or repository value may contain it | a runner or GitHub secret-store compromise can expose a secret available to that run |
+| the deprecated OIDC/materializer path is reintroduced | no `id-token: write` permission, materializer request, package, endpoint, or OIDC trust is allowed in this profile | reviewed workflow changes could still attempt an unauthorized redesign |
+| one credential silently gains all authority | keep the workflow `GITHUB_TOKEN` at `contents: read` and never pass it to the producer; use `GH_TOKEN` only for the producer's fixed Project 5 issue #27 authority; use independent producer read/write credentials if its reviewed interface makes that technically possible | a one-token producer interface cannot provide independent provider read/write credentials |
+| changed or ambiguous state is mutated or retried | fresh exact replan, independent approval, one attempt, no retry, and final zero-operation verification | unknown completion still requires operator reconciliation |
 | an approved plan exceeds the run budget partway through | producer pre-admits the complete request graph before the first mutation; `yukh-projects#131` blocks implementation | provider cost changes require a fresh qualification |
-| consumer silently broadens scope | first profile fixes repository, Project, issue, mode, producer and environment in reviewed source | any generalized or batch profile requires another RFC |
+| consumer silently broadens scope | reviewed source fixes repository, Project, issue, mode, producer, and environment | any generalized or batch profile requires another RFC |
 
-Acceptance authorizes only a separately reviewed inert workflow contract,
-materializer interface and synthetic negative tests. It would not authorize an
-Actions environment, OIDC trust, broker, credential, approval, Coordination
-endpoint, provider access, mutation, deployment or migration.
+The workflow remains permanently skipped and does not access `GH_TOKEN`.
+Manually configuring the secret, enabling the workflow, passing the secret to a
+producer, invoking a provider, or applying a plan each require separate explicit
+authorization.

--- a/test/supply-chain/workflows.test.mjs
+++ b/test/supply-chain/workflows.test.mjs
@@ -118,16 +118,18 @@ test("Yukh Projects shadow policy is versioned with its workflow", () => {
   assert.match(source, /^  overwrite_human_values: false$/mu);
 });
 
-test("accepted RFC-0007 permits only an inert protected apply contract", () => {
+test("accepted RFC-0008 keeps GH_TOKEN delivery contract inert", () => {
   const rfc = readFileSync(
     new URL(
-      "../../.context/rfcs/RFC-0007-protected-yukh-projects-apply-boundary.md",
+      "../../.context/rfcs/RFC-0008-gh-token-controlled-apply-credential-delivery.md",
       import.meta.url,
     ),
     "utf8",
   );
   assert.match(rfc, /^- Status: Accepted$/mu);
   assert.match(rfc, /^- Accepted: 2026-08-05$/mu);
+  assert.match(rfc, /^- Supersedes: RFC-0007 only for credential delivery$/mu);
+  assert.match(rfc, /GitHub Actions secret named `GH_TOKEN`/u);
   const source = readFileSync(new URL("yukh-projects-apply.yml", directory), "utf8");
   assert.equal(workflows.includes("yukh-projects-apply.yml"), true);
   assert.match(source, /^  workflow_dispatch:\n    inputs:/mu);
@@ -151,7 +153,8 @@ test("accepted RFC-0007 permits only an inert protected apply contract", () => {
   assert.match(source, /^  YUKH_PROJECTS_PROJECT_NUMBER: "5"$/mu);
   assert.match(source, /^  YUKH_PROJECTS_ISSUE_NUMBER: "27"$/mu);
   assert.match(source, /^  YUKH_PROJECTS_MODE: legacy-apply-v1$/mu);
-  assert.match(source, /^permissions:\n  contents: read\n  id-token: write$/mu);
+  assert.match(source, /^permissions:\n  contents: read$/mu);
+  assert.doesNotMatch(source, /id-token:/u);
   assert.match(
     source,
     /^concurrency:\n  group: yukh-projects-protected-apply-project-5-issue-27\n  cancel-in-progress: false$/mu,


### PR DESCRIPTION
Records the owner-approved permanent GH_TOKEN credential-delivery model. RFC-0008 supersedes RFC-0007 only for credential delivery; the workflow remains permanently skipped. No secret, environment, provider invocation, or apply is included.