### PR TITLE
docs: prepare inactive GH token apply workflow

### DIFF
--- a/.github/workflows/yukh-projects-apply.yml
+++ b/.github/workflows/yukh-projects-apply.yml
@@ -1,4 +1,4 @@
-name: Yukh Projects protected controlled apply (inert)
+name: Yukh Projects future controlled apply (permanently skipped)
 
 on:
   workflow_dispatch:
@@ -30,7 +30,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  protected-apply-contract:
+  future-controlled-apply:
     if: ${{ false && github.run_attempt == '1' }}
     runs-on: ubuntu-latest
     environment:

--- a/docs/guides/yukh-projects-shadow-migration.md
+++ b/docs/guides/yukh-projects-shadow-migration.md
@@ -43,7 +43,20 @@ former materializer and GitHub OIDC delivery model is not permitted.
 
 `nomed/yukh-projects#131` is resolved in v1.6.1, but controlled apply still
 requires a fresh shadow, an independently approved exact plan, and separately
-gated operational dependencies. The repository contains only a permanently
-skipped contract shape with no steps, secret access, outputs, or producer
-invocation. It has no OIDC permission. No executable apply workflow or runtime
-authority may be added by either RFC without separate explicit authorization.
+gated operational dependencies. The repository contains only the
+`future-controlled-apply` contract job. Its hard-coded false condition is
+permanent: it has no steps, secret access, outputs, or producer invocation.
+The job fixes the repository, Project 5, issue #27, policy path, mode,
+environment, producer pin, concurrency group, ten-minute limit, and
+first-attempt-only constraint for a future reviewed implementation. It has no
+OIDC permission.
+
+An independently issued approval for a freshly recreated exact plan and a
+reviewed host-capsule/Coordination profile remain absent. Neither a dispatch,
+an environment review, issue state, nor the presence of `GH_TOKEN` can replace
+either control. `GH_TOKEN` is deliberately documented only: no workflow job
+references it while the contract is skipped. The currently pinned producer
+Action is a bounded dry-run interface, not a qualified apply interface. A
+separate explicit authorization and review must qualify an immutable apply
+interface and the approval and host controls before any condition, secret
+reference, or provider invocation can be added.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -504,11 +504,14 @@ live implementation. Its principal threats and controls are:
 | `GH_TOKEN` is committed, printed, or retained | configure it manually as a GitHub Actions secret; pass it only to the reviewed pinned action; no output, artifact, cache, summary, log, or repository value may contain it | a runner or GitHub secret-store compromise can expose a secret available to that run |
 | the deprecated OIDC/materializer path is reintroduced | no `id-token: write` permission, materializer request, package, endpoint, or OIDC trust is allowed in this profile | reviewed workflow changes could still attempt an unauthorized redesign |
 | one credential silently gains all authority | keep the workflow `GITHUB_TOKEN` at `contents: read` and never pass it to the producer; use `GH_TOKEN` only for the producer's fixed Project 5 issue #27 authority; use independent producer read/write credentials if its reviewed interface makes that technically possible | a one-token producer interface cannot provide independent provider read/write credentials |
+| an absent approval or host-capsule/Coordination control is mistaken for authorization | the only apply job has a hard-coded false condition, no steps, secret access, or producer invocation; a future review must separately qualify the approval and host controls | GitHub source alone cannot establish either external control |
 | changed or ambiguous state is mutated or retried | fresh exact replan, independent approval, one attempt, no retry, and final zero-operation verification | unknown completion still requires operator reconciliation |
 | an approved plan exceeds the run budget partway through | producer pre-admits the complete request graph before the first mutation; `yukh-projects#131` blocks implementation | provider cost changes require a fresh qualification |
 | consumer silently broadens scope | reviewed source fixes repository, Project, issue, mode, producer, and environment | any generalized or batch profile requires another RFC |
 
-The workflow remains permanently skipped and does not access `GH_TOKEN`.
-Manually configuring the secret, enabling the workflow, passing the secret to a
-producer, invoking a provider, or applying a plan each require separate explicit
+The `future-controlled-apply` workflow job remains permanently skipped and does
+not access `GH_TOKEN`. No approval authority or reviewed
+host-capsule/Coordination profile is configured by this source. Manually
+configuring the secret, enabling the job, passing the secret to a producer,
+invoking a provider, or applying a plan each require separate explicit
 authorization.

--- a/test/supply-chain/workflows.test.mjs
+++ b/test/supply-chain/workflows.test.mjs
@@ -159,10 +159,14 @@ test("accepted RFC-0008 keeps GH_TOKEN delivery contract inert", () => {
     source,
     /^concurrency:\n  group: yukh-projects-protected-apply-project-5-issue-27\n  cancel-in-progress: false$/mu,
   );
-  assert.match(source, /^\s+if: \$\{\{ false && github\.run_attempt == '1' \}\}$/mu);
+  assert.match(
+    source,
+    /^  future-controlled-apply:\n    if: \$\{\{ false && github\.run_attempt == '1' \}\}$/mu,
+  );
   assert.match(source, /^\s+name: yukh-projects-controlled-apply$/mu);
   assert.match(source, /^\s+timeout-minutes: 10$/mu);
   assert.match(source, /^\s+steps: \[\]$/mu);
+  assert.match(source, /^name: Yukh Projects future controlled apply \(permanently skipped\)$/mu);
   assert.doesNotMatch(source, /^\s*(?:run|uses|outputs):/mu);
   assert.doesNotMatch(
     source,
@@ -171,4 +175,13 @@ test("accepted RFC-0008 keeps GH_TOKEN delivery contract inert", () => {
   assert.doesNotMatch(source, /https?:\/\/|secrets\.|GITHUB_TOKEN|github-token/iu);
   assert.doesNotMatch(source, /(?:credential|endpoint|materializer|url):/iu);
   assert.doesNotMatch(source, /apply-action|apply-enabled|upload-artifact|cache:/iu);
+
+  const guide = readFileSync(
+    new URL("../../docs/guides/yukh-projects-shadow-migration.md", import.meta.url),
+    "utf8",
+  );
+  assert.match(guide, /`future-controlled-apply` contract job/u);
+  assert.match(guide, /hard-coded false condition is\s+permanent/u);
+  assert.match(guide, /approval.*host-capsule\/Coordination profile remain absent/su);
+  assert.match(guide, /no workflow job\s+references it while the contract is skipped/u);
 });


### PR DESCRIPTION
Prepares the final fixed-scope GH_TOKEN workflow contract while keeping the sole job hard-disabled and step-free. No secret is referenced, no provider is invoked, and no apply is enabled pending approval and host-capsule materials.