### PR TITLE
feat: pin single-token apply release

### DIFF
--- a/.github/workflows/yukh-projects-apply.yml
+++ b/.github/workflows/yukh-projects-apply.yml
@@ -17,13 +17,13 @@ permissions:
 
 env:
   YUKH_PROJECTS_PROFILE: yukh-mcp/project-5-issue-27-legacy-apply-v1
-  YUKH_PROJECTS_PRODUCER_REF: nomed/yukh-projects@e3285c6994edd8fad1666da6ca48386522c9e90f
+  YUKH_PROJECTS_PRODUCER_REF: nomed/yukh-projects@71784218366805922e5a12903eef9073f715f59f
   YUKH_PROJECTS_OWNER: nomed
   YUKH_PROJECTS_REPOSITORY: yukh-mcp
   YUKH_PROJECTS_PROJECT_NUMBER: "5"
   YUKH_PROJECTS_ISSUE_NUMBER: "27"
   YUKH_PROJECTS_POLICY_PATH: .yukh/project.yaml
-  YUKH_PROJECTS_MODE: legacy-apply-v1
+  YUKH_PROJECTS_MODE: legacy-single-token-apply-v1
 
 concurrency:
   group: yukh-projects-protected-apply-project-5-issue-27
@@ -36,4 +36,6 @@ jobs:
     environment:
       name: yukh-projects-controlled-apply
     timeout-minutes: 10
+    env:
+      YUKH_PROJECTS_WRITE_TOKEN: ${{ secrets.YUKH_PROJECTS_WRITE_TOKEN }}
     steps: []

--- a/.github/workflows/yukh-projects-shadow.yml
+++ b/.github/workflows/yukh-projects-shadow.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Produce successor dry-run
         id: shadow
-        uses: nomed/yukh-projects@e3285c6994edd8fad1666da6ca48386522c9e90f # v1.6.1
+        uses: nomed/yukh-projects@71784218366805922e5a12903eef9073f715f59f # v1.7.0
         with:
           mode: legacy-shadow
           github-token: ${{ secrets.YUKH_PROJECT_TOKEN }}

--- a/docs/guides/yukh-projects-shadow-migration.md
+++ b/docs/guides/yukh-projects-shadow-migration.md
@@ -1,8 +1,8 @@
 # Yukh Projects shadow migration
 
 The `Yukh Projects shadow reconciliation` workflow audits one Project 5 issue
-without mutation. It pins the immutable `yukh-projects` v1.6.1 commit
-`e3285c6994edd8fad1666da6ca48386522c9e90f` and selects the bounded
+without mutation. It pins the immutable `yukh-projects` v1.7.0 commit
+`71784218366805922e5a12903eef9073f715f59f` and selects the bounded
 `legacy-shadow` adapter. It accepts no apply mode, approval artifact, or write
 credential.
 
@@ -14,7 +14,7 @@ the migration pull request before requesting controlled apply.
 The distinct `Area` contract remains separate from `Component`. The current
 policy targets native Issue Type for `kind`; `project_field: Work Type` remains
 only the required declarative fallback for a user-owned repository. GitHub
-reports `nomed/yukh-mcp` as user-owned, so v1.6.1 must report the same Project
+reports `nomed/yukh-mcp` as user-owned, so v1.7.0 must report the same Project
 `Work Type` fallback as controlled planning. A fresh shadow must prove this
 parity while preserving human-owned `Status` and the existing `Component`
 value.
@@ -41,22 +41,24 @@ manually outside repository content. `YUKH_PROJECTS_WRITE_TOKEN` must never be c
 printed, added to outputs, artifacts, caches, step summaries, or logs. The
 former materializer and GitHub OIDC delivery model is not permitted.
 
-`nomed/yukh-projects#131` is resolved in v1.6.1, but controlled apply still
+`nomed/yukh-projects#131` is resolved in v1.7.0, but controlled apply still
 requires a fresh shadow, an independently approved exact plan, and separately
 gated operational dependencies. The repository contains only the
 `future-controlled-apply` contract job. Its hard-coded false condition is
-permanent: it has no steps, secret access, outputs, or producer invocation.
-The job fixes the repository, Project 5, issue #27, policy path, mode,
-environment, producer pin, concurrency group, ten-minute limit, and
-first-attempt-only constraint for a future reviewed implementation. It has no
-OIDC permission.
+permanent: it has no steps, outputs, or producer invocation. The job fixes the
+repository, Project 5, issue #27, policy path, mode
+`legacy-single-token-apply-v1`, environment, producer pin, concurrency group,
+ten-minute limit, and first-attempt-only constraint for a future reviewed
+implementation. It has no OIDC permission.
 
 An independently issued approval for a freshly recreated exact plan and a
 reviewed host-capsule/Coordination profile remain absent. Neither a dispatch,
 an environment review, issue state, nor the presence of `YUKH_PROJECTS_WRITE_TOKEN` can replace
