### PR TITLE
Align audit context after writer foundation

### DIFF
--- a/.context/sessions/SESSION-2026-08-06-02-audit-context-alignment.md
+++ b/.context/sessions/SESSION-2026-08-06-02-audit-context-alignment.md
@@ -1,0 +1,59 @@
+# Session — audit context alignment
+
+- Date: 2026-08-06
+- Governing issues: https://github.com/nomed/yukh-mcp/issues/84 and https://github.com/nomed/yukh-mcp/issues/86
+- Alignment pull request: https://github.com/nomed/yukh-mcp/pull/88
+- Referenced pull requests: https://github.com/nomed/yukh-mcp/pull/85 and https://github.com/nomed/yukh-mcp/pull/87
+- Status: Context aligned; RFC-0010 proposal remains under review
+
+## Objective
+
+Align the nearest non-authoritative navigation record after the audit writer
+foundation merged and the repository-local durability profile reached a
+review-clean proposal head. This session record is used because the repository
+does not contain `.context/current.md`.
+
+## Work completed
+
+- Issue #84 / PR #85 merged the storage-neutral RFC-0004 audit writer
+  foundation to `main` at
+  `1fdcac661041e9b466a22bef341e78f35a6db559`.
+- Open issue #86 governs the repository-local durable audit and recovery
+  profile proposal.
+- Open PR #87 proposes RFC-0010 and its threat-model delta. Its review-clean
+  head is `53b53617ea8ee2c7171b2ad8e7b2209abf3d383d`.
+
+## Evidence and validation
+
+- The alignment branch starts at the PR #85 merge on current `main`.
+- The PR #87 head and its delta from `main` were inspected without importing
+  them into this branch.
+- `python3 -m mkdocs build --strict` completed successfully.
+- Contract and supply-chain validation passed all 68 tests; runtime validation
+  passed all 44 tests through Node's `--import tsx` path.
+
+## Decisions discovered
+
+RFC-0010 remains **Proposed**. No durable adapter, provider, or mutation is
+authorized. Acceptance must be explicit before a separately governed
+implementation may begin.
+
+The merged foundation defines storage-neutral writer and recovery-journal
+ports; it does not select or activate a durable store, recovery backend,
+checkpoint authority, provider integration, or live mutation path.
+
+## Context impact
+
+This non-authoritative session record only navigates merged and proposed work.
+It does not accept RFC-0010, modify an accepted RFC, or change architecture,
+security policy, runtime behavior, credentials, endpoints, deployment, or
+provider wiring.
+
+## Risks and unresolved work
+
+- RFC-0010 requires explicit owner acceptance and merge before it can govern
+  implementation.
+- Any durable adapter must use a separate focused issue and pull request after
+  acceptance.
+- Recovery import and acknowledgement remain subject to the additional
+  storage-neutral event-registry work identified by PR #87.


### PR DESCRIPTION
## Summary

- add the nearest non-authoritative session/navigation record because `.context/current.md` is absent
- record issue #84 / merged PR #85 as the storage-neutral audit writer foundation baseline
- record open issue #86 / PR #87 at review-clean head `53b53617ea8ee2c7171b2ad8e7b2209abf3d383d`
- state explicitly that RFC-0010 remains Proposed and no durable adapter, provider, or mutation is authorized

## Governing issue

Relates to #84 and #86.

## Security impact

- [x] No security-boundary impact
- [ ] Threat model updated
- [ ] Security review required

Explain: Documentation-only context alignment. It introduces no runtime, credential, endpoint, provider, persistence, mutation, or deployment change and edits no accepted RFC.

## Context impact

- [ ] No context impact
- [x] Session/handoff updated
- [ ] ADR/RFC proposed or superseded

Explain: Adds one non-authoritative session record. RFC-0010 remains Proposed.

## Validation

- `git diff --check` — passed
- `python3 -m mkdocs build --strict` — passed
- contract and supply-chain tests — 68 passed
- runtime tests via `node --import tsx --test test/runtime/*.test.ts` — 44 passed
- the repository's `tsx --test` wrapper encountered an environment-specific IPC socket collision; running the same runtime suite through Node's supported `--import tsx` path passed all tests

## Checklist

- [x] Change is narrowly scoped.
- [x] Public behavior and documentation agree.
- [x] Negative and failure paths are covered or unaffected.
- [x] No secrets or sensitive infrastructure data are included.
- [x] Dependencies and workflow actions are intentionally pinned.
