### PR TITLE
docs: rename controlled apply write secret

### DIFF
--- a/.context/rfcs/RFC-0009-yukh-projects-write-token-secret-name.md
+++ b/.context/rfcs/RFC-0009-yukh-projects-write-token-secret-name.md
@@ -1,0 +1,17 @@
+# RFC-0009 — Yukh Projects write-token secret name
+
+- Status: Accepted
+- Created: 2026-08-05
+- Accepted: 2026-08-05
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/27
+- Supersedes: RFC-0008 credential-secret name only
+
+## Decision
+
+The fixed GitHub Actions secret for the Project 5 controlled-apply profile is
+named `YUKH_PROJECTS_WRITE_TOKEN`.
+
+It replaces the ambiguous `GH_TOKEN` name in RFC-0008. The token is configured
+manually outside repository content, is never committed or printed, and is
+passed only to a future reviewed fixed-scope producer invocation. This change
+does not enable the inert workflow or authorize an apply.

--- a/docs/guides/yukh-projects-shadow-migration.md
+++ b/docs/guides/yukh-projects-shadow-migration.md
@@ -36,8 +36,8 @@ approval under issue #27.
 
 The protected apply boundary is tracked by issue #70, RFC-0007, and RFC-0008.
 RFC-0008 permanently supersedes RFC-0007 only for credential delivery:
-controlled apply must use a GitHub Actions secret named `GH_TOKEN`, configured
-manually outside repository content. `GH_TOKEN` must never be committed,
+controlled apply must use a GitHub Actions secret named `YUKH_PROJECTS_WRITE_TOKEN`, configured
+manually outside repository content. `YUKH_PROJECTS_WRITE_TOKEN` must never be committed,
 printed, added to outputs, artifacts, caches, step summaries, or logs. The
 former materializer and GitHub OIDC delivery model is not permitted.
 
@@ -53,8 +53,8 @@ OIDC permission.
 
 An independently issued approval for a freshly recreated exact plan and a
 reviewed host-capsule/Coordination profile remain absent. Neither a dispatch,
-an environment review, issue state, nor the presence of `GH_TOKEN` can replace
-either control. `GH_TOKEN` is deliberately documented only: no workflow job
+an environment review, issue state, nor the presence of `YUKH_PROJECTS_WRITE_TOKEN` can replace
+either control. `YUKH_PROJECTS_WRITE_TOKEN` is deliberately documented only: no workflow job
 references it while the contract is skipped. The currently pinned producer
 Action is a bounded dry-run interface, not a qualified apply interface. A
 separate explicit authorization and review must qualify an immutable apply

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -492,7 +492,7 @@ protected mutation, deployment or production authority.
 - Scope: manual planning, independent approval, one fixed controlled apply, and
   redacted result handling
 - Credential boundary: a manually configured GitHub Actions secret named
-  `GH_TOKEN`; neither OIDC nor a materializer is a permitted delivery path
+  `YUKH_PROJECTS_WRITE_TOKEN`; neither OIDC nor a materializer is a permitted delivery path
 
 RFC-0008 retains RFC-0007's exact fresh-plan, independent-approval, fixed-scope,
 single-attempt, verification, and redacted-evidence controls. It authorizes no
@@ -501,9 +501,9 @@ live implementation. Its principal threats and controls are:
 | Threat | Required control | Residual risk / dependency |
 | --- | --- | --- |
 | dispatch, issue state, secret presence, or environment review becomes approval | independent approval bound to the exact plan, operation digest, scope, policy commit, and environment | approval identity and custody profile still require separate qualification |
-| `GH_TOKEN` is committed, printed, or retained | configure it manually as a GitHub Actions secret; pass it only to the reviewed pinned action; no output, artifact, cache, summary, log, or repository value may contain it | a runner or GitHub secret-store compromise can expose a secret available to that run |
+| `YUKH_PROJECTS_WRITE_TOKEN` is committed, printed, or retained | configure it manually as a GitHub Actions secret; pass it only to the reviewed pinned action; no output, artifact, cache, summary, log, or repository value may contain it | a runner or GitHub secret-store compromise can expose a secret available to that run |
 | the deprecated OIDC/materializer path is reintroduced | no `id-token: write` permission, materializer request, package, endpoint, or OIDC trust is allowed in this profile | reviewed workflow changes could still attempt an unauthorized redesign |
-| one credential silently gains all authority | keep the workflow `GITHUB_TOKEN` at `contents: read` and never pass it to the producer; use `GH_TOKEN` only for the producer's fixed Project 5 issue #27 authority; use independent producer read/write credentials if its reviewed interface makes that technically possible | a one-token producer interface cannot provide independent provider read/write credentials |
+| one credential silently gains all authority | keep the workflow `GITHUB_TOKEN` at `contents: read` and never pass it to the producer; use `YUKH_PROJECTS_WRITE_TOKEN` only for the producer's fixed Project 5 issue #27 authority; use independent producer read/write credentials if its reviewed interface makes that technically possible | a one-token producer interface cannot provide independent provider read/write credentials |
 | an absent approval or host-capsule/Coordination control is mistaken for authorization | the only apply job has a hard-coded false condition, no steps, secret access, or producer invocation; a future review must separately qualify the approval and host controls | GitHub source alone cannot establish either external control |
 | changed or ambiguous state is mutated or retried | fresh exact replan, independent approval, one attempt, no retry, and final zero-operation verification | unknown completion still requires operator reconciliation |
 | an approved plan exceeds the run budget partway through | producer pre-admits the complete request graph before the first mutation; `yukh-projects#131` blocks implementation | provider cost changes require a fresh qualification |

--- a/test/supply-chain/workflows.test.mjs
+++ b/test/supply-chain/workflows.test.mjs
@@ -118,7 +118,7 @@ test("Yukh Projects shadow policy is versioned with its workflow", () => {
   assert.match(source, /^  overwrite_human_values: false$/mu);
 });
 
-test("accepted RFC-0008 keeps GH_TOKEN delivery contract inert", () => {
+test("accepted RFC-0008 keeps write-token delivery contract inert", () => {
   const rfc = readFileSync(
     new URL(
       "../../.context/rfcs/RFC-0008-gh-token-controlled-apply-credential-delivery.md",


### PR DESCRIPTION
Supersedes only the secret name from RFC-0008: `YUKH_PROJECTS_WRITE_TOKEN` replaces ambiguous `GH_TOKEN`. The workflow remains inactive and no secret value is referenced in source.