-either control. `YUKH_PROJECTS_WRITE_TOKEN` is deliberately documented only: no workflow job
-references it while the contract is skipped. The currently pinned producer
-Action is a bounded dry-run interface, not a qualified apply interface. A
-separate explicit authorization and review must qualify an immutable apply
-interface and the approval and host controls before any condition, secret
-reference, or provider invocation can be added.
+either control. The only `secrets.YUKH_PROJECTS_WRITE_TOKEN` expression is
+job-local to `future-controlled-apply`; its permanent false condition prevents
+the job, runner, and secret resolution. It is a reference only, not a configured
+or exposed secret. The pinned shadow Action is a bounded dry-run interface;
+although v1.7.0 defines the reviewed single-token mode for its separate apply
+entrypoint, this source does not invoke it. A separate explicit authorization
+and review must qualify an immutable apply interface and the approval and host
+controls before any condition change or provider invocation can be added.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -501,17 +501,17 @@ live implementation. Its principal threats and controls are:
 | Threat | Required control | Residual risk / dependency |
 | --- | --- | --- |
 | dispatch, issue state, secret presence, or environment review becomes approval | independent approval bound to the exact plan, operation digest, scope, policy commit, and environment | approval identity and custody profile still require separate qualification |
-| `YUKH_PROJECTS_WRITE_TOKEN` is committed, printed, or retained | configure it manually as a GitHub Actions secret; pass it only to the reviewed pinned action; no output, artifact, cache, summary, log, or repository value may contain it | a runner or GitHub secret-store compromise can expose a secret available to that run |
+| `YUKH_PROJECTS_WRITE_TOKEN` is committed, printed, or retained | configure it manually as a GitHub Actions secret; keep its sole workflow expression job-local to the permanently skipped contract; no output, artifact, cache, summary, log, or repository value may contain it | a runner or GitHub secret-store compromise can expose a secret available to a future authorized run |
 | the deprecated OIDC/materializer path is reintroduced | no `id-token: write` permission, materializer request, package, endpoint, or OIDC trust is allowed in this profile | reviewed workflow changes could still attempt an unauthorized redesign |
-| one credential silently gains all authority | keep the workflow `GITHUB_TOKEN` at `contents: read` and never pass it to the producer; use `YUKH_PROJECTS_WRITE_TOKEN` only for the producer's fixed Project 5 issue #27 authority; use independent producer read/write credentials if its reviewed interface makes that technically possible | a one-token producer interface cannot provide independent provider read/write credentials |
-| an absent approval or host-capsule/Coordination control is mistaken for authorization | the only apply job has a hard-coded false condition, no steps, secret access, or producer invocation; a future review must separately qualify the approval and host controls | GitHub source alone cannot establish either external control |
+| one credential silently gains all authority | keep the workflow `GITHUB_TOKEN` at `contents: read` and never pass it to the producer; the reviewed `legacy-single-token-apply-v1` exception may use `YUKH_PROJECTS_WRITE_TOKEN` as both producer credentials only for this fixed Project 5 issue #27 scope | sharing credentials outside that exact reviewed mode remains prohibited |
+| an absent approval or host-capsule/Coordination control is mistaken for authorization | the only apply job has a hard-coded false condition, no steps, runner, or producer invocation; its job-local secret expression cannot resolve; a future review must separately qualify the approval and host controls | GitHub source alone cannot establish either external control |
 | changed or ambiguous state is mutated or retried | fresh exact replan, independent approval, one attempt, no retry, and final zero-operation verification | unknown completion still requires operator reconciliation |
 | an approved plan exceeds the run budget partway through | producer pre-admits the complete request graph before the first mutation; `yukh-projects#131` blocks implementation | provider cost changes require a fresh qualification |
 | consumer silently broadens scope | reviewed source fixes repository, Project, issue, mode, producer, and environment | any generalized or batch profile requires another RFC |
 
-The `future-controlled-apply` workflow job remains permanently skipped and does
-not access `GH_TOKEN`. No approval authority or reviewed
-host-capsule/Coordination profile is configured by this source. Manually
-configuring the secret, enabling the job, passing the secret to a producer,
-invoking a provider, or applying a plan each require separate explicit
-authorization.
+The `future-controlled-apply` workflow job remains permanently skipped. Its
+sole `secrets.YUKH_PROJECTS_WRITE_TOKEN` expression is job-local, and no runner
+exists to resolve it. No approval authority or reviewed host-capsule/Coordination
+profile is configured by this source. Manually configuring the secret, enabling
+the job, passing the secret to a producer, invoking a provider, or applying a
+plan each require separate explicit authorization.

--- a/test/supply-chain/workflows.test.mjs
+++ b/test/supply-chain/workflows.test.mjs
@@ -85,7 +85,7 @@ test("workflow inventory is explicit", () => {
 
 test("Yukh Projects migration remains manual, immutable, and shadow-only", () => {
   const source = readFileSync(new URL("yukh-projects-shadow.yml", directory), "utf8");
-  assert.match(source, /nomed\/yukh-projects@e3285c6994edd8fad1666da6ca48386522c9e90f/u);
+  assert.match(source, /nomed\/yukh-projects@71784218366805922e5a12903eef9073f715f59f/u);
   assert.match(source, /workflow_dispatch:/u);
   assert.equal(source.includes("issues:"), true);
   assert.equal(source.includes("types: [opened"), false);
@@ -118,7 +118,7 @@ test("Yukh Projects shadow policy is versioned with its workflow", () => {
   assert.match(source, /^  overwrite_human_values: false$/mu);
 });
 
-test("accepted RFC-0008 keeps write-token delivery contract inert", () => {
+test("Yukh Projects controlled-apply contract remains inert", () => {
   const rfc = readFileSync(
     new URL(
       "../../.context/rfcs/RFC-0008-gh-token-controlled-apply-credential-delivery.md",
@@ -148,11 +148,11 @@ test("accepted RFC-0008 keeps write-token delivery contract inert", () => {
   assert.match(source, /^  YUKH_PROJECTS_PROFILE: yukh-mcp\/project-5-issue-27-legacy-apply-v1$/mu);
   assert.match(
     source,
-    /^  YUKH_PROJECTS_PRODUCER_REF: nomed\/yukh-projects@e3285c6994edd8fad1666da6ca48386522c9e90f$/mu,
+    /^  YUKH_PROJECTS_PRODUCER_REF: nomed\/yukh-projects@71784218366805922e5a12903eef9073f715f59f$/mu,
   );
   assert.match(source, /^  YUKH_PROJECTS_PROJECT_NUMBER: "5"$/mu);
   assert.match(source, /^  YUKH_PROJECTS_ISSUE_NUMBER: "27"$/mu);
-  assert.match(source, /^  YUKH_PROJECTS_MODE: legacy-apply-v1$/mu);
+  assert.match(source, /^  YUKH_PROJECTS_MODE: legacy-single-token-apply-v1$/mu);
   assert.match(source, /^permissions:\n  contents: read$/mu);
   assert.doesNotMatch(source, /id-token:/u);
   assert.match(
@@ -165,6 +165,10 @@ test("accepted RFC-0008 keeps write-token delivery contract inert", () => {
   );
   assert.match(source, /^\s+name: yukh-projects-controlled-apply$/mu);
   assert.match(source, /^\s+timeout-minutes: 10$/mu);
+  assert.match(
+    source,
+    /^    env:\n      YUKH_PROJECTS_WRITE_TOKEN: \$\{\{ secrets\.YUKH_PROJECTS_WRITE_TOKEN \}\}$/mu,
+  );
   assert.match(source, /^\s+steps: \[\]$/mu);
   assert.match(source, /^name: Yukh Projects future controlled apply \(permanently skipped\)$/mu);
   assert.doesNotMatch(source, /^\s*(?:run|uses|outputs):/mu);
@@ -172,7 +176,11 @@ test("accepted RFC-0008 keeps write-token delivery contract inert", () => {
     source,
     /^  (?:pull_request|push|repository_dispatch|schedule|workflow_call|workflow_run):/mu,
   );
-  assert.doesNotMatch(source, /https?:\/\/|secrets\.|GITHUB_TOKEN|github-token/iu);
+  assert.deepEqual(
+    [...source.matchAll(/secrets\.[A-Z_]+/gu)].map((match) => match[0]),
+    ["secrets.YUKH_PROJECTS_WRITE_TOKEN"],
+  );
+  assert.doesNotMatch(source, /https?:\/\/|GITHUB_TOKEN|github-token/iu);
   assert.doesNotMatch(source, /(?:credential|endpoint|materializer|url):/iu);
   assert.doesNotMatch(source, /apply-action|apply-enabled|upload-artifact|cache:/iu);
 
@@ -183,5 +191,6 @@ test("accepted RFC-0008 keeps write-token delivery contract inert", () => {
   assert.match(guide, /`future-controlled-apply` contract job/u);
   assert.match(guide, /hard-coded false condition is\s+permanent/u);
   assert.match(guide, /approval.*host-capsule\/Coordination profile remain absent/su);
-  assert.match(guide, /no workflow job\s+references it while the contract is skipped/u);
+  assert.match(guide, /only `secrets\.YUKH_PROJECTS_WRITE_TOKEN` expression is\s+job-local/u);
+  assert.match(guide, /mode\s+`legacy-single-token-apply-v1`/u);
 });


### PR DESCRIPTION
Pins yukh-projects v1.7.0 and records legacy-single-token-apply-v1 with secrets.YUKH_PROJECTS_WRITE_TOKEN in the still permanently skipped job. No apply is invoked.