### PR TITLE
Implement repository-local durable audit adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ dist/
 coverage/
 site/
 .audit-test-scratch/
+.yukh/runtime/
 *.log

--- a/docs/reference/audit-writer.md
+++ b/docs/reference/audit-writer.md
@@ -14,19 +14,28 @@ pre-effect evidence requirement in RFC-0003 apply admission step 9. It provides:
   hash;
 - exact duplicate handling and conflicting event-identity rejection;
 - retained-range chain verification; and
-- lifecycle guards that require a durable receipt before provider start and use
-  a separate bounded recovery fact after provider start.
+- lifecycle guards that require durable receipts plus a final typed
+  audit-readiness check immediately before provider start, and use a separate
+  bounded recovery fact after provider start.
 
 `InMemoryAuditStore` is only a deterministic conformance store. Its receipts are
 marked `volatile_test_only`, so `commitBeforeProviderStart` rejects them and does
-not call the supplied provider-start callback. The guard requires complete
-causal evidence through attempt reservation. Planning authorization is labeled
-and bound to the plan; after plan creation and any approval, a distinct
-apply-phase evaluation, explicit allow decision, and enforcement triplet is
-bound to apply admission. A future store must implement the `AuditStore` port,
-atomically compare event identity and stream head, and return `durable` only
-after committing the exact event bytes, candidate digest, sequence, and previous
-hash under a separately accepted deployment profile.
+not call the supplied provider-start callback. Even durable exact-duplicate
+receipts are non-authorizing: the guard calls the separate
+`RequiredAuditReadiness` port after the final receipt and denies if current
+health is failed. The guard requires complete causal evidence through attempt
+reservation. Planning authorization is labeled and bound to the plan; after
+plan creation and any approval, a distinct apply-phase evaluation, explicit
+allow decision, and enforcement triplet is bound to apply admission. A future
+store must implement the `AuditStore` port, atomically compare event identity and
+stream head, and return `durable` only after committing the exact event bytes,
+candidate digest, sequence, and previous hash under a separately accepted
+deployment profile.
+
+The repository-local implementation keeps Linux ext-family qualification. It
+fails closed on APFS because the supported Node runtime has no descriptor-based
+ACL inspection API, and reopening a path for an ACL utility would introduce a
+substitution race. It therefore makes no APFS qualification claim.
 
 Canonical JSON sorts object keys by code unit, preserves array order, permits
 only validated JSON values, and is covered by an object-order vector and a

--- a/packages/audit/src/contract.ts
+++ b/packages/audit/src/contract.ts
@@ -377,7 +377,8 @@ const REF = z
   .min(1)
   .max(128)
   .regex(/^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$/);
-const DIGEST = z.string().regex(/^sha256:[0-9a-f]{64}$/);
+const SHA256_DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
+const DIGEST = z.string().regex(SHA256_DIGEST_PATTERN);
 const AUDIT_TIMESTAMP_MAX_FRACTIONAL_DIGITS = 9;
 const AUDIT_TIMESTAMP_MAX_LENGTH = 21 + AUDIT_TIMESTAMP_MAX_FRACTIONAL_DIGITS;
 const AUDIT_TIMESTAMP_PATTERN = new RegExp(
@@ -390,6 +391,28 @@ const auditTimestampSchema = z.iso
 
 export function isValidAuditTimestamp(value: unknown): value is string {
   return auditTimestampSchema.safeParse(value).success;
+}
+
+export function compareAuditTimestamps(left: string, right: string): -1 | 0 | 1 {
+  if (!isValidAuditTimestamp(left) || !isValidAuditTimestamp(right)) {
+    throw new AuditError("audit_integrity_failure");
+  }
+  const normalize = (value: string): string => {
+    const withoutZulu = value.slice(0, -1);
+    const dot = withoutZulu.indexOf(".");
+    return dot === -1
+      ? `${withoutZulu}.${"0".repeat(AUDIT_TIMESTAMP_MAX_FRACTIONAL_DIGITS)}`
+      : `${withoutZulu.slice(0, dot)}.${withoutZulu
+          .slice(dot + 1)
+          .padEnd(AUDIT_TIMESTAMP_MAX_FRACTIONAL_DIGITS, "0")}`;
+  };
+  const normalizedLeft = normalize(left);
+  const normalizedRight = normalize(right);
+  return normalizedLeft < normalizedRight ? -1 : normalizedLeft > normalizedRight ? 1 : 0;
+}
+
+export function isValidSha256Digest(value: unknown): value is string {
+  return typeof value === "string" && value.length === 71 && SHA256_DIGEST_PATTERN.test(value);
 }
 
 const REASON = z.enum([

--- a/packages/audit/src/lifecycle.ts
+++ b/packages/audit/src/lifecycle.ts
@@ -395,8 +395,9 @@ function parseRecoveryOutcome(value: unknown): RecoveryOutcome {
   return value as RecoveryOutcome;
 }
 
-function validateRecoveryFactShape(fact: RecoveryFact): RecoveryFact {
-  const keys = Object.keys(fact).sort();
+export function validateRecoveryFactShape(value: unknown): RecoveryFact {
+  if (!isRecord(value)) throw new AuditError("audit_candidate_invalid");
+  const keys = Object.keys(value).sort();
   const expected = [
     "cause",
     "event_id",
@@ -413,45 +414,61 @@ function validateRecoveryFactShape(fact: RecoveryFact): RecoveryFact {
     "trace_ref",
     "withheld_outcome",
   ].sort();
-  const boundedRef = (value: string) => value.length <= 128 && REF.test(value);
+  const recoveryFactVersion = readOwn(value, "recovery_fact_version");
+  const recoveryId = readOwn(value, "recovery_id");
+  const eventId = readOwn(value, "event_id");
+  const eventType = readOwn(value, "event_type");
+  const originalObservedAt = readOwn(value, "original_observed_at");
+  const originalObservationParentEventRef = readOwn(value, "original_observation_parent_event_ref");
+  const cause = readOwn(value, "cause");
+  const traceRef = readOwn(value, "trace_ref");
+  const requestRef = readOwn(value, "request_ref");
+  const executionRef = readOwn(value, "execution_ref");
+  const planDigest = readOwn(value, "plan_digest");
+  const attempt = readOwn(value, "attempt");
+  const observedOutcome = readOwn(value, "observed_outcome");
+  const withheldOutcome = readOwn(value, "withheld_outcome");
+  const boundedRef = (candidate: unknown): candidate is string =>
+    typeof candidate === "string" && candidate.length <= 128 && REF.test(candidate);
   if (
     keys.length !== expected.length ||
     keys.some((key, index) => key !== expected[index]) ||
-    fact.recovery_fact_version !== 1 ||
-    !boundedRef(fact.recovery_id) ||
-    !boundedRef(fact.event_id) ||
-    !boundedRef(fact.trace_ref) ||
-    !boundedRef(fact.request_ref) ||
-    !boundedRef(fact.execution_ref) ||
-    !boundedRef(fact.original_observation_parent_event_ref) ||
-    (fact.event_type !== "execution.started.v1" && fact.event_type !== "execution.completed.v1") ||
-    !isValidAuditTimestamp(fact.original_observed_at) ||
-    !DIGEST.test(fact.plan_digest) ||
-    !Number.isInteger(fact.attempt) ||
-    fact.attempt < 1 ||
-    fact.attempt > 16 ||
-    fact.cause !== "primary_writer_failed_after_provider_start" ||
-    fact.withheld_outcome !== "completion_unknown" ||
-    !RECOVERY_OUTCOMES.includes(fact.observed_outcome) ||
-    (fact.event_type === "execution.started.v1" && fact.observed_outcome !== "completion_unknown")
+    recoveryFactVersion !== 1 ||
+    !boundedRef(recoveryId) ||
+    !boundedRef(eventId) ||
+    !boundedRef(traceRef) ||
+    !boundedRef(requestRef) ||
+    !boundedRef(executionRef) ||
+    !boundedRef(originalObservationParentEventRef) ||
+    (eventType !== "execution.started.v1" && eventType !== "execution.completed.v1") ||
+    !isValidAuditTimestamp(originalObservedAt) ||
+    typeof planDigest !== "string" ||
+    !DIGEST.test(planDigest) ||
+    !Number.isInteger(attempt) ||
+    (attempt as number) < 1 ||
+    (attempt as number) > 16 ||
+    cause !== "primary_writer_failed_after_provider_start" ||
+    withheldOutcome !== "completion_unknown" ||
+    !RECOVERY_OUTCOMES.includes(observedOutcome as RecoveryOutcome) ||
+    (eventType === "execution.started.v1" && observedOutcome !== "completion_unknown")
   ) {
     throw new AuditError("audit_candidate_invalid");
   }
   return {
     recovery_fact_version: 1,
-    recovery_id: fact.recovery_id,
-    event_id: fact.event_id,
-    event_type: fact.event_type,
-    original_observed_at: fact.original_observed_at,
-    original_observation_parent_event_ref: fact.original_observation_parent_event_ref,
-    cause: fact.cause,
-    trace_ref: fact.trace_ref,
-    request_ref: fact.request_ref,
-    execution_ref: fact.execution_ref,
-    plan_digest: fact.plan_digest,
-    attempt: fact.attempt,
-    observed_outcome: fact.observed_outcome,
-    withheld_outcome: fact.withheld_outcome,
+    recovery_id: recoveryId,
+    event_id: eventId,
+    event_type: eventType,
+    original_observed_at: originalObservedAt,
+    original_observation_parent_event_ref: originalObservationParentEventRef,
+    cause,
+    trace_ref: traceRef,
+    request_ref: requestRef,
+    execution_ref: executionRef,
+    plan_digest: planDigest,
+    attempt: attempt as number,
+    observed_outcome: observedOutcome as RecoveryOutcome,
+    withheld_outcome: withheldOutcome,
   };
 }
 

--- a/packages/audit/src/lifecycle.ts
+++ b/packages/audit/src/lifecycle.ts
@@ -13,6 +13,10 @@ export interface RequiredAuditWriter {
   commit(candidate: AuditCandidate): Promise<AuditCommitReceipt>;
 }
 
+export interface RequiredAuditReadiness {
+  assertReadyForProviderStart(): Promise<void>;
+}
+
 export interface RecoveryFact {
   readonly recovery_fact_version: 1;
   readonly recovery_id: string;
@@ -87,6 +91,7 @@ export async function commitBeforeProviderStart<T>(
   options: Readonly<{
     candidates: readonly AuditCandidate[];
     writer: RequiredAuditWriter;
+    readiness: RequiredAuditReadiness;
     startProvider: () => Promise<T>;
   }>,
 ): Promise<
@@ -210,6 +215,7 @@ export async function commitBeforeProviderStart<T>(
         throw new AuditError("audit_unavailable");
       }
     }
+    await options.readiness.assertReadyForProviderStart();
   } catch {
     return { status: "denied", code: "audit_unavailable" };
   }

--- a/packages/audit/src/repository-local-contract.ts
+++ b/packages/audit/src/repository-local-contract.ts
@@ -1,0 +1,987 @@
+import { createHash } from "node:crypto";
+import {
+  AuditError,
+  compareAuditTimestamps,
+  isValidAuditTimestamp,
+  isValidSha256Digest,
+  validateAuditCandidate,
+  validateProtectedAuditEvent,
+  type ProtectedAuditEvent,
+} from "./contract.js";
+import { validateRecoveryFactShape, type RecoveryFact } from "./lifecycle.js";
+import { canonicalAuditJson, computeAuditEventHash, type AuditCommitReceipt } from "./writer.js";
+
+export const REPOSITORY_LOCAL_PROFILE_ID = "yukh-mcp/repository-local-audit-v1";
+export const REPOSITORY_LOCAL_RUNTIME_PATH = ".yukh/runtime/audit-v1";
+export const REPOSITORY_LOCAL_CHECKPOINT_LIMITATION = "local_unwitnessed_not_complete";
+export const REPOSITORY_LOCAL_CHECKPOINT_AUTHORITY = "repository_local_writer_v1";
+export const REPOSITORY_LOCAL_CHECKPOINT_ALGORITHM = "sha256_local_checkpoint_v1";
+export const REPOSITORY_LOCAL_CANONICALIZATION = "canonical_json_code_unit_v1";
+export const REPOSITORY_LOCAL_RECORD_INTEGRITY = "sha256_domain_separated_v1";
+
+export const REPOSITORY_LOCAL_LIMITS = Object.freeze({
+  max_primary_commit_record_bytes: 64 * 1024,
+  max_recovery_record_bytes: 4 * 1024,
+  max_identity_record_bytes: 2 * 1024,
+  max_checkpoint_record_bytes: 16 * 1024,
+  max_primary_committed_bytes: 64 * 1024 * 1024,
+  max_recovery_bytes: 8 * 1024 * 1024,
+  max_event_identity_bytes: 16 * 1024 * 1024,
+  max_checkpoint_deletion_metadata_bytes: 4 * 1024 * 1024,
+  max_completed_export_bytes: 32 * 1024 * 1024,
+  max_temporary_bytes: 16 * 1024 * 1024,
+  max_streams: 64,
+  max_pending_recovery_facts: 512,
+  max_acknowledged_recovery_records: 512,
+  max_recovery_identities: 512,
+  max_event_identities: 8_192,
+  recovery_identity_reservation_bytes: 16 * 1024,
+  checkpoint_interval: 1_000,
+  pending_iterator_max_input_bytes: 8 * 1024 * 1024,
+  pending_iterator_max_milliseconds: 30_000,
+  pending_max_age_milliseconds: 30 * 24 * 60 * 60 * 1_000,
+} as const);
+
+export type RepositoryLocalLimits = typeof REPOSITORY_LOCAL_LIMITS;
+
+export interface RepositoryLocalProfileRecord {
+  readonly profile_record_version: 1;
+  readonly profile_id: typeof REPOSITORY_LOCAL_PROFILE_ID;
+  readonly canonicalization: typeof REPOSITORY_LOCAL_CANONICALIZATION;
+  readonly record_integrity: typeof REPOSITORY_LOCAL_RECORD_INTEGRITY;
+  readonly event_chain_algorithm: "sha256_chain_v1";
+  readonly checkpoint_algorithm: typeof REPOSITORY_LOCAL_CHECKPOINT_ALGORITHM;
+  readonly writer_ref: string;
+  readonly limits: RepositoryLocalLimits;
+  readonly created_at: string;
+  readonly profile_record_digest: string;
+}
+
+export interface RepositoryLocalWriterLockRecord {
+  readonly lock_record_version: 1;
+  readonly profile_id: typeof REPOSITORY_LOCAL_PROFILE_ID;
+  readonly writer_ref: string;
+  readonly owner_token: string;
+  readonly acquired_at: string;
+  readonly lock_record_digest: string;
+}
+
+export interface RepositoryLocalStreamRecord {
+  readonly stream_record_version: 1;
+  readonly profile_id: typeof REPOSITORY_LOCAL_PROFILE_ID;
+  readonly stream_ref: string;
+  readonly stream_path_digest: string;
+  readonly writer_ref: string;
+  readonly created_at: string;
+  readonly stream_record_digest: string;
+}
+
+export interface RepositoryLocalPrimaryCommitRecord {
+  readonly primary_commit_record_version: 1;
+  readonly profile_id: typeof REPOSITORY_LOCAL_PROFILE_ID;
+  readonly event: ProtectedAuditEvent;
+  readonly candidate_digest: string;
+  readonly primary_commit_record_digest: string;
+}
+
+export interface RepositoryLocalPrimaryIdentityRecord {
+  readonly primary_identity_record_version: 1;
+  readonly identity_version: 0;
+  readonly profile_id: typeof REPOSITORY_LOCAL_PROFILE_ID;
+  readonly event_id: string;
+  readonly candidate_digest: string;
+  readonly stream_ref: string;
+  readonly sequence: number;
+  readonly previous_event_hash: string;
+  readonly event_hash: string;
+  readonly committed_at: string;
+  readonly writer_ref: string;
+  readonly durability: "durable";
+  readonly commit_record_digest: string;
+  readonly primary_identity_record_digest: string;
+}
+
+export interface RepositoryLocalRecoveryPendingRecord {
+  readonly recovery_pending_record_version: 1;
+  readonly profile_id: typeof REPOSITORY_LOCAL_PROFILE_ID;
+  readonly fact: RecoveryFact;
+  readonly fact_digest: string;
+  readonly appended_at: string;
+  readonly recovery_pending_record_digest: string;
+}
+
+export interface RepositoryLocalRecoveryIdentityRecord {
+  readonly recovery_identity_record_version: 1;
+  readonly identity_version: 0;
+  readonly profile_id: typeof REPOSITORY_LOCAL_PROFILE_ID;
+  readonly recovery_id: string;
+  readonly fact_digest: string;
+  readonly pending_record_digest: string;
+  readonly appended_at: string;
+  readonly durability: "durable";
+  readonly recovery_identity_record_digest: string;
+}
+
+export interface RepositoryLocalCheckpointRecord {
+  readonly checkpoint_record_version: 1;
+  readonly profile_id: typeof REPOSITORY_LOCAL_PROFILE_ID;
+  readonly checkpoint_id: string;
+  readonly previous_checkpoint_ref: string | null;
+  readonly stream_ref: string;
+  readonly range_start: number;
+  readonly range_end: number;
+  readonly event_count: number;
+  readonly terminal_event_hash: string;
+  readonly writer_ref: string;
+  readonly authority_ref: typeof REPOSITORY_LOCAL_CHECKPOINT_AUTHORITY;
+  readonly algorithm: typeof REPOSITORY_LOCAL_CHECKPOINT_ALGORITHM;
+  readonly created_at: string;
+  readonly limitation: typeof REPOSITORY_LOCAL_CHECKPOINT_LIMITATION;
+  readonly checkpoint_record_digest: string;
+}
+
+export class RepositoryLocalFormatError extends Error {
+  constructor() {
+    super("repository_local_format_invalid");
+    this.name = "RepositoryLocalFormatError";
+  }
+}
+
+const REFERENCE_PATTERN = /^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$/;
+const RAW_SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const OWNER_TOKEN_PATTERN = /^[0-9a-f]{64}$/;
+const UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
+
+const PROFILE_KEYS = [
+  "canonicalization",
+  "checkpoint_algorithm",
+  "created_at",
+  "event_chain_algorithm",
+  "limits",
+  "profile_id",
+  "profile_record_digest",
+  "profile_record_version",
+  "record_integrity",
+  "writer_ref",
+] as const;
+const LIMIT_KEYS = Object.keys(REPOSITORY_LOCAL_LIMITS).sort();
+const LOCK_KEYS = [
+  "acquired_at",
+  "lock_record_digest",
+  "lock_record_version",
+  "owner_token",
+  "profile_id",
+  "writer_ref",
+] as const;
+const STREAM_KEYS = [
+  "created_at",
+  "profile_id",
+  "stream_path_digest",
+  "stream_record_digest",
+  "stream_record_version",
+  "stream_ref",
+  "writer_ref",
+] as const;
+const PRIMARY_COMMIT_KEYS = [
+  "candidate_digest",
+  "event",
+  "primary_commit_record_digest",
+  "primary_commit_record_version",
+  "profile_id",
+] as const;
+const PRIMARY_IDENTITY_KEYS = [
+  "candidate_digest",
+  "commit_record_digest",
+  "committed_at",
+  "durability",
+  "event_hash",
+  "event_id",
+  "identity_version",
+  "previous_event_hash",
+  "primary_identity_record_digest",
+  "primary_identity_record_version",
+  "profile_id",
+  "sequence",
+  "stream_ref",
+  "writer_ref",
+] as const;
+const RECOVERY_PENDING_KEYS = [
+  "appended_at",
+  "fact",
+  "fact_digest",
+  "profile_id",
+  "recovery_pending_record_digest",
+  "recovery_pending_record_version",
+] as const;
+const RECOVERY_IDENTITY_KEYS = [
+  "appended_at",
+  "durability",
+  "fact_digest",
+  "identity_version",
+  "pending_record_digest",
+  "profile_id",
+  "recovery_id",
+  "recovery_identity_record_digest",
+  "recovery_identity_record_version",
+] as const;
+const CHECKPOINT_KEYS = [
+  "algorithm",
+  "authority_ref",
+  "checkpoint_id",
+  "checkpoint_record_digest",
+  "checkpoint_record_version",
+  "created_at",
+  "event_count",
+  "limitation",
+  "previous_checkpoint_ref",
+  "profile_id",
+  "range_end",
+  "range_start",
+  "stream_ref",
+  "terminal_event_hash",
+  "writer_ref",
+] as const;
+
+function fail(): never {
+  throw new RepositoryLocalFormatError();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function requireRecord(value: unknown, expectedKeys: readonly string[]): Record<string, unknown> {
+  if (!isRecord(value)) return fail();
+  const keys = Object.keys(value).sort();
+  const expected = [...expectedKeys].sort();
+  if (keys.length !== expected.length || keys.some((key, index) => key !== expected[index])) {
+    return fail();
+  }
+  return value;
+}
+
+function read(record: Record<string, unknown>, key: string): unknown {
+  if (!Object.hasOwn(record, key)) return fail();
+  return record[key];
+}
+
+function reference(value: unknown): string {
+  if (typeof value !== "string" || value.length > 128 || !REFERENCE_PATTERN.test(value)) {
+    return fail();
+  }
+  return value;
+}
+
+function digest(value: unknown): string {
+  if (!isValidSha256Digest(value)) return fail();
+  return value;
+}
+
+function rawDigest(value: unknown): string {
+  if (typeof value !== "string" || !RAW_SHA256_PATTERN.test(value)) return fail();
+  return value;
+}
+
+function timestamp(value: unknown): string {
+  if (!isValidAuditTimestamp(value)) return fail();
+  return value;
+}
+
+function nonnegativeInteger(value: unknown): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) return fail();
+  return value as number;
+}
+
+function domainDigest(domain: string, value: unknown): string {
+  return `sha256:${createHash("sha256")
+    .update(domain, "utf8")
+    .update("\0", "utf8")
+    .update(canonicalAuditJson(value), "utf8")
+    .digest("hex")}`;
+}
+
+function digestWithoutField(
+  domain: string,
+  record: Readonly<Record<string, unknown>>,
+  field: string,
+): string {
+  const { [field]: _digest, ...withoutDigest } = record;
+  return domainDigest(domain, withoutDigest);
+}
+
+function assertSelfDigest(
+  domain: string,
+  record: Readonly<Record<string, unknown>>,
+  field: string,
+): void {
+  const stored = digest(record[field]);
+  if (stored !== digestWithoutField(domain, record, field)) fail();
+}
+
+function validateLimits(value: unknown): RepositoryLocalLimits {
+  const record = requireRecord(value, LIMIT_KEYS);
+  for (const key of LIMIT_KEYS) {
+    if (read(record, key) !== REPOSITORY_LOCAL_LIMITS[key as keyof RepositoryLocalLimits]) fail();
+  }
+  return REPOSITORY_LOCAL_LIMITS;
+}
+
+export function isRepositoryLocalReference(value: unknown): value is string {
+  return typeof value === "string" && value.length <= 128 && REFERENCE_PATTERN.test(value);
+}
+
+export function repositoryLocalReferencePathDigest(value: string): string {
+  if (!isRepositoryLocalReference(value)) return fail();
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+export function canonicalRepositoryLocalBytes(value: unknown): Buffer {
+  return Buffer.from(canonicalAuditJson(value), "utf8");
+}
+
+export function parseCanonicalRepositoryLocalBytes(bytes: Uint8Array): unknown {
+  let text: string;
+  let parsed: unknown;
+  try {
+    text = UTF8_DECODER.decode(bytes);
+    parsed = JSON.parse(text) as unknown;
+  } catch (error: unknown) {
+    if (error instanceof TypeError || error instanceof SyntaxError) return fail();
+    throw error;
+  }
+  let canonical: Buffer;
+  try {
+    canonical = canonicalRepositoryLocalBytes(parsed);
+  } catch (error: unknown) {
+    if (error instanceof AuditError) return fail();
+    throw error;
+  }
+  if (!canonical.equals(Buffer.from(bytes))) return fail();
+  return parsed;
+}
+
+export function computeProtectedEventCandidateDigest(event: ProtectedAuditEvent): string {
+  const candidate = validateAuditCandidate({
+    audit_candidate_version: 1,
+    event_id: event.event_id,
+    event_type: event.event_type,
+    occurred_at: event.occurred_at,
+    producer: event.producer,
+    correlation: event.correlation,
+    causation: event.causation,
+    subject: event.subject,
+    capability: event.capability,
+    scope: event.scope,
+    outcome: event.outcome,
+    payload: event.payload.value,
+  });
+  return `sha256:${createHash("sha256")
+    .update(canonicalAuditJson(candidate), "utf8")
+    .digest("hex")}`;
+}
+
+export function validateRepositoryLocalProtectedEvent(value: unknown): ProtectedAuditEvent {
+  let event: ProtectedAuditEvent;
+  try {
+    event = validateProtectedAuditEvent(value);
+  } catch (error: unknown) {
+    if (error instanceof AuditError) return fail();
+    throw error;
+  }
+  const { event_hash: _eventHash, ...integrityWithoutHash } = event.integrity;
+  const computed = computeAuditEventHash({ ...event, integrity: integrityWithoutHash });
+  if (computed !== event.integrity.event_hash) return fail();
+  return event;
+}
+
+export function computeRecoveryFactDigest(fact: RecoveryFact): string {
+  return domainDigest("yukh-mcp:repository-local:recovery-fact:v1", fact);
+}
+
+export function createRepositoryLocalProfileRecord(
+  writerRef: string,
+  createdAt: string,
+): RepositoryLocalProfileRecord {
+  if (!isRepositoryLocalReference(writerRef) || !isValidAuditTimestamp(createdAt)) return fail();
+  const withoutDigest: Omit<RepositoryLocalProfileRecord, "profile_record_digest"> = {
+    profile_record_version: 1 as const,
+    profile_id: REPOSITORY_LOCAL_PROFILE_ID,
+    canonicalization: REPOSITORY_LOCAL_CANONICALIZATION,
+    record_integrity: REPOSITORY_LOCAL_RECORD_INTEGRITY,
+    event_chain_algorithm: "sha256_chain_v1" as const,
+    checkpoint_algorithm: REPOSITORY_LOCAL_CHECKPOINT_ALGORITHM,
+    writer_ref: writerRef,
+    limits: REPOSITORY_LOCAL_LIMITS,
+    created_at: createdAt,
+  };
+  return {
+    ...withoutDigest,
+    profile_record_digest: domainDigest(
+      "yukh-mcp:repository-local:profile-record:v1",
+      withoutDigest,
+    ),
+  };
+}
+
+export function validateRepositoryLocalProfileRecord(value: unknown): RepositoryLocalProfileRecord {
+  const record = requireRecord(value, PROFILE_KEYS);
+  if (
+    read(record, "profile_record_version") !== 1 ||
+    read(record, "profile_id") !== REPOSITORY_LOCAL_PROFILE_ID ||
+    read(record, "canonicalization") !== REPOSITORY_LOCAL_CANONICALIZATION ||
+    read(record, "record_integrity") !== REPOSITORY_LOCAL_RECORD_INTEGRITY ||
+    read(record, "event_chain_algorithm") !== "sha256_chain_v1" ||
+    read(record, "checkpoint_algorithm") !== REPOSITORY_LOCAL_CHECKPOINT_ALGORITHM
+  ) {
+    return fail();
+  }
+  const parsed: RepositoryLocalProfileRecord = {
+    profile_record_version: 1,
+    profile_id: REPOSITORY_LOCAL_PROFILE_ID,
+    canonicalization: REPOSITORY_LOCAL_CANONICALIZATION,
+    record_integrity: REPOSITORY_LOCAL_RECORD_INTEGRITY,
+    event_chain_algorithm: "sha256_chain_v1",
+    checkpoint_algorithm: REPOSITORY_LOCAL_CHECKPOINT_ALGORITHM,
+    writer_ref: reference(read(record, "writer_ref")),
+    limits: validateLimits(read(record, "limits")),
+    created_at: timestamp(read(record, "created_at")),
+    profile_record_digest: digest(read(record, "profile_record_digest")),
+  };
+  assertSelfDigest(
+    "yukh-mcp:repository-local:profile-record:v1",
+    parsed as unknown as Record<string, unknown>,
+    "profile_record_digest",
+  );
+  return parsed;
+}
+
+export function createRepositoryLocalWriterLockRecord(
+  writerRef: string,
+  ownerToken: string,
+  acquiredAt: string,
+): RepositoryLocalWriterLockRecord {
+  if (
+    !isRepositoryLocalReference(writerRef) ||
+    !OWNER_TOKEN_PATTERN.test(ownerToken) ||
+    !isValidAuditTimestamp(acquiredAt)
+  ) {
+    return fail();
+  }
+  const withoutDigest: Omit<RepositoryLocalWriterLockRecord, "lock_record_digest"> = {
+    lock_record_version: 1 as const,
+    profile_id: REPOSITORY_LOCAL_PROFILE_ID,
+    writer_ref: writerRef,
+    owner_token: ownerToken,
+    acquired_at: acquiredAt,
+  };
+  return {
+    ...withoutDigest,
+    lock_record_digest: domainDigest(
+      "yukh-mcp:repository-local:writer-lock-record:v1",
+      withoutDigest,
+    ),
+  };
+}
+
+export function validateRepositoryLocalWriterLockRecord(
+  value: unknown,
+): RepositoryLocalWriterLockRecord {
+  const record = requireRecord(value, LOCK_KEYS);
+  const ownerToken = read(record, "owner_token");
+  if (
+    read(record, "lock_record_version") !== 1 ||
+    read(record, "profile_id") !== REPOSITORY_LOCAL_PROFILE_ID ||
+    typeof ownerToken !== "string" ||
+    !OWNER_TOKEN_PATTERN.test(ownerToken)
+  ) {
+    return fail();
+  }
+  const parsed: RepositoryLocalWriterLockRecord = {
+    lock_record_version: 1,
+    profile_id: REPOSITORY_LOCAL_PROFILE_ID,
+    writer_ref: reference(read(record, "writer_ref")),
+    owner_token: ownerToken,
+    acquired_at: timestamp(read(record, "acquired_at")),
+    lock_record_digest: digest(read(record, "lock_record_digest")),
+  };
+  assertSelfDigest(
+    "yukh-mcp:repository-local:writer-lock-record:v1",
+    parsed as unknown as Record<string, unknown>,
+    "lock_record_digest",
+  );
+  return parsed;
+}
+
+export function createRepositoryLocalStreamRecord(
+  streamRef: string,
+  writerRef: string,
+  createdAt: string,
+): RepositoryLocalStreamRecord {
+  if (
+    !isRepositoryLocalReference(streamRef) ||
+    !isRepositoryLocalReference(writerRef) ||
+    !isValidAuditTimestamp(createdAt)
+  ) {
+    return fail();
+  }
+  const withoutDigest: Omit<RepositoryLocalStreamRecord, "stream_record_digest"> = {
+    stream_record_version: 1 as const,
+    profile_id: REPOSITORY_LOCAL_PROFILE_ID,
+    stream_ref: streamRef,
+    stream_path_digest: repositoryLocalReferencePathDigest(streamRef),
+    writer_ref: writerRef,
+    created_at: createdAt,
+  };
+  return {
+    ...withoutDigest,
+    stream_record_digest: domainDigest("yukh-mcp:repository-local:stream-record:v1", withoutDigest),
+  };
+}
+
+export function validateRepositoryLocalStreamRecord(value: unknown): RepositoryLocalStreamRecord {
+  const record = requireRecord(value, STREAM_KEYS);
+  if (
+    read(record, "stream_record_version") !== 1 ||
+    read(record, "profile_id") !== REPOSITORY_LOCAL_PROFILE_ID
+  ) {
+    return fail();
+  }
+  const parsed: RepositoryLocalStreamRecord = {
+    stream_record_version: 1,
+    profile_id: REPOSITORY_LOCAL_PROFILE_ID,
+    stream_ref: reference(read(record, "stream_ref")),
+    stream_path_digest: rawDigest(read(record, "stream_path_digest")),
+    writer_ref: reference(read(record, "writer_ref")),
+    created_at: timestamp(read(record, "created_at")),
+    stream_record_digest: digest(read(record, "stream_record_digest")),
+  };
+  if (repositoryLocalReferencePathDigest(parsed.stream_ref) !== parsed.stream_path_digest) fail();
+  assertSelfDigest(
+    "yukh-mcp:repository-local:stream-record:v1",
+    parsed as unknown as Record<string, unknown>,
+    "stream_record_digest",
+  );
+  return parsed;
+}
+
+export function createRepositoryLocalPrimaryCommitRecord(
+  eventValue: unknown,
+  candidateDigest: string,
+): RepositoryLocalPrimaryCommitRecord {
+  const event = validateRepositoryLocalProtectedEvent(eventValue);
+  if (!isValidSha256Digest(candidateDigest)) return fail();
+  if (computeProtectedEventCandidateDigest(event) !== candidateDigest) return fail();
+  const withoutDigest: Omit<RepositoryLocalPrimaryCommitRecord, "primary_commit_record_digest"> = {
+    primary_commit_record_version: 1 as const,
+    profile_id: REPOSITORY_LOCAL_PROFILE_ID,
+    event,
+    candidate_digest: candidateDigest,
+  };
+  return {
+    ...withoutDigest,
+    primary_commit_record_digest: domainDigest(
+      "yukh-mcp:repository-local:primary-commit-record:v1",
+      withoutDigest,
+    ),
+  };
+}
+
+export function validateRepositoryLocalPrimaryCommitRecord(
+  value: unknown,
+): RepositoryLocalPrimaryCommitRecord {
+  const record = requireRecord(value, PRIMARY_COMMIT_KEYS);
+  if (
+    read(record, "primary_commit_record_version") !== 1 ||
+    read(record, "profile_id") !== REPOSITORY_LOCAL_PROFILE_ID
+  ) {
+    return fail();
+  }
+  const event = validateRepositoryLocalProtectedEvent(read(record, "event"));
+  const candidateDigest = digest(read(record, "candidate_digest"));
+  if (computeProtectedEventCandidateDigest(event) !== candidateDigest) return fail();
+  const parsed: RepositoryLocalPrimaryCommitRecord = {
+    primary_commit_record_version: 1,
+    profile_id: REPOSITORY_LOCAL_PROFILE_ID,
+    event,
+    candidate_digest: candidateDigest,
+    primary_commit_record_digest: digest(read(record, "primary_commit_record_digest")),
+  };
+  assertSelfDigest(
+    "yukh-mcp:repository-local:primary-commit-record:v1",
+    parsed as unknown as Record<string, unknown>,
+    "primary_commit_record_digest",
+  );
+  return parsed;
+}
+
+export function createRepositoryLocalPrimaryIdentityRecord(
+  commit: RepositoryLocalPrimaryCommitRecord,
+): RepositoryLocalPrimaryIdentityRecord {
+  const event = commit.event;
+  const withoutDigest: Omit<
+    RepositoryLocalPrimaryIdentityRecord,
+    "primary_identity_record_digest"
+  > = {
+    primary_identity_record_version: 1 as const,
+    identity_version: 0 as const,
+    profile_id: REPOSITORY_LOCAL_PROFILE_ID,
+    event_id: event.event_id,
+    candidate_digest: commit.candidate_digest,
+    stream_ref: event.integrity.stream_ref,
+    sequence: event.integrity.sequence,
+    previous_event_hash: event.integrity.previous_event_hash,
+    event_hash: event.integrity.event_hash,
+    committed_at: event.committed_at,
+    writer_ref: event.integrity.writer_ref,
+    durability: "durable" as const,
+    commit_record_digest: commit.primary_commit_record_digest,
+  };
+  return {
+    ...withoutDigest,
+    primary_identity_record_digest: domainDigest(
+      "yukh-mcp:repository-local:primary-identity-record:v0",
+      withoutDigest,
+    ),
+  };
+}
+
+export function validateRepositoryLocalPrimaryIdentityRecord(
+  value: unknown,
+): RepositoryLocalPrimaryIdentityRecord {
+  const record = requireRecord(value, PRIMARY_IDENTITY_KEYS);
+  if (
+    read(record, "primary_identity_record_version") !== 1 ||
+    read(record, "identity_version") !== 0 ||
+    read(record, "profile_id") !== REPOSITORY_LOCAL_PROFILE_ID ||
+    read(record, "durability") !== "durable"
+  ) {
+    return fail();
+  }
+  const parsed: RepositoryLocalPrimaryIdentityRecord = {
+    primary_identity_record_version: 1,
+    identity_version: 0,
+    profile_id: REPOSITORY_LOCAL_PROFILE_ID,
+    event_id: reference(read(record, "event_id")),
+    candidate_digest: digest(read(record, "candidate_digest")),
+    stream_ref: reference(read(record, "stream_ref")),
+    sequence: nonnegativeInteger(read(record, "sequence")),
+    previous_event_hash: digest(read(record, "previous_event_hash")),
+    event_hash: digest(read(record, "event_hash")),
+    committed_at: timestamp(read(record, "committed_at")),
+    writer_ref: reference(read(record, "writer_ref")),
+    durability: "durable",
+    commit_record_digest: digest(read(record, "commit_record_digest")),
+    primary_identity_record_digest: digest(read(record, "primary_identity_record_digest")),
+  };
+  assertSelfDigest(
+    "yukh-mcp:repository-local:primary-identity-record:v0",
+    parsed as unknown as Record<string, unknown>,
+    "primary_identity_record_digest",
+  );
+  return parsed;
+}
+
+export function primaryIdentityMatchesCommit(
+  identity: RepositoryLocalPrimaryIdentityRecord,
+  commit: RepositoryLocalPrimaryCommitRecord,
+): boolean {
+  const event = commit.event;
+  return (
+    identity.event_id === event.event_id &&
+    identity.candidate_digest === commit.candidate_digest &&
+    identity.stream_ref === event.integrity.stream_ref &&
+    identity.sequence === event.integrity.sequence &&
+    identity.previous_event_hash === event.integrity.previous_event_hash &&
+    identity.event_hash === event.integrity.event_hash &&
+    identity.committed_at === event.committed_at &&
+    identity.writer_ref === event.integrity.writer_ref &&
+    identity.commit_record_digest === commit.primary_commit_record_digest
+  );
+}
+
+export function createRepositoryLocalRecoveryPendingRecord(
+  factValue: unknown,
+  appendedAt: string,
+): RepositoryLocalRecoveryPendingRecord {
+  let fact: RecoveryFact;
+  try {
+    fact = validateRecoveryFactShape(factValue);
+  } catch (error: unknown) {
+    if (error instanceof AuditError) return fail();
+    throw error;
+  }
+  if (!isValidAuditTimestamp(appendedAt)) return fail();
+  if (compareAuditTimestamps(appendedAt, fact.original_observed_at) < 0) return fail();
+  const withoutDigest: Omit<
+    RepositoryLocalRecoveryPendingRecord,
+    "recovery_pending_record_digest"
+  > = {
+    recovery_pending_record_version: 1 as const,
+    profile_id: REPOSITORY_LOCAL_PROFILE_ID,
+    fact,
+    fact_digest: computeRecoveryFactDigest(fact),
+    appended_at: appendedAt,
+  };
+  return {
+    ...withoutDigest,
+    recovery_pending_record_digest: domainDigest(
+      "yukh-mcp:repository-local:recovery-pending-record:v1",
+      withoutDigest,
+    ),
+  };
+}
+
+export function validateRepositoryLocalRecoveryPendingRecord(
+  value: unknown,
+): RepositoryLocalRecoveryPendingRecord {
+  const record = requireRecord(value, RECOVERY_PENDING_KEYS);
+  if (
+    read(record, "recovery_pending_record_version") !== 1 ||
+    read(record, "profile_id") !== REPOSITORY_LOCAL_PROFILE_ID
+  ) {
+    return fail();
+  }
+  let fact: RecoveryFact;
+  try {
+    fact = validateRecoveryFactShape(read(record, "fact"));
+  } catch (error: unknown) {
+    if (error instanceof AuditError) return fail();
+    throw error;
+  }
+  const factDigest = digest(read(record, "fact_digest"));
+  if (computeRecoveryFactDigest(fact) !== factDigest) return fail();
+  const parsed: RepositoryLocalRecoveryPendingRecord = {
+    recovery_pending_record_version: 1,
+    profile_id: REPOSITORY_LOCAL_PROFILE_ID,
+    fact,
+    fact_digest: factDigest,
+    appended_at: timestamp(read(record, "appended_at")),
+    recovery_pending_record_digest: digest(read(record, "recovery_pending_record_digest")),
+  };
+  if (compareAuditTimestamps(parsed.appended_at, parsed.fact.original_observed_at) < 0) {
+    return fail();
+  }
+  assertSelfDigest(
+    "yukh-mcp:repository-local:recovery-pending-record:v1",
+    parsed as unknown as Record<string, unknown>,
+    "recovery_pending_record_digest",
+  );
+  return parsed;
+}
+
+export function createRepositoryLocalRecoveryIdentityRecord(
+  pending: RepositoryLocalRecoveryPendingRecord,
+): RepositoryLocalRecoveryIdentityRecord {
+  const withoutDigest: Omit<
+    RepositoryLocalRecoveryIdentityRecord,
+    "recovery_identity_record_digest"
+  > = {
+    recovery_identity_record_version: 1 as const,
+    identity_version: 0 as const,
+    profile_id: REPOSITORY_LOCAL_PROFILE_ID,
+    recovery_id: pending.fact.recovery_id,
+    fact_digest: pending.fact_digest,
+    pending_record_digest: pending.recovery_pending_record_digest,
+    appended_at: pending.appended_at,
+    durability: "durable" as const,
+  };
+  return {
+    ...withoutDigest,
+    recovery_identity_record_digest: domainDigest(
+      "yukh-mcp:repository-local:recovery-identity-record:v0",
+      withoutDigest,
+    ),
+  };
+}
+
+export function validateRepositoryLocalRecoveryIdentityRecord(
+  value: unknown,
+): RepositoryLocalRecoveryIdentityRecord {
+  const record = requireRecord(value, RECOVERY_IDENTITY_KEYS);
+  if (
+    read(record, "recovery_identity_record_version") !== 1 ||
+    read(record, "identity_version") !== 0 ||
+    read(record, "profile_id") !== REPOSITORY_LOCAL_PROFILE_ID ||
+    read(record, "durability") !== "durable"
+  ) {
+    return fail();
+  }
+  const parsed: RepositoryLocalRecoveryIdentityRecord = {
+    recovery_identity_record_version: 1,
+    identity_version: 0,
+    profile_id: REPOSITORY_LOCAL_PROFILE_ID,
+    recovery_id: reference(read(record, "recovery_id")),
+    fact_digest: digest(read(record, "fact_digest")),
+    pending_record_digest: digest(read(record, "pending_record_digest")),
+    appended_at: timestamp(read(record, "appended_at")),
+    durability: "durable",
+    recovery_identity_record_digest: digest(read(record, "recovery_identity_record_digest")),
+  };
+  assertSelfDigest(
+    "yukh-mcp:repository-local:recovery-identity-record:v0",
+    parsed as unknown as Record<string, unknown>,
+    "recovery_identity_record_digest",
+  );
+  return parsed;
+}
+
+export function recoveryIdentityMatchesPending(
+  identity: RepositoryLocalRecoveryIdentityRecord,
+  pending: RepositoryLocalRecoveryPendingRecord,
+): boolean {
+  return (
+    identity.recovery_id === pending.fact.recovery_id &&
+    identity.fact_digest === pending.fact_digest &&
+    identity.pending_record_digest === pending.recovery_pending_record_digest &&
+    identity.appended_at === pending.appended_at
+  );
+}
+
+function checkpointIdentity(
+  input: Readonly<{
+    stream_ref: string;
+    range_start: number;
+    range_end: number;
+    terminal_event_hash: string;
+    previous_checkpoint_ref: string | null;
+  }>,
+): string {
+  return domainDigest("yukh-mcp:repository-local:checkpoint-identity:v1", input);
+}
+
+export function createRepositoryLocalCheckpointRecord(
+  input: Readonly<{
+    stream_ref: string;
+    range_start: number;
+    range_end: number;
+    terminal_event_hash: string;
+    previous_checkpoint_ref: string | null;
+    writer_ref: string;
+    created_at: string;
+  }>,
+): RepositoryLocalCheckpointRecord {
+  const streamRef = reference(input.stream_ref);
+  const rangeStart = nonnegativeInteger(input.range_start);
+  const rangeEnd = nonnegativeInteger(input.range_end);
+  const terminalEventHash = digest(input.terminal_event_hash);
+  const writerRef = reference(input.writer_ref);
+  const createdAt = timestamp(input.created_at);
+  const previousCheckpointRef =
+    input.previous_checkpoint_ref === null ? null : digest(input.previous_checkpoint_ref);
+  if (rangeEnd < rangeStart) return fail();
+  const identityInput = {
+    stream_ref: streamRef,
+    range_start: rangeStart,
+    range_end: rangeEnd,
+    terminal_event_hash: terminalEventHash,
+    previous_checkpoint_ref: previousCheckpointRef,
+  };
+  const withoutDigest: Omit<RepositoryLocalCheckpointRecord, "checkpoint_record_digest"> = {
+    checkpoint_record_version: 1 as const,
+    profile_id: REPOSITORY_LOCAL_PROFILE_ID,
+    checkpoint_id: checkpointIdentity(identityInput),
+    previous_checkpoint_ref: previousCheckpointRef,
+    stream_ref: streamRef,
+    range_start: rangeStart,
+    range_end: rangeEnd,
+    event_count: rangeEnd - rangeStart + 1,
+    terminal_event_hash: terminalEventHash,
+    writer_ref: writerRef,
+    authority_ref: REPOSITORY_LOCAL_CHECKPOINT_AUTHORITY,
+    algorithm: REPOSITORY_LOCAL_CHECKPOINT_ALGORITHM,
+    created_at: createdAt,
+    limitation: REPOSITORY_LOCAL_CHECKPOINT_LIMITATION,
+  };
+  return {
+    ...withoutDigest,
+    checkpoint_record_digest: domainDigest(
+      "yukh-mcp:repository-local:checkpoint-record:v1",
+      withoutDigest,
+    ),
+  };
+}
+
+export function validateRepositoryLocalCheckpointRecord(
+  value: unknown,
+): RepositoryLocalCheckpointRecord {
+  const record = requireRecord(value, CHECKPOINT_KEYS);
+  if (
+    read(record, "checkpoint_record_version") !== 1 ||
+    read(record, "profile_id") !== REPOSITORY_LOCAL_PROFILE_ID ||
+    read(record, "authority_ref") !== REPOSITORY_LOCAL_CHECKPOINT_AUTHORITY ||
+    read(record, "algorithm") !== REPOSITORY_LOCAL_CHECKPOINT_ALGORITHM ||
+    read(record, "limitation") !== REPOSITORY_LOCAL_CHECKPOINT_LIMITATION
+  ) {
+    return fail();
+  }
+  const previous =
+    read(record, "previous_checkpoint_ref") === null
+      ? null
+      : digest(read(record, "previous_checkpoint_ref"));
+  const parsed: RepositoryLocalCheckpointRecord = {
+    checkpoint_record_version: 1,
+    profile_id: REPOSITORY_LOCAL_PROFILE_ID,
+    checkpoint_id: digest(read(record, "checkpoint_id")),
+    previous_checkpoint_ref: previous,
+    stream_ref: reference(read(record, "stream_ref")),
+    range_start: nonnegativeInteger(read(record, "range_start")),
+    range_end: nonnegativeInteger(read(record, "range_end")),
+    event_count: nonnegativeInteger(read(record, "event_count")),
+    terminal_event_hash: digest(read(record, "terminal_event_hash")),
+    writer_ref: reference(read(record, "writer_ref")),
+    authority_ref: REPOSITORY_LOCAL_CHECKPOINT_AUTHORITY,
+    algorithm: REPOSITORY_LOCAL_CHECKPOINT_ALGORITHM,
+    created_at: timestamp(read(record, "created_at")),
+    limitation: REPOSITORY_LOCAL_CHECKPOINT_LIMITATION,
+    checkpoint_record_digest: digest(read(record, "checkpoint_record_digest")),
+  };
+  if (
+    parsed.range_end < parsed.range_start ||
+    parsed.event_count !== parsed.range_end - parsed.range_start + 1 ||
+    parsed.checkpoint_id !==
+      checkpointIdentity({
+        stream_ref: parsed.stream_ref,
+        range_start: parsed.range_start,
+        range_end: parsed.range_end,
+        terminal_event_hash: parsed.terminal_event_hash,
+        previous_checkpoint_ref: parsed.previous_checkpoint_ref,
+      })
+  ) {
+    return fail();
+  }
+  assertSelfDigest(
+    "yukh-mcp:repository-local:checkpoint-record:v1",
+    parsed as unknown as Record<string, unknown>,
+    "checkpoint_record_digest",
+  );
+  return parsed;
+}
+
+export function repositoryLocalCheckpointFileName(checkpointId: string): string {
+  const validated = digest(checkpointId);
+  return `${validated.slice("sha256:".length)}.json`;
+}
+
+export function repositoryLocalSequenceFileName(sequence: number): string {
+  const validated = nonnegativeInteger(sequence);
+  if (validated > 99_999_999_999_999_999_999) return fail();
+  return `${validated.toString().padStart(20, "0")}.json`;
+}
+
+export function repositoryLocalIdentityVersionFileName(version: 0): string {
+  if (version !== 0) return fail();
+  return "00000000.json";
+}
+
+export function receiptFromPrimaryCommit(
+  commit: RepositoryLocalPrimaryCommitRecord,
+  duplicate: boolean,
+): AuditCommitReceipt {
+  return {
+    event: commit.event,
+    durability: "durable",
+    duplicate,
+  };
+}

--- a/packages/audit/src/repository-local-filesystem.ts
+++ b/packages/audit/src/repository-local-filesystem.ts
@@ -721,6 +721,7 @@ export async function readBoundedRepositoryLocalFile(
   expectedDevice: number,
   hooks?: RepositoryLocalFilesystemHooks,
   expectedLinks: 1 | 2 = 1,
+  beforeRead?: (size: number) => void,
 ): Promise<RepositoryLocalReadResult> {
   let handle: FileHandle;
   try {
@@ -739,6 +740,7 @@ export async function readBoundedRepositoryLocalFile(
       hooks,
     );
     if (before.size <= 0) return fail("corruption_detected");
+    beforeRead?.(before.size);
     bytes = Buffer.allocUnsafe(before.size);
     let offset = 0;
     while (offset < bytes.length) {
@@ -872,6 +874,11 @@ export async function qualifyRepositoryLocalFilesystem(
           : "unsupported";
   }
   if (filesystemKind === "unsupported") return fail("unsupported_filesystem");
+  if (filesystemKind === "apfs") {
+    // Node exposes no descriptor-based APFS ACL API, while /dev/fd reports the
+    // fdesc vnode rather than the opened target. Reopening a path would race.
+    return fail("unsupported_filesystem");
+  }
 
   const sourceName = ".qualification.source.tmp";
   const destinationName = ".qualification.destination.tmp";

--- a/packages/audit/src/repository-local-filesystem.ts
+++ b/packages/audit/src/repository-local-filesystem.ts
@@ -1,0 +1,1078 @@
+import { randomBytes } from "node:crypto";
+import {
+  constants,
+  lstat,
+  mkdir,
+  open,
+  opendir,
+  realpath,
+  statfs,
+  unlink,
+  link,
+  type FileHandle,
+} from "node:fs/promises";
+import type { Stats } from "node:fs";
+import path from "node:path";
+import {
+  canonicalRepositoryLocalBytes,
+  createRepositoryLocalWriterLockRecord,
+  parseCanonicalRepositoryLocalBytes,
+  REPOSITORY_LOCAL_RUNTIME_PATH,
+  validateRepositoryLocalWriterLockRecord,
+  type RepositoryLocalWriterLockRecord,
+} from "./repository-local-contract.js";
+
+export type RepositoryLocalFailureReason =
+  | "capacity_exhausted"
+  | "corruption_detected"
+  | "io_failure"
+  | "lock_unavailable"
+  | "publication_conflict"
+  | "unsafe_metadata"
+  | "unsupported_filesystem";
+
+export class RepositoryLocalFilesystemError extends Error {
+  constructor(
+    readonly reason: RepositoryLocalFailureReason,
+    readonly ambiguous: boolean = false,
+  ) {
+    super("repository_local_filesystem_failure");
+    this.name = "RepositoryLocalFilesystemError";
+  }
+}
+
+export type RepositoryLocalFileKind =
+  | "checkpoint"
+  | "primary_identity"
+  | "primary_record"
+  | "profile"
+  | "qualification"
+  | "recovery_identity"
+  | "recovery_record"
+  | "stream";
+
+export type RepositoryLocalFilesystemEvent =
+  | "directory.after_create"
+  | "directory.after_self_sync"
+  | "directory.after_parent_sync"
+  | "lock.after_file_sync"
+  | "lock.after_directory_sync"
+  | `${RepositoryLocalFileKind}.before_temp_create`
+  | `${RepositoryLocalFileKind}.during_temp_write`
+  | `${RepositoryLocalFileKind}.after_temp_sync`
+  | `${RepositoryLocalFileKind}.after_link`
+  | `${RepositoryLocalFileKind}.after_publish`
+  | `${RepositoryLocalFileKind}.before_directory_sync`
+  | `${RepositoryLocalFileKind}.after_directory_sync`;
+
+export interface RepositoryLocalMetadataSnapshot {
+  readonly device: number;
+  readonly inode: number;
+  readonly mode: number;
+  readonly links: number;
+  readonly owner: number;
+  readonly size: number;
+  readonly kind: "directory" | "file" | "other";
+}
+
+export interface RepositoryLocalFilesystemHooks {
+  readonly onEvent?: (event: RepositoryLocalFilesystemEvent) => void | Promise<void>;
+  readonly filesystemKindOverride?: "apfs" | "ext" | "unsupported";
+  readonly availableBytesOverride?: bigint;
+  readonly writeChunkLimit?: (kind: RepositoryLocalFileKind, remainingBytes: number) => number;
+  readonly metadataOverride?: (
+    label: "directory" | "file" | "repository",
+    metadata: RepositoryLocalMetadataSnapshot,
+  ) => RepositoryLocalMetadataSnapshot;
+}
+
+export interface RepositoryLocalPaths {
+  readonly repositoryRoot: string;
+  readonly runtimeRoot: string;
+  readonly profile: string;
+  readonly lock: string;
+  readonly primary: string;
+  readonly streams: string;
+  readonly primaryIdentities: string;
+  readonly checkpoints: string;
+  readonly deletions: string;
+  readonly recovery: string;
+  readonly pending: string;
+  readonly acknowledged: string;
+  readonly recoveryIdentities: string;
+  readonly quarantine: string;
+  readonly exports: string;
+  readonly temporary: string;
+}
+
+export interface RepositoryLocalOwnedLock {
+  readonly handle: FileHandle;
+  readonly record: RepositoryLocalWriterLockRecord;
+  readonly bytes: Buffer;
+  readonly device: number;
+  readonly inode: number;
+  released: boolean;
+}
+
+export interface RepositoryLocalReadResult {
+  readonly value: unknown;
+  readonly bytes: Buffer;
+  readonly metadata: RepositoryLocalMetadataSnapshot;
+}
+
+const DIRECTORY_MODE = 0o700;
+const FILE_MODE = 0o600;
+const APFS_DARWIN_TYPE = 26;
+const EXT_LINUX_TYPE = 0xef53;
+const O_NOFOLLOW = constants.O_NOFOLLOW ?? 0;
+const O_DIRECTORY = constants.O_DIRECTORY ?? 0;
+const CREATE_EXCLUSIVE_FLAGS = constants.O_CREAT | constants.O_EXCL | constants.O_RDWR | O_NOFOLLOW;
+const READ_NOFOLLOW_FLAGS = constants.O_RDONLY | O_NOFOLLOW;
+const DIRECTORY_FLAGS = constants.O_RDONLY | O_NOFOLLOW | O_DIRECTORY;
+
+function fail(reason: RepositoryLocalFailureReason, ambiguous = false): never {
+  throw new RepositoryLocalFilesystemError(reason, ambiguous);
+}
+
+function nodeErrorCode(error: unknown): string | undefined {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "string"
+  ) {
+    return error.code;
+  }
+  return undefined;
+}
+
+function mapFilesystemError(error: unknown, ambiguous = false): never {
+  if (error instanceof RepositoryLocalFilesystemError) throw error;
+  const code = nodeErrorCode(error);
+  if (code === "ENOSPC" || code === "EDQUOT" || code === "EFBIG") {
+    return fail("capacity_exhausted", ambiguous);
+  }
+  if (
+    code === "ELOOP" ||
+    code === "ENOTDIR" ||
+    code === "EPERM" ||
+    code === "EACCES" ||
+    code === "EMLINK" ||
+    code === "EXDEV"
+  ) {
+    return fail("unsafe_metadata", ambiguous);
+  }
+  return fail("io_failure", ambiguous);
+}
+
+async function emit(
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+  event: RepositoryLocalFilesystemEvent,
+): Promise<void> {
+  if (hooks?.onEvent === undefined) return;
+  try {
+    await hooks.onEvent(event);
+  } catch (error: unknown) {
+    mapFilesystemError(
+      error,
+      event.endsWith("after_link") ||
+        event.endsWith("after_publish") ||
+        event.endsWith("before_directory_sync") ||
+        event.endsWith("after_directory_sync"),
+    );
+  }
+}
+
+function effectiveUserId(): number {
+  if (typeof process.geteuid !== "function") return fail("unsupported_filesystem");
+  return process.geteuid();
+}
+
+function metadataFromStats(stats: Stats): RepositoryLocalMetadataSnapshot {
+  return {
+    device: stats.dev,
+    inode: stats.ino,
+    mode: stats.mode & 0o777,
+    links: stats.nlink,
+    owner: stats.uid,
+    size: stats.size,
+    kind: stats.isDirectory() ? "directory" : stats.isFile() ? "file" : "other",
+  };
+}
+
+function metadata(
+  stats: Stats,
+  label: "directory" | "file" | "repository",
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+): RepositoryLocalMetadataSnapshot {
+  const actual = metadataFromStats(stats);
+  return hooks?.metadataOverride?.(label, actual) ?? actual;
+}
+
+function assertRepositoryMetadata(
+  stats: Stats,
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+): RepositoryLocalMetadataSnapshot {
+  const snapshot = metadata(stats, "repository", hooks);
+  if (
+    snapshot.kind !== "directory" ||
+    snapshot.owner !== effectiveUserId() ||
+    snapshot.links < 1 ||
+    (snapshot.mode & 0o022) !== 0
+  ) {
+    return fail("unsafe_metadata");
+  }
+  return snapshot;
+}
+
+export function assertRepositoryLocalDirectoryMetadata(
+  stats: Stats,
+  hooks?: RepositoryLocalFilesystemHooks,
+): RepositoryLocalMetadataSnapshot {
+  const snapshot = metadata(stats, "directory", hooks);
+  if (
+    snapshot.kind !== "directory" ||
+    snapshot.owner !== effectiveUserId() ||
+    snapshot.mode !== DIRECTORY_MODE ||
+    snapshot.links < 1
+  ) {
+    return fail("unsafe_metadata");
+  }
+  return snapshot;
+}
+
+export function assertRepositoryLocalFileMetadata(
+  stats: Stats,
+  expectedDevice: number,
+  expectedLinks: 1 | 2,
+  maximumBytes: number,
+  hooks?: RepositoryLocalFilesystemHooks,
+): RepositoryLocalMetadataSnapshot {
+  const snapshot = metadata(stats, "file", hooks);
+  if (
+    snapshot.kind !== "file" ||
+    snapshot.owner !== effectiveUserId() ||
+    snapshot.mode !== FILE_MODE ||
+    snapshot.links !== expectedLinks ||
+    snapshot.device !== expectedDevice ||
+    snapshot.size < 0 ||
+    snapshot.size > maximumBytes
+  ) {
+    return fail("unsafe_metadata");
+  }
+  return snapshot;
+}
+
+async function safeLstat(filePath: string): Promise<Stats> {
+  try {
+    return await lstat(filePath);
+  } catch (error: unknown) {
+    mapFilesystemError(error);
+  }
+}
+
+async function lstatIfPresent(filePath: string): Promise<Stats | undefined> {
+  try {
+    return await lstat(filePath);
+  } catch (error: unknown) {
+    if (nodeErrorCode(error) === "ENOENT") return undefined;
+    mapFilesystemError(error);
+  }
+}
+
+async function validateExistingPathComponents(absolutePath: string): Promise<void> {
+  const parsed = path.parse(absolutePath);
+  const relative = absolutePath.slice(parsed.root.length);
+  const components = relative.split(path.sep).filter((component) => component.length > 0);
+  let current = parsed.root;
+  for (const component of components) {
+    current = path.join(current, component);
+    const stats = await safeLstat(current);
+    if (!stats.isDirectory() || stats.isSymbolicLink()) return fail("unsafe_metadata");
+  }
+}
+
+export async function resolveTrustedRepositoryLocalPaths(
+  trustedRepositoryRoot: string,
+  hooks?: RepositoryLocalFilesystemHooks,
+): Promise<RepositoryLocalPaths> {
+  if (
+    O_NOFOLLOW === 0 ||
+    O_DIRECTORY === 0 ||
+    !path.isAbsolute(trustedRepositoryRoot) ||
+    path.normalize(trustedRepositoryRoot) !== trustedRepositoryRoot ||
+    trustedRepositoryRoot === path.parse(trustedRepositoryRoot).root ||
+    trustedRepositoryRoot
+      .split(path.sep)
+      .some((component) => component.toLocaleLowerCase("en-US") === ".git")
+  ) {
+    return fail("unsafe_metadata");
+  }
+  await validateExistingPathComponents(trustedRepositoryRoot);
+  let canonical: string;
+  try {
+    canonical = await realpath(trustedRepositoryRoot);
+  } catch (error: unknown) {
+    mapFilesystemError(error);
+  }
+  if (canonical !== trustedRepositoryRoot) return fail("unsafe_metadata");
+  const repositoryMetadata = assertRepositoryMetadata(
+    await safeLstat(trustedRepositoryRoot),
+    hooks,
+  );
+  const runtimeRoot = path.join(trustedRepositoryRoot, ...REPOSITORY_LOCAL_RUNTIME_PATH.split("/"));
+  const gitRoot = path.join(trustedRepositoryRoot, ".git");
+  if (runtimeRoot === gitRoot || runtimeRoot.startsWith(`${gitRoot}${path.sep}`)) {
+    return fail("unsafe_metadata");
+  }
+  const primary = path.join(runtimeRoot, "primary");
+  const recovery = path.join(runtimeRoot, "recovery");
+  const paths: RepositoryLocalPaths = {
+    repositoryRoot: trustedRepositoryRoot,
+    runtimeRoot,
+    profile: path.join(runtimeRoot, "profile.json"),
+    lock: path.join(runtimeRoot, "writer.lock"),
+    primary,
+    streams: path.join(primary, "streams"),
+    primaryIdentities: path.join(primary, "identities"),
+    checkpoints: path.join(primary, "checkpoints"),
+    deletions: path.join(primary, "deletions"),
+    recovery,
+    pending: path.join(recovery, "pending"),
+    acknowledged: path.join(recovery, "acknowledged"),
+    recoveryIdentities: path.join(recovery, "identities"),
+    quarantine: path.join(recovery, "quarantine"),
+    exports: path.join(runtimeRoot, "exports"),
+    temporary: path.join(runtimeRoot, "tmp"),
+  };
+  Object.defineProperty(paths, "__repositoryDevice", {
+    value: repositoryMetadata.device,
+    enumerable: false,
+  });
+  return paths;
+}
+
+async function syncDirectoryHandle(
+  directoryPath: string,
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+  trustedRepositoryRoot = false,
+): Promise<void> {
+  let handle: FileHandle;
+  try {
+    handle = await open(directoryPath, DIRECTORY_FLAGS);
+  } catch (error: unknown) {
+    mapFilesystemError(error);
+  }
+  try {
+    const stats = await handle.stat();
+    if (trustedRepositoryRoot) {
+      assertRepositoryMetadata(stats, hooks);
+    } else {
+      assertRepositoryLocalDirectoryMetadata(stats, hooks);
+    }
+    await handle.sync();
+  } catch (error: unknown) {
+    try {
+      await handle.close();
+    } catch (closeError: unknown) {
+      mapFilesystemError(closeError, true);
+    }
+    mapFilesystemError(error, true);
+  }
+  try {
+    await handle.close();
+  } catch (error: unknown) {
+    mapFilesystemError(error, true);
+  }
+}
+
+export async function syncRepositoryLocalDirectory(
+  directoryPath: string,
+  hooks?: RepositoryLocalFilesystemHooks,
+  kind?: RepositoryLocalFileKind,
+): Promise<void> {
+  if (kind !== undefined) await emit(hooks, `${kind}.before_directory_sync`);
+  await syncDirectoryHandle(directoryPath, hooks);
+  if (kind !== undefined) await emit(hooks, `${kind}.after_directory_sync`);
+}
+
+export async function ensureDurableRepositoryLocalDirectory(
+  directoryPath: string,
+  parentPath: string,
+  expectedDevice: number,
+  hooks?: RepositoryLocalFilesystemHooks,
+  parentMayUseRepositoryMode = false,
+  existingMayUseRepositoryMode = false,
+): Promise<Readonly<{ created: boolean; metadata: RepositoryLocalMetadataSnapshot }>> {
+  const existing = await lstatIfPresent(directoryPath);
+  if (existing !== undefined) {
+    const existingMetadata = existingMayUseRepositoryMode
+      ? assertRepositoryMetadata(existing, hooks)
+      : assertRepositoryLocalDirectoryMetadata(existing, hooks);
+    if (existingMetadata.device !== expectedDevice) return fail("unsafe_metadata");
+    await syncDirectoryHandle(directoryPath, hooks, existingMayUseRepositoryMode);
+    await emit(hooks, "directory.after_self_sync");
+    await syncDirectoryHandle(parentPath, hooks, parentMayUseRepositoryMode);
+    await emit(hooks, "directory.after_parent_sync");
+    return { created: false, metadata: existingMetadata };
+  }
+  try {
+    await mkdir(directoryPath, { mode: DIRECTORY_MODE });
+  } catch (error: unknown) {
+    if (nodeErrorCode(error) === "EEXIST") return fail("unsafe_metadata");
+    mapFilesystemError(error);
+  }
+  await emit(hooks, "directory.after_create");
+  const createdMetadata = assertRepositoryLocalDirectoryMetadata(
+    await safeLstat(directoryPath),
+    hooks,
+  );
+  if (createdMetadata.device !== expectedDevice) return fail("unsafe_metadata");
+  await syncDirectoryHandle(directoryPath, hooks);
+  await emit(hooks, "directory.after_self_sync");
+  await syncDirectoryHandle(parentPath, hooks, parentMayUseRepositoryMode);
+  await emit(hooks, "directory.after_parent_sync");
+  return { created: true, metadata: createdMetadata };
+}
+
+export async function ensureRepositoryLocalRuntimeRoot(
+  paths: RepositoryLocalPaths,
+  hooks?: RepositoryLocalFilesystemHooks,
+): Promise<number> {
+  const repositoryMetadata = assertRepositoryMetadata(await safeLstat(paths.repositoryRoot), hooks);
+  const yukhRoot = path.join(paths.repositoryRoot, ".yukh");
+  const runtimeParent = path.join(yukhRoot, "runtime");
+  await ensureDurableRepositoryLocalDirectory(
+    yukhRoot,
+    paths.repositoryRoot,
+    repositoryMetadata.device,
+    hooks,
+    true,
+    true,
+  );
+  await ensureDurableRepositoryLocalDirectory(
+    runtimeParent,
+    yukhRoot,
+    repositoryMetadata.device,
+    hooks,
+    true,
+  );
+  const root = await ensureDurableRepositoryLocalDirectory(
+    paths.runtimeRoot,
+    runtimeParent,
+    repositoryMetadata.device,
+    hooks,
+  );
+  return root.metadata.device;
+}
+
+export async function ensureRepositoryLocalTopology(
+  paths: RepositoryLocalPaths,
+  expectedDevice: number,
+  hooks?: RepositoryLocalFilesystemHooks,
+): Promise<void> {
+  for (const [directoryPath, parentPath] of [
+    [paths.primary, paths.runtimeRoot],
+    [paths.streams, paths.primary],
+    [paths.primaryIdentities, paths.primary],
+    [paths.checkpoints, paths.primary],
+    [paths.deletions, paths.primary],
+    [paths.recovery, paths.runtimeRoot],
+    [paths.pending, paths.recovery],
+    [paths.acknowledged, paths.recovery],
+    [paths.recoveryIdentities, paths.recovery],
+    [paths.quarantine, paths.recovery],
+    [paths.exports, paths.runtimeRoot],
+    [paths.temporary, paths.runtimeRoot],
+  ] as const) {
+    await ensureDurableRepositoryLocalDirectory(directoryPath, parentPath, expectedDevice, hooks);
+  }
+}
+
+async function writeAll(
+  handle: FileHandle,
+  bytes: Buffer,
+  kind: RepositoryLocalFileKind,
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+  baseOffset = 0,
+  emitDuringWrite = true,
+): Promise<void> {
+  let offset = 0;
+  let emittedDuringWrite = false;
+  while (offset < bytes.length) {
+    const remaining = bytes.length - offset;
+    const requested = hooks?.writeChunkLimit?.(kind, remaining) ?? remaining;
+    if (!Number.isSafeInteger(requested) || requested <= 0 || requested > remaining) {
+      return fail("io_failure", true);
+    }
+    let written: number;
+    try {
+      ({ bytesWritten: written } = await handle.write(
+        bytes,
+        offset,
+        requested,
+        baseOffset + offset,
+      ));
+    } catch (error: unknown) {
+      mapFilesystemError(error, true);
+    }
+    if (written <= 0 || written > requested) return fail("io_failure", true);
+    offset += written;
+    if (emitDuringWrite && !emittedDuringWrite && bytes.length > 1 && offset < bytes.length) {
+      emittedDuringWrite = true;
+      await emit(hooks, `${kind}.during_temp_write`);
+    }
+  }
+}
+
+async function writeExclusiveTemporary(
+  temporaryPath: string,
+  bytes: Buffer,
+  maximumBytes: number,
+  expectedDevice: number,
+  kind: RepositoryLocalFileKind,
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+): Promise<void> {
+  if (bytes.length <= 0 || bytes.length > maximumBytes) return fail("capacity_exhausted");
+  await emit(hooks, `${kind}.before_temp_create`);
+  let handle: FileHandle;
+  try {
+    handle = await open(temporaryPath, CREATE_EXCLUSIVE_FLAGS, FILE_MODE);
+  } catch (error: unknown) {
+    if (nodeErrorCode(error) === "EEXIST") return fail("publication_conflict");
+    mapFilesystemError(error);
+  }
+  let closed = false;
+  try {
+    if (bytes.length > 1 && hooks?.onEvent !== undefined) {
+      const firstLength = Math.max(1, Math.floor(bytes.length / 2));
+      let firstWritten: number;
+      ({ bytesWritten: firstWritten } = await handle.write(bytes, 0, firstLength, 0));
+      if (firstWritten <= 0 || firstWritten > firstLength) return fail("io_failure", true);
+      await emit(hooks, `${kind}.during_temp_write`);
+      if (firstWritten < bytes.length) {
+        const remaining = bytes.subarray(firstWritten);
+        await writeAll(handle, remaining, kind, hooks, firstWritten, false);
+      }
+    } else {
+      await writeAll(handle, bytes, kind, hooks);
+    }
+    await handle.sync();
+    await emit(hooks, `${kind}.after_temp_sync`);
+    const fileMetadata = assertRepositoryLocalFileMetadata(
+      await handle.stat(),
+      expectedDevice,
+      1,
+      maximumBytes,
+      hooks,
+    );
+    if (fileMetadata.size !== bytes.length) return fail("io_failure", true);
+    await handle.close();
+    closed = true;
+  } catch (error: unknown) {
+    if (!closed) {
+      try {
+        await handle.close();
+      } catch (closeError: unknown) {
+        mapFilesystemError(closeError, true);
+      }
+    }
+    mapFilesystemError(error, true);
+  }
+  const closedMetadata = assertRepositoryLocalFileMetadata(
+    await safeLstat(temporaryPath),
+    expectedDevice,
+    1,
+    maximumBytes,
+    hooks,
+  );
+  if (closedMetadata.size !== bytes.length) return fail("io_failure", true);
+}
+
+export async function publishRepositoryLocalFile(
+  directoryPath: string,
+  destinationName: string,
+  temporaryName: string,
+  bytes: Buffer,
+  maximumBytes: number,
+  expectedDevice: number,
+  kind: RepositoryLocalFileKind,
+  hooks?: RepositoryLocalFilesystemHooks,
+): Promise<void> {
+  if (
+    destinationName.includes(path.sep) ||
+    temporaryName.includes(path.sep) ||
+    destinationName.length === 0 ||
+    temporaryName.length === 0 ||
+    destinationName === "." ||
+    destinationName === ".." ||
+    temporaryName === "." ||
+    temporaryName === ".." ||
+    destinationName.includes("\0") ||
+    temporaryName.includes("\0") ||
+    destinationName === temporaryName
+  ) {
+    return fail("unsafe_metadata");
+  }
+  const destinationPath = path.join(directoryPath, destinationName);
+  const temporaryPath = path.join(directoryPath, temporaryName);
+  await writeExclusiveTemporary(temporaryPath, bytes, maximumBytes, expectedDevice, kind, hooks);
+  try {
+    await link(temporaryPath, destinationPath);
+  } catch (error: unknown) {
+    if (nodeErrorCode(error) === "EEXIST") return fail("publication_conflict");
+    mapFilesystemError(error, true);
+  }
+  const temporaryMetadata = assertRepositoryLocalFileMetadata(
+    await safeLstat(temporaryPath),
+    expectedDevice,
+    2,
+    maximumBytes,
+    hooks,
+  );
+  const destinationMetadata = assertRepositoryLocalFileMetadata(
+    await safeLstat(destinationPath),
+    expectedDevice,
+    2,
+    maximumBytes,
+    hooks,
+  );
+  if (
+    temporaryMetadata.inode !== destinationMetadata.inode ||
+    temporaryMetadata.size !== bytes.length ||
+    destinationMetadata.size !== bytes.length
+  ) {
+    return fail("unsafe_metadata", true);
+  }
+  await emit(hooks, `${kind}.after_link`);
+  try {
+    await unlink(temporaryPath);
+  } catch (error: unknown) {
+    mapFilesystemError(error, true);
+  }
+  const publishedMetadata = assertRepositoryLocalFileMetadata(
+    await safeLstat(destinationPath),
+    expectedDevice,
+    1,
+    maximumBytes,
+    hooks,
+  );
+  if (publishedMetadata.size !== bytes.length) return fail("io_failure", true);
+  await emit(hooks, `${kind}.after_publish`);
+}
+
+export async function removeRecognizedRepositoryLocalTemporary(
+  temporaryPath: string,
+  containingDirectory: string,
+  maximumBytes: number,
+  expectedDevice: number,
+  hooks?: RepositoryLocalFilesystemHooks,
+  publishedDestinationPath?: string,
+): Promise<void> {
+  const temporaryStats = await safeLstat(temporaryPath);
+  if (publishedDestinationPath === undefined) {
+    assertRepositoryLocalFileMetadata(temporaryStats, expectedDevice, 1, maximumBytes, hooks);
+  } else {
+    const destinationStats = await safeLstat(publishedDestinationPath);
+    const temporaryMetadata = assertRepositoryLocalFileMetadata(
+      temporaryStats,
+      expectedDevice,
+      2,
+      maximumBytes,
+      hooks,
+    );
+    const destinationMetadata = assertRepositoryLocalFileMetadata(
+      destinationStats,
+      expectedDevice,
+      2,
+      maximumBytes,
+      hooks,
+    );
+    if (
+      temporaryMetadata.inode !== destinationMetadata.inode ||
+      temporaryMetadata.size !== destinationMetadata.size
+    ) {
+      return fail("unsafe_metadata");
+    }
+  }
+  try {
+    await unlink(temporaryPath);
+  } catch (error: unknown) {
+    mapFilesystemError(error, true);
+  }
+  await syncDirectoryHandle(containingDirectory, hooks);
+}
+
+export async function inspectRepositoryLocalTemporaryBytes(
+  temporaryPath: string,
+  maximumBytes: number,
+  expectedDevice: number,
+  hooks?: RepositoryLocalFilesystemHooks,
+): Promise<number> {
+  const stats = await safeLstat(temporaryPath);
+  const links = stats.nlink === 1 ? 1 : stats.nlink === 2 ? 2 : undefined;
+  if (links === undefined) return fail("unsafe_metadata");
+  return assertRepositoryLocalFileMetadata(stats, expectedDevice, links, maximumBytes, hooks).size;
+}
+
+export async function readBoundedRepositoryLocalFile(
+  filePath: string,
+  maximumBytes: number,
+  expectedDevice: number,
+  hooks?: RepositoryLocalFilesystemHooks,
+  expectedLinks: 1 | 2 = 1,
+): Promise<RepositoryLocalReadResult> {
+  let handle: FileHandle;
+  try {
+    handle = await open(filePath, READ_NOFOLLOW_FLAGS);
+  } catch (error: unknown) {
+    mapFilesystemError(error);
+  }
+  let before: RepositoryLocalMetadataSnapshot;
+  let bytes: Buffer;
+  try {
+    before = assertRepositoryLocalFileMetadata(
+      await handle.stat(),
+      expectedDevice,
+      expectedLinks,
+      maximumBytes,
+      hooks,
+    );
+    if (before.size <= 0) return fail("corruption_detected");
+    bytes = Buffer.allocUnsafe(before.size);
+    let offset = 0;
+    while (offset < bytes.length) {
+      const result = await handle.read(bytes, offset, bytes.length - offset, offset);
+      if (result.bytesRead <= 0) return fail("corruption_detected");
+      offset += result.bytesRead;
+    }
+    const after = assertRepositoryLocalFileMetadata(
+      await handle.stat(),
+      expectedDevice,
+      expectedLinks,
+      maximumBytes,
+      hooks,
+    );
+    if (
+      after.inode !== before.inode ||
+      after.size !== before.size ||
+      after.device !== before.device
+    ) {
+      return fail("unsafe_metadata");
+    }
+    await handle.close();
+  } catch (error: unknown) {
+    try {
+      await handle.close();
+    } catch (closeError: unknown) {
+      mapFilesystemError(closeError, true);
+    }
+    mapFilesystemError(error);
+  }
+  let value: unknown;
+  try {
+    value = parseCanonicalRepositoryLocalBytes(bytes);
+  } catch (error: unknown) {
+    if (error instanceof RepositoryLocalFilesystemError) throw error;
+    return fail("corruption_detected");
+  }
+  return { value, bytes, metadata: before };
+}
+
+export async function listRepositoryLocalDirectory(
+  directoryPath: string,
+  expectedDevice: number,
+  maximumEntries: number,
+  hooks?: RepositoryLocalFilesystemHooks,
+): Promise<readonly string[]> {
+  if (!Number.isSafeInteger(maximumEntries) || maximumEntries < 0) {
+    return fail("corruption_detected");
+  }
+  const directoryMetadata = assertRepositoryLocalDirectoryMetadata(
+    await safeLstat(directoryPath),
+    hooks,
+  );
+  if (directoryMetadata.device !== expectedDevice) return fail("unsafe_metadata");
+  let directory: Awaited<ReturnType<typeof opendir>>;
+  try {
+    directory = await opendir(directoryPath);
+  } catch (error: unknown) {
+    mapFilesystemError(error);
+  }
+  const names: string[] = [];
+  let closed = false;
+  try {
+    for (;;) {
+      const entry = await directory.read();
+      if (entry === null) break;
+      names.push(entry.name);
+      if (names.length > maximumEntries) return fail("corruption_detected");
+    }
+    await directory.close();
+    closed = true;
+  } catch (error: unknown) {
+    if (!closed) {
+      try {
+        await directory.close();
+      } catch (closeError: unknown) {
+        mapFilesystemError(closeError);
+      }
+    }
+    mapFilesystemError(error);
+  }
+  names.sort((left, right) => Buffer.compare(Buffer.from(left), Buffer.from(right)));
+  const caseFolded = new Set<string>();
+  for (const name of names) {
+    if (
+      name.length === 0 ||
+      name === "." ||
+      name === ".." ||
+      name.includes("/") ||
+      name.includes("\0")
+    ) {
+      return fail("unsafe_metadata");
+    }
+    const folded = name.toLocaleLowerCase("en-US");
+    if (caseFolded.has(folded)) return fail("unsafe_metadata");
+    caseFolded.add(folded);
+  }
+  return names;
+}
+
+export async function assertEmptyRepositoryLocalDirectory(
+  directoryPath: string,
+  expectedDevice: number,
+  hooks?: RepositoryLocalFilesystemHooks,
+): Promise<void> {
+  if ((await listRepositoryLocalDirectory(directoryPath, expectedDevice, 0, hooks)).length !== 0) {
+    return fail("corruption_detected");
+  }
+}
+
+export async function qualifyRepositoryLocalFilesystem(
+  paths: RepositoryLocalPaths,
+  expectedDevice: number,
+  hooks?: RepositoryLocalFilesystemHooks,
+): Promise<void> {
+  let filesystemKind: "apfs" | "ext" | "unsupported";
+  if (hooks?.filesystemKindOverride !== undefined) {
+    filesystemKind = hooks.filesystemKindOverride;
+  } else {
+    let information: Awaited<ReturnType<typeof statfs>>;
+    try {
+      information = await statfs(paths.runtimeRoot);
+    } catch (error: unknown) {
+      mapFilesystemError(error);
+    }
+    filesystemKind =
+      process.platform === "darwin" && information.type === APFS_DARWIN_TYPE
+        ? "apfs"
+        : process.platform === "linux" && information.type === EXT_LINUX_TYPE
+          ? "ext"
+          : "unsupported";
+  }
+  if (filesystemKind === "unsupported") return fail("unsupported_filesystem");
+
+  const sourceName = ".qualification.source.tmp";
+  const destinationName = ".qualification.destination.tmp";
+  const sourcePath = path.join(paths.runtimeRoot, sourceName);
+  const destinationPath = path.join(paths.runtimeRoot, destinationName);
+  if (
+    (await lstatIfPresent(sourcePath)) !== undefined ||
+    (await lstatIfPresent(destinationPath)) !== undefined
+  ) {
+    return fail("unsafe_metadata");
+  }
+  const bytes = Buffer.from("repository-local-filesystem-qualification-v1", "utf8");
+  await writeExclusiveTemporary(
+    sourcePath,
+    bytes,
+    bytes.length,
+    expectedDevice,
+    "qualification",
+    hooks,
+  );
+  try {
+    await link(sourcePath, destinationPath);
+  } catch (error: unknown) {
+    mapFilesystemError(error, true);
+  }
+  try {
+    await link(sourcePath, destinationPath);
+    return fail("unsupported_filesystem", true);
+  } catch (error: unknown) {
+    if (nodeErrorCode(error) !== "EEXIST") mapFilesystemError(error, true);
+  }
+  const sourceMetadata = assertRepositoryLocalFileMetadata(
+    await safeLstat(sourcePath),
+    expectedDevice,
+    2,
+    bytes.length,
+    hooks,
+  );
+  const destinationMetadata = assertRepositoryLocalFileMetadata(
+    await safeLstat(destinationPath),
+    expectedDevice,
+    2,
+    bytes.length,
+    hooks,
+  );
+  if (sourceMetadata.inode !== destinationMetadata.inode) {
+    return fail("unsupported_filesystem", true);
+  }
+  try {
+    await unlink(destinationPath);
+    await unlink(sourcePath);
+  } catch (error: unknown) {
+    mapFilesystemError(error, true);
+  }
+  await syncDirectoryHandle(paths.runtimeRoot, hooks);
+}
+
+export async function repositoryLocalAvailableBytes(
+  runtimeRoot: string,
+  hooks?: RepositoryLocalFilesystemHooks,
+): Promise<bigint> {
+  if (hooks?.availableBytesOverride !== undefined) return hooks.availableBytesOverride;
+  let information: Awaited<ReturnType<typeof statfs>>;
+  try {
+    information = await statfs(runtimeRoot, { bigint: true });
+  } catch (error: unknown) {
+    mapFilesystemError(error);
+  }
+  const available = information.bavail * information.bsize;
+  if (available < 0n) return fail("io_failure");
+  return available;
+}
+
+export async function acquireRepositoryLocalWriterLock(
+  paths: RepositoryLocalPaths,
+  writerRef: string,
+  acquiredAt: string,
+  expectedDevice: number,
+  hooks?: RepositoryLocalFilesystemHooks,
+): Promise<RepositoryLocalOwnedLock> {
+  const record = createRepositoryLocalWriterLockRecord(
+    writerRef,
+    randomBytes(32).toString("hex"),
+    acquiredAt,
+  );
+  const bytes = canonicalRepositoryLocalBytes(record);
+  let handle: FileHandle;
+  try {
+    handle = await open(paths.lock, CREATE_EXCLUSIVE_FLAGS, FILE_MODE);
+  } catch (error: unknown) {
+    if (nodeErrorCode(error) === "EEXIST") return fail("lock_unavailable");
+    mapFilesystemError(error);
+  }
+  try {
+    await writeAll(handle, bytes, "profile", hooks);
+    await handle.sync();
+    await emit(hooks, "lock.after_file_sync");
+    const fileMetadata = assertRepositoryLocalFileMetadata(
+      await handle.stat(),
+      expectedDevice,
+      1,
+      bytes.length,
+      hooks,
+    );
+    if (fileMetadata.size !== bytes.length) return fail("io_failure", true);
+    await syncDirectoryHandle(paths.runtimeRoot, hooks);
+    await emit(hooks, "lock.after_directory_sync");
+    return {
+      handle,
+      record,
+      bytes,
+      device: fileMetadata.device,
+      inode: fileMetadata.inode,
+      released: false,
+    };
+  } catch (error: unknown) {
+    try {
+      await handle.close();
+    } catch (closeError: unknown) {
+      mapFilesystemError(closeError, true);
+    }
+    mapFilesystemError(error, true);
+  }
+}
+
+export async function verifyRepositoryLocalWriterLock(
+  paths: RepositoryLocalPaths,
+  lockOwner: RepositoryLocalOwnedLock,
+  hooks?: RepositoryLocalFilesystemHooks,
+): Promise<void> {
+  if (lockOwner.released) return fail("lock_unavailable");
+  let descriptorMetadata: RepositoryLocalMetadataSnapshot;
+  try {
+    descriptorMetadata = assertRepositoryLocalFileMetadata(
+      await lockOwner.handle.stat(),
+      lockOwner.device,
+      1,
+      lockOwner.bytes.length,
+      hooks,
+    );
+  } catch (error: unknown) {
+    mapFilesystemError(error);
+  }
+  const pathMetadata = assertRepositoryLocalFileMetadata(
+    await safeLstat(paths.lock),
+    lockOwner.device,
+    1,
+    lockOwner.bytes.length,
+    hooks,
+  );
+  if (
+    descriptorMetadata.inode !== lockOwner.inode ||
+    pathMetadata.inode !== lockOwner.inode ||
+    descriptorMetadata.size !== lockOwner.bytes.length ||
+    pathMetadata.size !== lockOwner.bytes.length
+  ) {
+    return fail("unsafe_metadata");
+  }
+  const bytes = Buffer.allocUnsafe(lockOwner.bytes.length);
+  let offset = 0;
+  try {
+    while (offset < bytes.length) {
+      const result = await lockOwner.handle.read(bytes, offset, bytes.length - offset, offset);
+      if (result.bytesRead <= 0) return fail("corruption_detected");
+      offset += result.bytesRead;
+    }
+  } catch (error: unknown) {
+    mapFilesystemError(error);
+  }
+  if (!bytes.equals(lockOwner.bytes)) return fail("unsafe_metadata");
+  let parsed: RepositoryLocalWriterLockRecord;
+  try {
+    parsed = validateRepositoryLocalWriterLockRecord(parseCanonicalRepositoryLocalBytes(bytes));
+  } catch {
+    return fail("unsafe_metadata");
+  }
+  if (
+    parsed.owner_token !== lockOwner.record.owner_token ||
+    parsed.lock_record_digest !== lockOwner.record.lock_record_digest
+  ) {
+    return fail("unsafe_metadata");
+  }
+}
+
+export async function releaseRepositoryLocalWriterLock(
+  paths: RepositoryLocalPaths,
+  lockOwner: RepositoryLocalOwnedLock,
+  hooks?: RepositoryLocalFilesystemHooks,
+): Promise<void> {
+  if (lockOwner.released) return;
+  await verifyRepositoryLocalWriterLock(paths, lockOwner, hooks);
+  try {
+    await unlink(paths.lock);
+    await lockOwner.handle.close();
+    lockOwner.released = true;
+    await syncDirectoryHandle(paths.runtimeRoot, hooks);
+  } catch (error: unknown) {
+    mapFilesystemError(error, true);
+  }
+}
+
+export async function fileExistsWithoutFollowing(filePath: string): Promise<boolean> {
+  return (await lstatIfPresent(filePath)) !== undefined;
+}

--- a/packages/audit/src/repository-local-state.ts
+++ b/packages/audit/src/repository-local-state.ts
@@ -18,6 +18,7 @@ export type RepositoryLocalHealthPhase =
   | "closed"
   | "closing"
   | "pending_read"
+  | "pre_effect_check"
   | "primary_append"
   | "ready"
   | "recovery_append"

--- a/packages/audit/src/repository-local-state.ts
+++ b/packages/audit/src/repository-local-state.ts
@@ -1,0 +1,561 @@
+import { AuditError, compareAuditTimestamps, type ProtectedAuditEvent } from "./contract.js";
+import {
+  REPOSITORY_LOCAL_LIMITS,
+  primaryIdentityMatchesCommit,
+  receiptFromPrimaryCommit,
+  recoveryIdentityMatchesPending,
+  type RepositoryLocalCheckpointRecord,
+  type RepositoryLocalPrimaryCommitRecord,
+  type RepositoryLocalPrimaryIdentityRecord,
+  type RepositoryLocalRecoveryIdentityRecord,
+  type RepositoryLocalRecoveryPendingRecord,
+  type RepositoryLocalStreamRecord,
+} from "./repository-local-contract.js";
+
+export type RepositoryLocalHealthState = "healthy" | "degraded" | "failed";
+export type RepositoryLocalHealthPhase =
+  | "checkpoint"
+  | "closed"
+  | "closing"
+  | "pending_read"
+  | "primary_append"
+  | "ready"
+  | "recovery_append"
+  | "startup";
+export type RepositoryLocalHealthReason =
+  | "capacity_degraded"
+  | "capacity_exhausted"
+  | "checkpoint_invalid"
+  | "duplicate_conflict"
+  | "filesystem_unsupported"
+  | "io_ambiguous"
+  | "io_failure"
+  | "none"
+  | "pending_expired"
+  | "pending_read_bound"
+  | "state_corrupt"
+  | "state_stale"
+  | "unsafe_metadata";
+export type RepositoryLocalCapacityState = "available" | "degraded" | "exhausted";
+
+export interface RepositoryLocalPrimaryEntry {
+  readonly commit: RepositoryLocalPrimaryCommitRecord;
+  readonly identity: RepositoryLocalPrimaryIdentityRecord;
+  readonly commitBytes: number;
+  readonly identityBytes: number;
+}
+
+export interface RepositoryLocalRecoveryEntry {
+  readonly pending: RepositoryLocalRecoveryPendingRecord;
+  readonly identity: RepositoryLocalRecoveryIdentityRecord;
+  readonly pendingBytes: number;
+  readonly identityBytes: number;
+}
+
+export interface RepositoryLocalStreamState {
+  readonly metadata: RepositoryLocalStreamRecord;
+  readonly metadataBytes: number;
+  readonly commits: RepositoryLocalPrimaryEntry[];
+  readonly checkpoints: RepositoryLocalCheckpointRecord[];
+}
+
+export interface RepositoryLocalCapacityUsage {
+  primaryCommittedBytes: number;
+  eventIdentityBytes: number;
+  recoveryReservedBytes: number;
+  checkpointMetadataBytes: number;
+  temporaryBytes: number;
+  streams: number;
+  eventIdentities: number;
+  pendingRecoveryFacts: number;
+  recoveryIdentities: number;
+}
+
+export interface RepositoryLocalHealthDiagnostic {
+  readonly profile_version: 1;
+  readonly phase: RepositoryLocalHealthPhase;
+  readonly state: RepositoryLocalHealthState;
+  readonly reason: RepositoryLocalHealthReason;
+  readonly counts: Readonly<{
+    streams: number;
+    event_identities: number;
+    pending_recovery_facts: number;
+    recovery_identities: number;
+  }>;
+  readonly capacity: Readonly<{
+    primary_committed_bytes: RepositoryLocalCapacityState;
+    event_identity_bytes: RepositoryLocalCapacityState;
+    recovery_bytes: RepositoryLocalCapacityState;
+    checkpoint_metadata_bytes: RepositoryLocalCapacityState;
+    temporary_bytes: RepositoryLocalCapacityState;
+    stream_count: RepositoryLocalCapacityState;
+    event_identity_count: RepositoryLocalCapacityState;
+    pending_recovery_count: RepositoryLocalCapacityState;
+    recovery_identity_count: RepositoryLocalCapacityState;
+  }>;
+  readonly checkpoint_authority: "local_unwitnessed_not_complete";
+}
+
+export interface RepositoryLocalStateSnapshot {
+  readonly streams: ReadonlyMap<string, RepositoryLocalStreamState>;
+  readonly primaryByEventId: ReadonlyMap<string, RepositoryLocalPrimaryEntry>;
+  readonly recoveriesById: ReadonlyMap<string, RepositoryLocalRecoveryEntry>;
+  readonly diagnostic: RepositoryLocalHealthDiagnostic;
+}
+
+const NINETY_PERCENT_NUMERATOR = 9;
+const NINETY_PERCENT_DENOMINATOR = 10;
+
+export function classifyRepositoryLocalCapacity(
+  value: number,
+  limit: number,
+): RepositoryLocalCapacityState {
+  if (!Number.isSafeInteger(value) || !Number.isSafeInteger(limit) || value < 0 || limit <= 0) {
+    throw new AuditError("audit_integrity_failure");
+  }
+  if (value >= limit) return "exhausted";
+  return value * NINETY_PERCENT_DENOMINATOR >= limit * NINETY_PERCENT_NUMERATOR
+    ? "degraded"
+    : "available";
+}
+
+function safeAdd(current: number, addition: number): number {
+  if (
+    !Number.isSafeInteger(current) ||
+    !Number.isSafeInteger(addition) ||
+    current < 0 ||
+    addition < 0
+  ) {
+    throw new AuditError("audit_integrity_failure");
+  }
+  const result = current + addition;
+  if (!Number.isSafeInteger(result) || result < current) {
+    throw new AuditError("audit_integrity_failure");
+  }
+  return result;
+}
+
+function boundedCount(value: number, limit: number): number {
+  if (!Number.isSafeInteger(value) || value < 0) return limit + 1;
+  return Math.min(value, limit + 1);
+}
+
+export class RepositoryLocalState {
+  readonly streams = new Map<string, RepositoryLocalStreamState>();
+  readonly primaryByEventId = new Map<string, RepositoryLocalPrimaryEntry>();
+  readonly recoveriesById = new Map<string, RepositoryLocalRecoveryEntry>();
+  readonly retainedPrimaryIdentityIds = new Set<string>();
+  readonly retainedRecoveryIdentityIds = new Set<string>();
+  readonly usage: RepositoryLocalCapacityUsage = {
+    primaryCommittedBytes: 0,
+    eventIdentityBytes: 0,
+    recoveryReservedBytes: 0,
+    checkpointMetadataBytes: 0,
+    temporaryBytes: 0,
+    streams: 0,
+    eventIdentities: 0,
+    pendingRecoveryFacts: 0,
+    recoveryIdentities: 0,
+  };
+
+  private phase: RepositoryLocalHealthPhase = "startup";
+  private state: RepositoryLocalHealthState = "healthy";
+  private reason: RepositoryLocalHealthReason = "none";
+  private capacityOnlyFailure = false;
+
+  setPhase(phase: RepositoryLocalHealthPhase): void {
+    if (this.phase === "closed") return;
+    this.phase = phase;
+  }
+
+  fail(reason: Exclude<RepositoryLocalHealthReason, "none" | "capacity_degraded">): void {
+    if (this.state !== "failed") {
+      this.state = "failed";
+      this.reason = reason;
+      this.capacityOnlyFailure = reason === "capacity_exhausted";
+    } else if (reason !== "capacity_exhausted") {
+      this.capacityOnlyFailure = false;
+    }
+  }
+
+  degrade(): void {
+    if (this.state === "healthy") {
+      this.state = "degraded";
+      this.reason = "capacity_degraded";
+    }
+  }
+
+  isFailed(): boolean {
+    return this.state === "failed";
+  }
+
+  allowsCapacityDuplicate(): boolean {
+    return this.state === "failed" && this.capacityOnlyFailure;
+  }
+
+  assertReadable(): void {
+    if (this.state === "failed" && !this.capacityOnlyFailure) {
+      throw new AuditError("audit_unavailable");
+    }
+  }
+
+  assertWritable(): void {
+    if (this.state === "failed") throw new AuditError("audit_unavailable");
+  }
+
+  registerStream(metadata: RepositoryLocalStreamRecord, metadataBytes: number): void {
+    if (this.streams.has(metadata.stream_ref)) throw new AuditError("audit_integrity_failure");
+    this.streams.set(metadata.stream_ref, {
+      metadata,
+      metadataBytes,
+      commits: [],
+      checkpoints: [],
+    });
+    this.usage.streams = safeAdd(this.usage.streams, 1);
+    this.usage.checkpointMetadataBytes = safeAdd(this.usage.checkpointMetadataBytes, metadataBytes);
+  }
+
+  registerPrimary(stream: RepositoryLocalStreamState, entry: RepositoryLocalPrimaryEntry): void {
+    if (!primaryIdentityMatchesCommit(entry.identity, entry.commit)) {
+      throw new AuditError("audit_integrity_failure");
+    }
+    const event = entry.commit.event;
+    const tail = stream.commits.at(-1)?.commit.event;
+    const expectedSequence = tail === undefined ? 0 : tail.integrity.sequence + 1;
+    const expectedPrevious = tail?.integrity.event_hash ?? `sha256:${"0".repeat(64)}`;
+    if (
+      event.integrity.stream_ref !== stream.metadata.stream_ref ||
+      event.integrity.sequence !== expectedSequence ||
+      event.integrity.previous_event_hash !== expectedPrevious ||
+      this.primaryByEventId.has(event.event_id) ||
+      this.retainedPrimaryIdentityIds.has(event.event_id)
+    ) {
+      throw new AuditError("audit_integrity_failure");
+    }
+    stream.commits.push(entry);
+    this.primaryByEventId.set(event.event_id, entry);
+    this.retainedPrimaryIdentityIds.add(event.event_id);
+    this.usage.primaryCommittedBytes = safeAdd(this.usage.primaryCommittedBytes, entry.commitBytes);
+    this.usage.eventIdentityBytes = safeAdd(this.usage.eventIdentityBytes, entry.identityBytes);
+    this.usage.eventIdentities = safeAdd(this.usage.eventIdentities, 1);
+  }
+
+  registerOrphanPrimaryIdentity(
+    identity: RepositoryLocalPrimaryIdentityRecord,
+    identityBytes: number,
+  ): void {
+    if (this.retainedPrimaryIdentityIds.has(identity.event_id)) {
+      throw new AuditError("audit_integrity_failure");
+    }
+    this.retainedPrimaryIdentityIds.add(identity.event_id);
+    this.usage.eventIdentityBytes = safeAdd(this.usage.eventIdentityBytes, identityBytes);
+    this.usage.eventIdentities = safeAdd(this.usage.eventIdentities, 1);
+  }
+
+  registerRecovery(entry: RepositoryLocalRecoveryEntry): void {
+    if (!recoveryIdentityMatchesPending(entry.identity, entry.pending)) {
+      throw new AuditError("audit_integrity_failure");
+    }
+    const recoveryId = entry.pending.fact.recovery_id;
+    if (this.recoveriesById.has(recoveryId) || this.retainedRecoveryIdentityIds.has(recoveryId)) {
+      throw new AuditError("audit_integrity_failure");
+    }
+    this.recoveriesById.set(recoveryId, entry);
+    this.retainedRecoveryIdentityIds.add(recoveryId);
+    this.usage.pendingRecoveryFacts = safeAdd(this.usage.pendingRecoveryFacts, 1);
+    this.usage.recoveryIdentities = safeAdd(this.usage.recoveryIdentities, 1);
+    this.usage.recoveryReservedBytes = safeAdd(
+      this.usage.recoveryReservedBytes,
+      REPOSITORY_LOCAL_LIMITS.recovery_identity_reservation_bytes,
+    );
+  }
+
+  registerOrphanRecoveryIdentity(_identity: RepositoryLocalRecoveryIdentityRecord): void {
+    if (this.retainedRecoveryIdentityIds.has(_identity.recovery_id)) {
+      throw new AuditError("audit_integrity_failure");
+    }
+    this.retainedRecoveryIdentityIds.add(_identity.recovery_id);
+    this.usage.recoveryIdentities = safeAdd(this.usage.recoveryIdentities, 1);
+    this.usage.recoveryReservedBytes = safeAdd(
+      this.usage.recoveryReservedBytes,
+      REPOSITORY_LOCAL_LIMITS.recovery_identity_reservation_bytes,
+    );
+  }
+
+  registerCheckpoint(
+    stream: RepositoryLocalStreamState,
+    checkpoint: RepositoryLocalCheckpointRecord,
+    checkpointBytes: number,
+  ): void {
+    const previous = stream.checkpoints.at(-1);
+    const expectedStart = previous === undefined ? 0 : previous.range_end + 1;
+    const expectedPrevious = previous?.checkpoint_id ?? null;
+    const terminal = stream.commits[checkpoint.range_end]?.commit.event;
+    if (
+      checkpoint.stream_ref !== stream.metadata.stream_ref ||
+      checkpoint.writer_ref !== stream.metadata.writer_ref ||
+      checkpoint.range_start !== expectedStart ||
+      checkpoint.previous_checkpoint_ref !== expectedPrevious ||
+      checkpoint.range_end >= stream.commits.length ||
+      checkpoint.event_count !== checkpoint.range_end - checkpoint.range_start + 1 ||
+      terminal === undefined ||
+      terminal.integrity.event_hash !== checkpoint.terminal_event_hash
+    ) {
+      throw new AuditError("audit_integrity_failure");
+    }
+    stream.checkpoints.push(checkpoint);
+    this.usage.checkpointMetadataBytes = safeAdd(
+      this.usage.checkpointMetadataBytes,
+      checkpointBytes,
+    );
+  }
+
+  findPrimary(eventId: string): RepositoryLocalPrimaryEntry | undefined {
+    return this.primaryByEventId.get(eventId);
+  }
+
+  findRecovery(recoveryId: string): RepositoryLocalRecoveryEntry | undefined {
+    return this.recoveriesById.get(recoveryId);
+  }
+
+  hasRetainedPrimaryIdentity(eventId: string): boolean {
+    return this.retainedPrimaryIdentityIds.has(eventId);
+  }
+
+  hasRetainedRecoveryIdentity(recoveryId: string): boolean {
+    return this.retainedRecoveryIdentityIds.has(recoveryId);
+  }
+
+  tail(streamRef: string): ProtectedAuditEvent | undefined {
+    return this.streams.get(streamRef)?.commits.at(-1)?.commit.event;
+  }
+
+  receipt(eventId: string, duplicate: boolean) {
+    const entry = this.primaryByEventId.get(eventId);
+    return entry === undefined ? undefined : receiptFromPrimaryCommit(entry.commit, duplicate);
+  }
+
+  assertCanAppendPrimary(
+    commitBytes: number,
+    identityBytes: number,
+    createsStream: boolean,
+    streamMetadataBytes: number,
+    checkpointBytes: number,
+    availableBytes: bigint,
+  ): void {
+    this.assertWritable();
+    const nextPrimary = safeAdd(this.usage.primaryCommittedBytes, commitBytes);
+    const nextIdentityBytes = safeAdd(this.usage.eventIdentityBytes, identityBytes);
+    const nextIdentities = safeAdd(this.usage.eventIdentities, 1);
+    const nextStreams = safeAdd(this.usage.streams, createsStream ? 1 : 0);
+    const nextCheckpointMetadata = safeAdd(
+      this.usage.checkpointMetadataBytes,
+      safeAdd(createsStream ? streamMetadataBytes : 0, checkpointBytes),
+    );
+    const requiredFree = BigInt(
+      2 *
+        (REPOSITORY_LOCAL_LIMITS.max_primary_commit_record_bytes +
+          REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes +
+          (createsStream ? REPOSITORY_LOCAL_LIMITS.max_checkpoint_record_bytes : 0) +
+          (checkpointBytes === 0 ? 0 : REPOSITORY_LOCAL_LIMITS.max_checkpoint_record_bytes)),
+    );
+    if (
+      nextPrimary > REPOSITORY_LOCAL_LIMITS.max_primary_committed_bytes ||
+      nextIdentityBytes > REPOSITORY_LOCAL_LIMITS.max_event_identity_bytes ||
+      nextIdentities > REPOSITORY_LOCAL_LIMITS.max_event_identities ||
+      nextStreams > REPOSITORY_LOCAL_LIMITS.max_streams ||
+      nextCheckpointMetadata > REPOSITORY_LOCAL_LIMITS.max_checkpoint_deletion_metadata_bytes ||
+      availableBytes < requiredFree
+    ) {
+      this.fail("capacity_exhausted");
+      throw new AuditError("audit_unavailable");
+    }
+  }
+
+  assertCanAppendRecovery(availableBytes: bigint): void {
+    this.assertWritable();
+    const nextPending = safeAdd(this.usage.pendingRecoveryFacts, 1);
+    const nextIdentities = safeAdd(this.usage.recoveryIdentities, 1);
+    const nextReserved = safeAdd(
+      this.usage.recoveryReservedBytes,
+      REPOSITORY_LOCAL_LIMITS.recovery_identity_reservation_bytes,
+    );
+    const requiredFree = BigInt(
+      2 *
+        (REPOSITORY_LOCAL_LIMITS.max_recovery_record_bytes +
+          REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes),
+    );
+    if (
+      nextPending > REPOSITORY_LOCAL_LIMITS.max_pending_recovery_facts ||
+      nextIdentities > REPOSITORY_LOCAL_LIMITS.max_recovery_identities ||
+      nextReserved > REPOSITORY_LOCAL_LIMITS.max_recovery_bytes ||
+      availableBytes < requiredFree
+    ) {
+      this.fail("capacity_exhausted");
+      throw new AuditError("audit_unavailable");
+    }
+  }
+
+  assertStartupBounds(): void {
+    if (
+      this.usage.streams > REPOSITORY_LOCAL_LIMITS.max_streams ||
+      this.usage.primaryCommittedBytes > REPOSITORY_LOCAL_LIMITS.max_primary_committed_bytes ||
+      this.usage.eventIdentityBytes > REPOSITORY_LOCAL_LIMITS.max_event_identity_bytes ||
+      this.usage.eventIdentities > REPOSITORY_LOCAL_LIMITS.max_event_identities ||
+      this.usage.pendingRecoveryFacts > REPOSITORY_LOCAL_LIMITS.max_pending_recovery_facts ||
+      this.usage.recoveryIdentities > REPOSITORY_LOCAL_LIMITS.max_recovery_identities ||
+      this.usage.recoveryReservedBytes > REPOSITORY_LOCAL_LIMITS.max_recovery_bytes ||
+      this.usage.checkpointMetadataBytes >
+        REPOSITORY_LOCAL_LIMITS.max_checkpoint_deletion_metadata_bytes ||
+      this.usage.temporaryBytes > REPOSITORY_LOCAL_LIMITS.max_temporary_bytes
+    ) {
+      this.fail("capacity_exhausted");
+      throw new AuditError("audit_unavailable");
+    }
+  }
+
+  updateCapacityHealth(): void {
+    const capacity = this.capacityDiagnostic();
+    const values = Object.values(capacity);
+    if (values.includes("exhausted")) {
+      this.fail("capacity_exhausted");
+    } else if (values.includes("degraded")) {
+      this.degrade();
+    }
+  }
+
+  uncheckpointedCount(stream: RepositoryLocalStreamState): number {
+    const lastEnd = stream.checkpoints.at(-1)?.range_end ?? -1;
+    return stream.commits.length - (lastEnd + 1);
+  }
+
+  requiredFreeBytesForNextWrite(): bigint {
+    let primaryBytes = 0;
+    const primaryCountAvailable =
+      this.usage.primaryCommittedBytes < REPOSITORY_LOCAL_LIMITS.max_primary_committed_bytes &&
+      this.usage.eventIdentityBytes < REPOSITORY_LOCAL_LIMITS.max_event_identity_bytes &&
+      this.usage.eventIdentities < REPOSITORY_LOCAL_LIMITS.max_event_identities &&
+      (this.usage.streams > 0 || this.usage.streams < REPOSITORY_LOCAL_LIMITS.max_streams);
+    if (primaryCountAvailable) {
+      const needsMetadata =
+        this.usage.streams < REPOSITORY_LOCAL_LIMITS.max_streams ||
+        [...this.streams.values()].some(
+          (stream) =>
+            this.uncheckpointedCount(stream) + 1 === REPOSITORY_LOCAL_LIMITS.checkpoint_interval,
+        );
+      primaryBytes =
+        2 *
+        (REPOSITORY_LOCAL_LIMITS.max_primary_commit_record_bytes +
+          REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes +
+          (needsMetadata ? REPOSITORY_LOCAL_LIMITS.max_checkpoint_record_bytes : 0));
+    }
+    const recoveryAvailable =
+      this.usage.pendingRecoveryFacts < REPOSITORY_LOCAL_LIMITS.max_pending_recovery_facts &&
+      this.usage.recoveryIdentities < REPOSITORY_LOCAL_LIMITS.max_recovery_identities &&
+      this.usage.recoveryReservedBytes < REPOSITORY_LOCAL_LIMITS.max_recovery_bytes;
+    const recoveryBytes = recoveryAvailable
+      ? 2 *
+        (REPOSITORY_LOCAL_LIMITS.max_recovery_record_bytes +
+          REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes)
+      : 0;
+    return BigInt(Math.max(primaryBytes, recoveryBytes));
+  }
+
+  pendingSnapshot(): readonly RepositoryLocalRecoveryEntry[] {
+    return [...this.recoveriesById.values()].sort((left, right) => {
+      const time = compareAuditTimestamps(
+        left.pending.fact.original_observed_at,
+        right.pending.fact.original_observed_at,
+      );
+      if (time !== 0) return time;
+      const id =
+        left.pending.fact.recovery_id < right.pending.fact.recovery_id
+          ? -1
+          : left.pending.fact.recovery_id > right.pending.fact.recovery_id
+            ? 1
+            : 0;
+      if (id !== 0) return id;
+      return left.pending.fact_digest < right.pending.fact_digest
+        ? -1
+        : left.pending.fact_digest > right.pending.fact_digest
+          ? 1
+          : 0;
+    });
+  }
+
+  diagnostic(): RepositoryLocalHealthDiagnostic {
+    return {
+      profile_version: 1,
+      phase: this.phase,
+      state: this.state,
+      reason: this.reason,
+      counts: {
+        streams: boundedCount(this.usage.streams, REPOSITORY_LOCAL_LIMITS.max_streams),
+        event_identities: boundedCount(
+          this.usage.eventIdentities,
+          REPOSITORY_LOCAL_LIMITS.max_event_identities,
+        ),
+        pending_recovery_facts: boundedCount(
+          this.usage.pendingRecoveryFacts,
+          REPOSITORY_LOCAL_LIMITS.max_pending_recovery_facts,
+        ),
+        recovery_identities: boundedCount(
+          this.usage.recoveryIdentities,
+          REPOSITORY_LOCAL_LIMITS.max_recovery_identities,
+        ),
+      },
+      capacity: this.capacityDiagnostic(),
+      checkpoint_authority: "local_unwitnessed_not_complete",
+    };
+  }
+
+  snapshot(): RepositoryLocalStateSnapshot {
+    return {
+      streams: this.streams,
+      primaryByEventId: this.primaryByEventId,
+      recoveriesById: this.recoveriesById,
+      diagnostic: this.diagnostic(),
+    };
+  }
+
+  private capacityDiagnostic(): RepositoryLocalHealthDiagnostic["capacity"] {
+    return {
+      primary_committed_bytes: classifyRepositoryLocalCapacity(
+        this.usage.primaryCommittedBytes,
+        REPOSITORY_LOCAL_LIMITS.max_primary_committed_bytes,
+      ),
+      event_identity_bytes: classifyRepositoryLocalCapacity(
+        this.usage.eventIdentityBytes,
+        REPOSITORY_LOCAL_LIMITS.max_event_identity_bytes,
+      ),
+      recovery_bytes: classifyRepositoryLocalCapacity(
+        this.usage.recoveryReservedBytes,
+        REPOSITORY_LOCAL_LIMITS.max_recovery_bytes,
+      ),
+      checkpoint_metadata_bytes: classifyRepositoryLocalCapacity(
+        this.usage.checkpointMetadataBytes,
+        REPOSITORY_LOCAL_LIMITS.max_checkpoint_deletion_metadata_bytes,
+      ),
+      temporary_bytes: classifyRepositoryLocalCapacity(
+        this.usage.temporaryBytes,
+        REPOSITORY_LOCAL_LIMITS.max_temporary_bytes,
+      ),
+      stream_count: classifyRepositoryLocalCapacity(
+        this.usage.streams,
+        REPOSITORY_LOCAL_LIMITS.max_streams,
+      ),
+      event_identity_count: classifyRepositoryLocalCapacity(
+        this.usage.eventIdentities,
+        REPOSITORY_LOCAL_LIMITS.max_event_identities,
+      ),
+      pending_recovery_count: classifyRepositoryLocalCapacity(
+        this.usage.pendingRecoveryFacts,
+        REPOSITORY_LOCAL_LIMITS.max_pending_recovery_facts,
+      ),
+      recovery_identity_count: classifyRepositoryLocalCapacity(
+        this.usage.recoveryIdentities,
+        REPOSITORY_LOCAL_LIMITS.max_recovery_identities,
+      ),
+    };
+  }
+}

--- a/packages/audit/src/repository-local.ts
+++ b/packages/audit/src/repository-local.ts
@@ -6,7 +6,12 @@ import {
   isValidAuditTimestamp,
   type ProtectedAuditEvent,
 } from "./contract.js";
-import { validateRecoveryFactShape, type RecoveryFact, type RecoveryJournal } from "./lifecycle.js";
+import {
+  validateRecoveryFactShape,
+  type RecoveryFact,
+  type RecoveryJournal,
+  type RequiredAuditReadiness,
+} from "./lifecycle.js";
 import {
   canonicalRepositoryLocalBytes,
   computeRecoveryFactDigest,
@@ -83,6 +88,7 @@ export interface RepositoryLocalAuditProfileOptions {
 export interface RepositoryLocalAuditProfile {
   readonly store: AuditStore;
   readonly journal: RecoveryJournal;
+  readonly readiness: RequiredAuditReadiness;
   pendingFacts(): AsyncIterable<RecoveryFact>;
   diagnostic(): RepositoryLocalHealthDiagnostic;
   close(): Promise<void>;
@@ -92,6 +98,12 @@ export interface RepositoryLocalQualificationOptions extends RepositoryLocalAudi
   readonly now?: () => Date;
   readonly monotonicNow?: () => number;
   readonly filesystemHooks?: RepositoryLocalFilesystemHooks;
+  readonly startupPrimaryScanLimits?: RepositoryLocalStartupScanLimits;
+}
+
+export interface RepositoryLocalStartupScanLimits {
+  readonly maxRecords: number;
+  readonly maxBytes: number;
 }
 
 interface RepositoryLocalClock {
@@ -156,6 +168,42 @@ const RECOVERY_ENTRY_LIMIT = REPOSITORY_LOCAL_LIMITS.max_recovery_identities + 1
 const STREAM_ENTRY_LIMIT = REPOSITORY_LOCAL_LIMITS.max_streams + 1;
 const RECORD_DIRECTORY_ENTRY_LIMIT = 3;
 const IDENTITY_DIRECTORY_ENTRY_LIMIT = 2;
+const DEFAULT_PRIMARY_STARTUP_SCAN_LIMITS: RepositoryLocalStartupScanLimits = Object.freeze({
+  maxRecords: REPOSITORY_LOCAL_LIMITS.max_event_identities,
+  maxBytes: REPOSITORY_LOCAL_LIMITS.max_primary_committed_bytes,
+});
+
+class PrimaryStartupScanBudget {
+  private records = 0;
+  private bytes = 0;
+
+  constructor(private readonly limits: RepositoryLocalStartupScanLimits) {
+    if (
+      !Number.isSafeInteger(limits.maxRecords) ||
+      !Number.isSafeInteger(limits.maxBytes) ||
+      limits.maxRecords <= 0 ||
+      limits.maxBytes <= 0 ||
+      limits.maxRecords > REPOSITORY_LOCAL_LIMITS.max_event_identities ||
+      limits.maxBytes > REPOSITORY_LOCAL_LIMITS.max_primary_committed_bytes
+    ) {
+      corruption();
+    }
+  }
+
+  admitRecord(): void {
+    if (this.records >= this.limits.maxRecords) {
+      throw new RepositoryLocalFilesystemError("capacity_exhausted");
+    }
+    this.records += 1;
+  }
+
+  admitBytes(bytes: number): void {
+    if (!Number.isSafeInteger(bytes) || bytes <= 0 || this.bytes > this.limits.maxBytes - bytes) {
+      throw new RepositoryLocalFilesystemError("capacity_exhausted");
+    }
+    this.bytes += bytes;
+  }
+}
 
 function freezeDeep<T>(value: T): T {
   if (value !== null && typeof value === "object" && !Object.isFrozen(value)) {
@@ -239,6 +287,7 @@ async function readValidatedRecord<T>(
   hooks: RepositoryLocalFilesystemHooks | undefined,
   validate: (value: unknown) => T,
   expectedLinks: 1 | 2 = 1,
+  beforeRead?: (size: number) => void,
 ): Promise<LoadedRecord<T>> {
   const loaded = await readBoundedRepositoryLocalFile(
     filePath,
@@ -246,6 +295,7 @@ async function readValidatedRecord<T>(
     expectedDevice,
     hooks,
     expectedLinks,
+    beforeRead,
   );
   let record: T;
   try {
@@ -511,6 +561,7 @@ async function scanCommitDirectory(
   directoryPath: string,
   expectedDevice: number,
   hooks: RepositoryLocalFilesystemHooks | undefined,
+  budget: PrimaryStartupScanBudget,
 ): Promise<readonly LoadedCommit[]> {
   const names = await listRepositoryLocalDirectory(
     directoryPath,
@@ -538,6 +589,7 @@ async function scanCommitDirectory(
     if (!Number.isSafeInteger(sequence) || repositoryLocalSequenceFileName(sequence) !== name) {
       corruption();
     }
+    budget.admitRecord();
     const filePath = path.join(directoryPath, name);
     const loaded = await readValidatedRecord(
       filePath,
@@ -546,6 +598,7 @@ async function scanCommitDirectory(
       hooks,
       validateRepositoryLocalPrimaryCommitRecord,
       temporaryDestinations.has(name) ? 2 : 1,
+      (size) => budget.admitBytes(size),
     );
     if (loaded.record.event.integrity.sequence !== sequence) corruption();
     finals.set(name, { ...loaded, directoryPath, filePath });
@@ -578,6 +631,7 @@ async function scanStreams(
   hooks: RepositoryLocalFilesystemHooks | undefined,
   writerRef: string,
   state: RepositoryLocalState,
+  budget: PrimaryStartupScanBudget,
 ): Promise<readonly LoadedStream[]> {
   const streamDirectoryNames = await listRepositoryLocalDirectory(
     paths.streams,
@@ -611,7 +665,7 @@ async function scanStreams(
       if (streamFileExists || temporaries.length !== 0 || entries.length !== 0) corruption();
       continue;
     }
-    const commits = await scanCommitDirectory(commitsDirectoryPath, expectedDevice, hooks);
+    const commits = await scanCommitDirectory(commitsDirectoryPath, expectedDevice, hooks, budget);
     let loadedMetadata: LoadedRecord<RepositoryLocalStreamRecord> | undefined;
     if (streamFileExists) {
       loadedMetadata = await readValidatedRecord(
@@ -1337,6 +1391,7 @@ function mapFilesystemReason(
 class RepositoryLocalProfileCore {
   readonly store: AuditStore;
   readonly journal: RecoveryJournal;
+  readonly readiness: RequiredAuditReadiness;
   private queue: Promise<void> = Promise.resolve();
   private closed = false;
 
@@ -1357,6 +1412,9 @@ class RepositoryLocalProfileCore {
     });
     this.journal = Object.freeze({
       append: (fact: RecoveryFact) => this.appendRecovery(fact),
+    });
+    this.readiness = Object.freeze({
+      assertReadyForProviderStart: () => this.assertReadyForProviderStart(),
     });
   }
 
@@ -1430,7 +1488,7 @@ class RepositoryLocalProfileCore {
   }
 
   private run<T>(
-    phase: "pending_read" | "primary_append" | "recovery_append",
+    phase: "pending_read" | "pre_effect_check" | "primary_append" | "recovery_append",
     operation: () => Promise<T>,
   ): Promise<T> {
     const result = this.queue.then(async () => {
@@ -1451,6 +1509,21 @@ class RepositoryLocalProfileCore {
       () => undefined,
     );
     return result;
+  }
+
+  private assertReadyForProviderStart(): Promise<void> {
+    return this.run("pre_effect_check", async () => {
+      this.state.assertWritable();
+      const availableBytes = await repositoryLocalAvailableBytes(
+        this.paths.runtimeRoot,
+        this.hooks,
+      );
+      if (availableBytes < this.state.requiredFreeBytesForNextWrite()) {
+        this.state.fail("capacity_exhausted");
+        throw unavailable();
+      }
+      this.state.assertWritable();
+    });
   }
 
   private translate(error: unknown): AuditError {
@@ -1889,6 +1962,7 @@ class RepositoryLocalProfileCore {
 
 async function openRepositoryLocalAuditProfileInternal(
   options: RepositoryLocalQualificationOptions,
+  startupPrimaryScanLimits: RepositoryLocalStartupScanLimits,
 ): Promise<RepositoryLocalAuditProfile> {
   if (!isRepositoryLocalReference(options.writerRef)) {
     throw new AuditError("audit_candidate_invalid");
@@ -1932,6 +2006,7 @@ async function openRepositoryLocalAuditProfileInternal(
       options.filesystemHooks,
       profile.writer_ref,
       state,
+      new PrimaryStartupScanBudget(startupPrimaryScanLimits),
     );
     const primaryIdentityDirectories = await scanPrimaryIdentityDirectories(
       paths,
@@ -2008,6 +2083,7 @@ async function openRepositoryLocalAuditProfileInternal(
     return Object.freeze({
       store: core.store,
       journal: core.journal,
+      readiness: core.readiness,
       pendingFacts: () => core.pendingFacts(),
       diagnostic: () => core.diagnostic(),
       close: () => core.close(),
@@ -2048,11 +2124,14 @@ async function openRepositoryLocalAuditProfileInternal(
 export function openRepositoryLocalAuditProfile(
   options: RepositoryLocalAuditProfileOptions,
 ): Promise<RepositoryLocalAuditProfile> {
-  return openRepositoryLocalAuditProfileInternal(options);
+  return openRepositoryLocalAuditProfileInternal(options, DEFAULT_PRIMARY_STARTUP_SCAN_LIMITS);
 }
 
 export function openRepositoryLocalAuditProfileForQualification(
   options: RepositoryLocalQualificationOptions,
 ): Promise<RepositoryLocalAuditProfile> {
-  return openRepositoryLocalAuditProfileInternal(options);
+  return openRepositoryLocalAuditProfileInternal(
+    options,
+    options.startupPrimaryScanLimits ?? DEFAULT_PRIMARY_STARTUP_SCAN_LIMITS,
+  );
 }

--- a/packages/audit/src/repository-local.ts
+++ b/packages/audit/src/repository-local.ts
@@ -1,0 +1,2058 @@
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import {
+  AuditError,
+  compareAuditTimestamps,
+  isValidAuditTimestamp,
+  type ProtectedAuditEvent,
+} from "./contract.js";
+import { validateRecoveryFactShape, type RecoveryFact, type RecoveryJournal } from "./lifecycle.js";
+import {
+  canonicalRepositoryLocalBytes,
+  computeRecoveryFactDigest,
+  createRepositoryLocalCheckpointRecord,
+  createRepositoryLocalPrimaryCommitRecord,
+  createRepositoryLocalPrimaryIdentityRecord,
+  createRepositoryLocalProfileRecord,
+  createRepositoryLocalRecoveryIdentityRecord,
+  createRepositoryLocalRecoveryPendingRecord,
+  createRepositoryLocalStreamRecord,
+  isRepositoryLocalReference,
+  primaryIdentityMatchesCommit,
+  REPOSITORY_LOCAL_LIMITS,
+  receiptFromPrimaryCommit,
+  recoveryIdentityMatchesPending,
+  repositoryLocalCheckpointFileName,
+  repositoryLocalIdentityVersionFileName,
+  repositoryLocalReferencePathDigest,
+  repositoryLocalSequenceFileName,
+  RepositoryLocalFormatError,
+  validateRepositoryLocalCheckpointRecord,
+  validateRepositoryLocalPrimaryCommitRecord,
+  validateRepositoryLocalPrimaryIdentityRecord,
+  validateRepositoryLocalProfileRecord,
+  validateRepositoryLocalRecoveryIdentityRecord,
+  validateRepositoryLocalRecoveryPendingRecord,
+  validateRepositoryLocalStreamRecord,
+  type RepositoryLocalCheckpointRecord,
+  type RepositoryLocalPrimaryCommitRecord,
+  type RepositoryLocalPrimaryIdentityRecord,
+  type RepositoryLocalProfileRecord,
+  type RepositoryLocalRecoveryIdentityRecord,
+  type RepositoryLocalRecoveryPendingRecord,
+  type RepositoryLocalStreamRecord,
+} from "./repository-local-contract.js";
+import {
+  acquireRepositoryLocalWriterLock,
+  assertEmptyRepositoryLocalDirectory,
+  ensureDurableRepositoryLocalDirectory,
+  ensureRepositoryLocalRuntimeRoot,
+  ensureRepositoryLocalTopology,
+  fileExistsWithoutFollowing,
+  inspectRepositoryLocalTemporaryBytes,
+  listRepositoryLocalDirectory,
+  publishRepositoryLocalFile,
+  qualifyRepositoryLocalFilesystem,
+  readBoundedRepositoryLocalFile,
+  releaseRepositoryLocalWriterLock,
+  removeRecognizedRepositoryLocalTemporary,
+  repositoryLocalAvailableBytes,
+  resolveTrustedRepositoryLocalPaths,
+  syncRepositoryLocalDirectory,
+  verifyRepositoryLocalWriterLock,
+  RepositoryLocalFilesystemError,
+  type RepositoryLocalFileKind,
+  type RepositoryLocalFilesystemHooks,
+  type RepositoryLocalOwnedLock,
+  type RepositoryLocalPaths,
+} from "./repository-local-filesystem.js";
+import {
+  RepositoryLocalState,
+  type RepositoryLocalHealthDiagnostic,
+  type RepositoryLocalPrimaryEntry,
+  type RepositoryLocalRecoveryEntry,
+  type RepositoryLocalStreamState,
+} from "./repository-local-state.js";
+import { AUDIT_GENESIS_HASH, type AuditCommitReceipt, type AuditStore } from "./writer.js";
+
+export interface RepositoryLocalAuditProfileOptions {
+  readonly trustedRepositoryRoot: string;
+  readonly writerRef: string;
+}
+
+export interface RepositoryLocalAuditProfile {
+  readonly store: AuditStore;
+  readonly journal: RecoveryJournal;
+  pendingFacts(): AsyncIterable<RecoveryFact>;
+  diagnostic(): RepositoryLocalHealthDiagnostic;
+  close(): Promise<void>;
+}
+
+export interface RepositoryLocalQualificationOptions extends RepositoryLocalAuditProfileOptions {
+  readonly now?: () => Date;
+  readonly monotonicNow?: () => number;
+  readonly filesystemHooks?: RepositoryLocalFilesystemHooks;
+}
+
+interface RepositoryLocalClock {
+  nowIso(): string;
+  monotonic(): number;
+}
+
+interface LoadedRecord<T> {
+  readonly record: T;
+  readonly bytes: Buffer;
+}
+
+interface LoadedCommit extends LoadedRecord<RepositoryLocalPrimaryCommitRecord> {
+  readonly directoryPath: string;
+  readonly filePath: string;
+}
+
+interface LoadedStream {
+  readonly state: RepositoryLocalStreamState;
+  readonly commits: readonly LoadedCommit[];
+}
+
+interface PrimaryIdentityDirectory {
+  readonly directoryPath: string;
+  readonly pathDigest: string;
+  readonly final?: LoadedRecord<RepositoryLocalPrimaryIdentityRecord>;
+  readonly temporaries: readonly string[];
+}
+
+interface RecoveryIdentityDirectory {
+  readonly directoryPath: string;
+  readonly pathDigest: string;
+  readonly final?: LoadedRecord<RepositoryLocalRecoveryIdentityRecord>;
+  readonly temporaries: readonly string[];
+}
+
+interface PreparedCheckpoint {
+  readonly record: RepositoryLocalCheckpointRecord;
+  readonly bytes: Buffer;
+}
+
+interface PendingFactPass {
+  readonly facts: readonly RecoveryFact[];
+  readonly started: number;
+}
+
+const RAW_DIGEST_PATTERN = /^[0-9a-f]{64}$/;
+const SEQUENCE_FILE_PATTERN = /^[0-9]{20}\.json$/;
+const CHECKPOINT_FILE_PATTERN = /^[0-9a-f]{64}\.json$/;
+const TEMPORARY_FILE_PATTERN = /^\.(.+\.json)\.([0-9a-f]{64})\.tmp$/;
+const STATIC_ROOT_ENTRIES = [
+  "exports",
+  "primary",
+  "profile.json",
+  "recovery",
+  "tmp",
+  "writer.lock",
+] as const;
+const ROOT_ENTRY_LIMIT = STATIC_ROOT_ENTRIES.length + 1;
+const PRIMARY_ENTRY_LIMIT = REPOSITORY_LOCAL_LIMITS.max_event_identities + 1;
+const RECOVERY_ENTRY_LIMIT = REPOSITORY_LOCAL_LIMITS.max_recovery_identities + 1;
+const STREAM_ENTRY_LIMIT = REPOSITORY_LOCAL_LIMITS.max_streams + 1;
+const RECORD_DIRECTORY_ENTRY_LIMIT = 3;
+const IDENTITY_DIRECTORY_ENTRY_LIMIT = 2;
+
+function freezeDeep<T>(value: T): T {
+  if (value !== null && typeof value === "object" && !Object.isFrozen(value)) {
+    for (const child of Object.values(value as Record<string, unknown>)) freezeDeep(child);
+    Object.freeze(value);
+  }
+  return value;
+}
+
+function unavailable(): AuditError {
+  return new AuditError("audit_unavailable");
+}
+
+function corruption(): never {
+  throw new RepositoryLocalFilesystemError("corruption_detected");
+}
+
+function createClock(
+  options: Readonly<{
+    now?: () => Date;
+    monotonicNow?: () => number;
+  }>,
+): RepositoryLocalClock {
+  const now = options.now ?? (() => new Date());
+  const monotonicNow = options.monotonicNow ?? (() => performance.now());
+  return {
+    nowIso(): string {
+      let value: Date;
+      let timestamp: string;
+      try {
+        value = now();
+        timestamp = value.toISOString();
+      } catch {
+        throw unavailable();
+      }
+      if (!(value instanceof Date) || !isValidAuditTimestamp(timestamp)) throw unavailable();
+      return timestamp;
+    },
+    monotonic(): number {
+      let value: number;
+      try {
+        value = monotonicNow();
+      } catch {
+        throw unavailable();
+      }
+      if (!Number.isFinite(value) || value < 0) throw unavailable();
+      return value;
+    },
+  };
+}
+
+function assertExactNames(actual: readonly string[], expected: readonly string[]): void {
+  if (
+    actual.length !== expected.length ||
+    actual.some((name, index) => name !== [...expected].sort()[index])
+  ) {
+    corruption();
+  }
+}
+
+function temporaryName(destinationName: string, recordDigest: string): string {
+  if (!recordDigest.startsWith("sha256:")) corruption();
+  const raw = recordDigest.slice("sha256:".length);
+  if (!RAW_DIGEST_PATTERN.test(raw)) corruption();
+  return `.${destinationName}.${raw}.tmp`;
+}
+
+function parseTemporaryName(
+  name: string,
+): Readonly<{ destinationName: string; digest: string }> | undefined {
+  const match = TEMPORARY_FILE_PATTERN.exec(name);
+  if (match === null || match[1] === undefined || match[2] === undefined) return undefined;
+  if (match[1].startsWith(".") || match[1].includes(path.sep)) return undefined;
+  return { destinationName: match[1], digest: `sha256:${match[2]}` };
+}
+
+async function readValidatedRecord<T>(
+  filePath: string,
+  maximumBytes: number,
+  expectedDevice: number,
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+  validate: (value: unknown) => T,
+  expectedLinks: 1 | 2 = 1,
+): Promise<LoadedRecord<T>> {
+  const loaded = await readBoundedRepositoryLocalFile(
+    filePath,
+    maximumBytes,
+    expectedDevice,
+    hooks,
+    expectedLinks,
+  );
+  let record: T;
+  try {
+    record = validate(loaded.value);
+  } catch {
+    corruption();
+  }
+  return { record: freezeDeep(record), bytes: loaded.bytes };
+}
+
+async function cleanupBoundTemporary(
+  directoryPath: string,
+  temporary: string,
+  expectedDestination: string,
+  expectedDigest: string | undefined,
+  maximumBytes: number,
+  expectedDevice: number,
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+  destinationExists: boolean,
+): Promise<void> {
+  const binding = parseTemporaryName(temporary);
+  if (
+    binding === undefined ||
+    binding.destinationName !== expectedDestination ||
+    (expectedDigest !== undefined && binding.digest !== expectedDigest)
+  ) {
+    corruption();
+  }
+  await removeRecognizedRepositoryLocalTemporary(
+    path.join(directoryPath, temporary),
+    directoryPath,
+    maximumBytes,
+    expectedDevice,
+    hooks,
+    destinationExists ? path.join(directoryPath, expectedDestination) : undefined,
+  );
+}
+
+async function assertClosedStaticTopology(
+  paths: RepositoryLocalPaths,
+  expectedDevice: number,
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+): Promise<void> {
+  assertExactNames(
+    await listRepositoryLocalDirectory(paths.runtimeRoot, expectedDevice, ROOT_ENTRY_LIMIT, hooks),
+    STATIC_ROOT_ENTRIES,
+  );
+  assertExactNames(await listRepositoryLocalDirectory(paths.primary, expectedDevice, 4, hooks), [
+    "checkpoints",
+    "deletions",
+    "identities",
+    "streams",
+  ]);
+  assertExactNames(await listRepositoryLocalDirectory(paths.recovery, expectedDevice, 4, hooks), [
+    "acknowledged",
+    "identities",
+    "pending",
+    "quarantine",
+  ]);
+  await assertEmptyRepositoryLocalDirectory(paths.deletions, expectedDevice, hooks);
+  await assertEmptyRepositoryLocalDirectory(paths.acknowledged, expectedDevice, hooks);
+  await assertEmptyRepositoryLocalDirectory(paths.quarantine, expectedDevice, hooks);
+  await assertEmptyRepositoryLocalDirectory(paths.exports, expectedDevice, hooks);
+  await assertEmptyRepositoryLocalDirectory(paths.temporary, expectedDevice, hooks);
+}
+
+async function assertBoundedStartupTemporaryState(
+  paths: RepositoryLocalPaths,
+  expectedDevice: number,
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+): Promise<void> {
+  let count = 0;
+  let bytes = 0;
+  const inspect = async (
+    directoryPath: string,
+    maximumBytes: number,
+    maximumEntries: number,
+  ): Promise<void> => {
+    const names = await listRepositoryLocalDirectory(
+      directoryPath,
+      expectedDevice,
+      maximumEntries,
+      hooks,
+    );
+    for (const name of names) {
+      if (!name.endsWith(".tmp")) continue;
+      if (parseTemporaryName(name) === undefined) corruption();
+      count += 1;
+      bytes += await inspectRepositoryLocalTemporaryBytes(
+        path.join(directoryPath, name),
+        maximumBytes,
+        expectedDevice,
+        hooks,
+      );
+      if (
+        count > 1 ||
+        !Number.isSafeInteger(bytes) ||
+        bytes > REPOSITORY_LOCAL_LIMITS.max_temporary_bytes
+      ) {
+        corruption();
+      }
+    }
+  };
+
+  await inspect(
+    paths.runtimeRoot,
+    REPOSITORY_LOCAL_LIMITS.max_checkpoint_record_bytes,
+    ROOT_ENTRY_LIMIT,
+  );
+  await inspect(
+    paths.checkpoints,
+    REPOSITORY_LOCAL_LIMITS.max_checkpoint_record_bytes,
+    PRIMARY_ENTRY_LIMIT,
+  );
+  await inspect(
+    paths.pending,
+    REPOSITORY_LOCAL_LIMITS.max_recovery_record_bytes,
+    RECOVERY_ENTRY_LIMIT,
+  );
+  for (const name of await listRepositoryLocalDirectory(
+    paths.streams,
+    expectedDevice,
+    STREAM_ENTRY_LIMIT,
+    hooks,
+  )) {
+    if (!RAW_DIGEST_PATTERN.test(name)) corruption();
+    const streamPath = path.join(paths.streams, name);
+    await inspect(
+      streamPath,
+      REPOSITORY_LOCAL_LIMITS.max_checkpoint_record_bytes,
+      RECORD_DIRECTORY_ENTRY_LIMIT,
+    );
+    if (await fileExistsWithoutFollowing(path.join(streamPath, "commits"))) {
+      await inspect(
+        path.join(streamPath, "commits"),
+        REPOSITORY_LOCAL_LIMITS.max_primary_commit_record_bytes,
+        PRIMARY_ENTRY_LIMIT,
+      );
+    }
+  }
+  for (const [root, maximumBytes] of [
+    [paths.primaryIdentities, REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes],
+    [paths.recoveryIdentities, REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes],
+  ] as const) {
+    const rootLimit = root === paths.primaryIdentities ? PRIMARY_ENTRY_LIMIT : RECOVERY_ENTRY_LIMIT;
+    for (const name of await listRepositoryLocalDirectory(root, expectedDevice, rootLimit, hooks)) {
+      if (!RAW_DIGEST_PATTERN.test(name)) corruption();
+      await inspect(path.join(root, name), maximumBytes, IDENTITY_DIRECTORY_ENTRY_LIMIT);
+    }
+  }
+}
+
+async function assertNoEvidenceForProfileCreation(
+  paths: RepositoryLocalPaths,
+  expectedDevice: number,
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+): Promise<void> {
+  for (const directoryPath of [
+    paths.streams,
+    paths.primaryIdentities,
+    paths.checkpoints,
+    paths.deletions,
+    paths.pending,
+    paths.acknowledged,
+    paths.recoveryIdentities,
+    paths.quarantine,
+    paths.exports,
+    paths.temporary,
+  ]) {
+    await assertEmptyRepositoryLocalDirectory(directoryPath, expectedDevice, hooks);
+  }
+}
+
+async function loadOrCreateProfile(
+  paths: RepositoryLocalPaths,
+  writerRef: string,
+  createdAt: string,
+  expectedDevice: number,
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+): Promise<RepositoryLocalProfileRecord> {
+  const rootNames = await listRepositoryLocalDirectory(
+    paths.runtimeRoot,
+    expectedDevice,
+    ROOT_ENTRY_LIMIT,
+    hooks,
+  );
+  const profileTemporaries = rootNames.filter((name) => {
+    const binding = parseTemporaryName(name);
+    return binding?.destinationName === "profile.json";
+  });
+  const unexpected = rootNames.filter(
+    (name) =>
+      !STATIC_ROOT_ENTRIES.includes(name as (typeof STATIC_ROOT_ENTRIES)[number]) &&
+      !profileTemporaries.includes(name),
+  );
+  if (unexpected.length !== 0 || profileTemporaries.length > 1) corruption();
+
+  const profileExists = await fileExistsWithoutFollowing(paths.profile);
+  if (profileExists) {
+    let loaded = await readValidatedRecord(
+      paths.profile,
+      REPOSITORY_LOCAL_LIMITS.max_checkpoint_record_bytes,
+      expectedDevice,
+      hooks,
+      validateRepositoryLocalProfileRecord,
+      profileTemporaries.length === 1 ? 2 : 1,
+    );
+    if (loaded.record.writer_ref !== writerRef) corruption();
+    if (profileTemporaries[0] !== undefined) {
+      await cleanupBoundTemporary(
+        paths.runtimeRoot,
+        profileTemporaries[0],
+        "profile.json",
+        loaded.record.profile_record_digest,
+        REPOSITORY_LOCAL_LIMITS.max_checkpoint_record_bytes,
+        expectedDevice,
+        hooks,
+        true,
+      );
+    }
+    await syncRepositoryLocalDirectory(paths.runtimeRoot, hooks, "profile");
+    loaded = await readValidatedRecord(
+      paths.profile,
+      REPOSITORY_LOCAL_LIMITS.max_checkpoint_record_bytes,
+      expectedDevice,
+      hooks,
+      validateRepositoryLocalProfileRecord,
+    );
+    if (loaded.record.writer_ref !== writerRef) corruption();
+    return loaded.record;
+  }
+
+  if (profileTemporaries[0] !== undefined) {
+    await cleanupBoundTemporary(
+      paths.runtimeRoot,
+      profileTemporaries[0],
+      "profile.json",
+      undefined,
+      REPOSITORY_LOCAL_LIMITS.max_checkpoint_record_bytes,
+      expectedDevice,
+      hooks,
+      false,
+    );
+  }
+  await assertNoEvidenceForProfileCreation(paths, expectedDevice, hooks);
+  const profile = createRepositoryLocalProfileRecord(writerRef, createdAt);
+  const bytes = canonicalRepositoryLocalBytes(profile);
+  await publishRepositoryLocalFile(
+    paths.runtimeRoot,
+    "profile.json",
+    temporaryName("profile.json", profile.profile_record_digest),
+    bytes,
+    REPOSITORY_LOCAL_LIMITS.max_checkpoint_record_bytes,
+    expectedDevice,
+    "profile",
+    hooks,
+  );
+  await syncRepositoryLocalDirectory(paths.runtimeRoot, hooks, "profile");
+  return freezeDeep(profile);
+}
+
+async function scanCommitDirectory(
+  directoryPath: string,
+  expectedDevice: number,
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+): Promise<readonly LoadedCommit[]> {
+  const names = await listRepositoryLocalDirectory(
+    directoryPath,
+    expectedDevice,
+    PRIMARY_ENTRY_LIMIT,
+    hooks,
+  );
+  const finals = new Map<string, LoadedCommit>();
+  const temporaries = names.filter((name) => name.endsWith(".tmp"));
+  const temporaryDestinations = new Set<string>();
+  for (const temporary of temporaries) {
+    const binding = parseTemporaryName(temporary);
+    if (
+      binding === undefined ||
+      !SEQUENCE_FILE_PATTERN.test(binding.destinationName) ||
+      temporaryDestinations.has(binding.destinationName)
+    ) {
+      corruption();
+    }
+    temporaryDestinations.add(binding.destinationName);
+  }
+  for (const name of names.filter((entry) => !entry.endsWith(".tmp"))) {
+    if (!SEQUENCE_FILE_PATTERN.test(name)) corruption();
+    const sequence = Number(name.slice(0, 20));
+    if (!Number.isSafeInteger(sequence) || repositoryLocalSequenceFileName(sequence) !== name) {
+      corruption();
+    }
+    const filePath = path.join(directoryPath, name);
+    const loaded = await readValidatedRecord(
+      filePath,
+      REPOSITORY_LOCAL_LIMITS.max_primary_commit_record_bytes,
+      expectedDevice,
+      hooks,
+      validateRepositoryLocalPrimaryCommitRecord,
+      temporaryDestinations.has(name) ? 2 : 1,
+    );
+    if (loaded.record.event.integrity.sequence !== sequence) corruption();
+    finals.set(name, { ...loaded, directoryPath, filePath });
+  }
+  for (const temporary of temporaries) {
+    const binding = parseTemporaryName(temporary);
+    if (binding === undefined || !SEQUENCE_FILE_PATTERN.test(binding.destinationName)) {
+      corruption();
+    }
+    const final = finals.get(binding.destinationName);
+    await cleanupBoundTemporary(
+      directoryPath,
+      temporary,
+      binding.destinationName,
+      final?.record.primary_commit_record_digest,
+      REPOSITORY_LOCAL_LIMITS.max_primary_commit_record_bytes,
+      expectedDevice,
+      hooks,
+      final !== undefined,
+    );
+  }
+  return [...finals.values()].sort(
+    (left, right) => left.record.event.integrity.sequence - right.record.event.integrity.sequence,
+  );
+}
+
+async function scanStreams(
+  paths: RepositoryLocalPaths,
+  expectedDevice: number,
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+  writerRef: string,
+  state: RepositoryLocalState,
+): Promise<readonly LoadedStream[]> {
+  const streamDirectoryNames = await listRepositoryLocalDirectory(
+    paths.streams,
+    expectedDevice,
+    STREAM_ENTRY_LIMIT,
+    hooks,
+  );
+  const loadedStreams: LoadedStream[] = [];
+  for (const streamDirectoryName of streamDirectoryNames) {
+    if (!RAW_DIGEST_PATTERN.test(streamDirectoryName)) corruption();
+    const streamDirectoryPath = path.join(paths.streams, streamDirectoryName);
+    const entries = await listRepositoryLocalDirectory(
+      streamDirectoryPath,
+      expectedDevice,
+      RECORD_DIRECTORY_ENTRY_LIMIT,
+      hooks,
+    );
+    const temporaries = entries.filter((name) => name.endsWith(".tmp"));
+    if (
+      temporaries.length > 1 ||
+      entries.some(
+        (name) => name !== "commits" && name !== "stream.json" && !temporaries.includes(name),
+      )
+    ) {
+      corruption();
+    }
+    const commitsDirectoryPath = path.join(streamDirectoryPath, "commits");
+    const commitsDirectoryExists = entries.includes("commits");
+    const streamFileExists = entries.includes("stream.json");
+    if (!commitsDirectoryExists) {
+      if (streamFileExists || temporaries.length !== 0 || entries.length !== 0) corruption();
+      continue;
+    }
+    const commits = await scanCommitDirectory(commitsDirectoryPath, expectedDevice, hooks);
+    let loadedMetadata: LoadedRecord<RepositoryLocalStreamRecord> | undefined;
+    if (streamFileExists) {
+      loadedMetadata = await readValidatedRecord(
+        path.join(streamDirectoryPath, "stream.json"),
+        REPOSITORY_LOCAL_LIMITS.max_checkpoint_record_bytes,
+        expectedDevice,
+        hooks,
+        validateRepositoryLocalStreamRecord,
+        temporaries.length === 1 ? 2 : 1,
+      );
+      if (
+        loadedMetadata.record.stream_path_digest !== streamDirectoryName ||
+        loadedMetadata.record.writer_ref !== writerRef
+      ) {
+        corruption();
+      }
+    }
+    if (temporaries[0] !== undefined) {
+      await cleanupBoundTemporary(
+        streamDirectoryPath,
+        temporaries[0],
+        "stream.json",
+        loadedMetadata?.record.stream_record_digest,
+        REPOSITORY_LOCAL_LIMITS.max_checkpoint_record_bytes,
+        expectedDevice,
+        hooks,
+        loadedMetadata !== undefined,
+      );
+    }
+    if (loadedMetadata === undefined) {
+      if (commits.length !== 0) corruption();
+      continue;
+    }
+    await syncRepositoryLocalDirectory(streamDirectoryPath, hooks, "stream");
+    loadedMetadata = await readValidatedRecord(
+      path.join(streamDirectoryPath, "stream.json"),
+      REPOSITORY_LOCAL_LIMITS.max_checkpoint_record_bytes,
+      expectedDevice,
+      hooks,
+      validateRepositoryLocalStreamRecord,
+    );
+    if (
+      loadedMetadata.record.stream_path_digest !== streamDirectoryName ||
+      loadedMetadata.record.writer_ref !== writerRef
+    ) {
+      corruption();
+    }
+    state.registerStream(loadedMetadata.record, loadedMetadata.bytes.length);
+    const streamState = state.streams.get(loadedMetadata.record.stream_ref);
+    if (streamState === undefined) corruption();
+    loadedStreams.push({ state: streamState, commits });
+  }
+  return loadedStreams;
+}
+
+async function scanPrimaryIdentityDirectories(
+  paths: RepositoryLocalPaths,
+  expectedDevice: number,
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+  writerRef: string,
+): Promise<ReadonlyMap<string, PrimaryIdentityDirectory>> {
+  const directories = new Map<string, PrimaryIdentityDirectory>();
+  const names = await listRepositoryLocalDirectory(
+    paths.primaryIdentities,
+    expectedDevice,
+    PRIMARY_ENTRY_LIMIT,
+    hooks,
+  );
+  for (const name of names) {
+    if (!RAW_DIGEST_PATTERN.test(name)) corruption();
+    const directoryPath = path.join(paths.primaryIdentities, name);
+    const entries = await listRepositoryLocalDirectory(
+      directoryPath,
+      expectedDevice,
+      IDENTITY_DIRECTORY_ENTRY_LIMIT,
+      hooks,
+    );
+    const temporaries = entries.filter((entry) => entry.endsWith(".tmp"));
+    const finalName = repositoryLocalIdentityVersionFileName(0);
+    if (
+      temporaries.length > 1 ||
+      entries.some((entry) => entry !== finalName && !temporaries.includes(entry))
+    ) {
+      corruption();
+    }
+    let final: LoadedRecord<RepositoryLocalPrimaryIdentityRecord> | undefined;
+    if (entries.includes(finalName)) {
+      final = await readValidatedRecord(
+        path.join(directoryPath, finalName),
+        REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes,
+        expectedDevice,
+        hooks,
+        validateRepositoryLocalPrimaryIdentityRecord,
+        temporaries.length === 1 ? 2 : 1,
+      );
+      if (
+        repositoryLocalReferencePathDigest(final.record.event_id) !== name ||
+        final.record.writer_ref !== writerRef
+      ) {
+        corruption();
+      }
+    }
+    directories.set(name, {
+      directoryPath,
+      pathDigest: name,
+      ...(final === undefined ? {} : { final }),
+      temporaries,
+    });
+  }
+  return directories;
+}
+
+async function rereadPrimaryPair(
+  commit: LoadedCommit,
+  identityPath: string,
+  expectedDevice: number,
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+): Promise<
+  Readonly<{
+    commit: LoadedRecord<RepositoryLocalPrimaryCommitRecord>;
+    identity: LoadedRecord<RepositoryLocalPrimaryIdentityRecord>;
+  }>
+> {
+  const reloadedCommit = await readValidatedRecord(
+    commit.filePath,
+    REPOSITORY_LOCAL_LIMITS.max_primary_commit_record_bytes,
+    expectedDevice,
+    hooks,
+    validateRepositoryLocalPrimaryCommitRecord,
+  );
+  const reloadedIdentity = await readValidatedRecord(
+    identityPath,
+    REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes,
+    expectedDevice,
+    hooks,
+    validateRepositoryLocalPrimaryIdentityRecord,
+  );
+  if (
+    !reloadedCommit.bytes.equals(commit.bytes) ||
+    !primaryIdentityMatchesCommit(reloadedIdentity.record, reloadedCommit.record)
+  ) {
+    corruption();
+  }
+  return { commit: reloadedCommit, identity: reloadedIdentity };
+}
+
+function prevalidatePrimaryState(
+  streams: readonly LoadedStream[],
+  identityDirectories: ReadonlyMap<string, PrimaryIdentityDirectory>,
+  state: RepositoryLocalState,
+): void {
+  const eventIds = new Set<string>();
+  const consumedIdentityDirectories = new Set<string>();
+  let committedBytes = 0;
+  let identityBytes = 0;
+  for (const stream of streams) {
+    let expectedSequence = 0;
+    let expectedPrevious = AUDIT_GENESIS_HASH;
+    for (const loadedCommit of stream.commits) {
+      const event = loadedCommit.record.event;
+      const genesisHash =
+        event.event_type === "audit.stream_opened.v1"
+          ? (event.payload.value as Readonly<{ genesis_hash?: unknown }>).genesis_hash
+          : undefined;
+      if (
+        event.integrity.stream_ref !== stream.state.metadata.stream_ref ||
+        event.integrity.writer_ref !== stream.state.metadata.writer_ref ||
+        event.integrity.sequence !== expectedSequence ||
+        event.integrity.previous_event_hash !== expectedPrevious ||
+        eventIds.has(event.event_id) ||
+        (expectedSequence === 0 &&
+          (event.event_type !== "audit.stream_opened.v1" || genesisHash !== AUDIT_GENESIS_HASH)) ||
+        (expectedSequence !== 0 && event.event_type === "audit.stream_opened.v1")
+      ) {
+        corruption();
+      }
+      eventIds.add(event.event_id);
+      committedBytes += loadedCommit.bytes.length;
+      expectedSequence += 1;
+      expectedPrevious = event.integrity.event_hash;
+
+      const identityDirectoryName = repositoryLocalReferencePathDigest(event.event_id);
+      const identityDirectory = identityDirectories.get(identityDirectoryName);
+      if (identityDirectory === undefined) corruption();
+      consumedIdentityDirectories.add(identityDirectoryName);
+      const expectedIdentity = createRepositoryLocalPrimaryIdentityRecord(loadedCommit.record);
+      identityBytes +=
+        identityDirectory.final?.bytes.length ??
+        canonicalRepositoryLocalBytes(expectedIdentity).length;
+      if (
+        (identityDirectory.final !== undefined &&
+          !primaryIdentityMatchesCommit(identityDirectory.final.record, loadedCommit.record)) ||
+        (identityDirectory.temporaries[0] !== undefined &&
+          identityDirectory.temporaries[0] !==
+            temporaryName(
+              repositoryLocalIdentityVersionFileName(0),
+              expectedIdentity.primary_identity_record_digest,
+            ))
+      ) {
+        corruption();
+      }
+    }
+    if (
+      !Number.isSafeInteger(committedBytes) ||
+      !Number.isSafeInteger(identityBytes) ||
+      streams.length > REPOSITORY_LOCAL_LIMITS.max_streams ||
+      eventIds.size > REPOSITORY_LOCAL_LIMITS.max_event_identities ||
+      committedBytes > REPOSITORY_LOCAL_LIMITS.max_primary_committed_bytes ||
+      identityBytes > REPOSITORY_LOCAL_LIMITS.max_event_identity_bytes
+    ) {
+      state.fail("capacity_exhausted");
+      throw unavailable();
+    }
+  }
+  for (const [directoryName, directory] of identityDirectories) {
+    if (
+      !consumedIdentityDirectories.has(directoryName) &&
+      (directory.final !== undefined || directory.temporaries.length !== 0)
+    ) {
+      corruption();
+    }
+  }
+}
+
+async function cleanupPrimaryIdentityTemporaries(
+  streams: readonly LoadedStream[],
+  identityDirectories: ReadonlyMap<string, PrimaryIdentityDirectory>,
+  expectedDevice: number,
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+): Promise<void> {
+  for (const stream of streams) {
+    const firstCommit = stream.commits[0];
+    if (firstCommit !== undefined) {
+      await syncRepositoryLocalDirectory(firstCommit.directoryPath, hooks, "primary_record");
+    }
+    for (const loadedCommit of stream.commits) {
+      const identityDirectory = identityDirectories.get(
+        repositoryLocalReferencePathDigest(loadedCommit.record.event.event_id),
+      );
+      if (identityDirectory === undefined) corruption();
+      const temporary = identityDirectory.temporaries[0];
+      if (temporary === undefined) continue;
+      const expectedIdentity = createRepositoryLocalPrimaryIdentityRecord(loadedCommit.record);
+      await cleanupBoundTemporary(
+        identityDirectory.directoryPath,
+        temporary,
+        repositoryLocalIdentityVersionFileName(0),
+        expectedIdentity.primary_identity_record_digest,
+        REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes,
+        expectedDevice,
+        hooks,
+        identityDirectory.final !== undefined,
+      );
+    }
+  }
+}
+
+async function resolvePrimaryState(
+  streams: readonly LoadedStream[],
+  identityDirectories: ReadonlyMap<string, PrimaryIdentityDirectory>,
+  expectedDevice: number,
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+  state: RepositoryLocalState,
+): Promise<void> {
+  const consumedIdentityDirectories = new Set<string>();
+  for (const stream of streams) {
+    for (const loadedCommit of stream.commits) {
+      const event = loadedCommit.record.event;
+      if (
+        event.integrity.stream_ref !== stream.state.metadata.stream_ref ||
+        event.integrity.writer_ref !== stream.state.metadata.writer_ref
+      ) {
+        corruption();
+      }
+      const identityDirectoryName = repositoryLocalReferencePathDigest(event.event_id);
+      const identityDirectory = identityDirectories.get(identityDirectoryName);
+      if (identityDirectory === undefined) corruption();
+      consumedIdentityDirectories.add(identityDirectoryName);
+      const expectedIdentity = createRepositoryLocalPrimaryIdentityRecord(loadedCommit.record);
+      const finalName = repositoryLocalIdentityVersionFileName(0);
+      if (
+        identityDirectory.final !== undefined &&
+        !primaryIdentityMatchesCommit(identityDirectory.final.record, loadedCommit.record)
+      ) {
+        corruption();
+      }
+      if (identityDirectory.final === undefined) {
+        const bytes = canonicalRepositoryLocalBytes(expectedIdentity);
+        await publishRepositoryLocalFile(
+          identityDirectory.directoryPath,
+          finalName,
+          temporaryName(finalName, expectedIdentity.primary_identity_record_digest),
+          bytes,
+          REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes,
+          expectedDevice,
+          "primary_identity",
+          hooks,
+        );
+      }
+      await syncRepositoryLocalDirectory(
+        identityDirectory.directoryPath,
+        hooks,
+        "primary_identity",
+      );
+      const pair = await rereadPrimaryPair(
+        loadedCommit,
+        path.join(identityDirectory.directoryPath, finalName),
+        expectedDevice,
+        hooks,
+      );
+      state.registerPrimary(stream.state, {
+        commit: pair.commit.record,
+        identity: pair.identity.record,
+        commitBytes: pair.commit.bytes.length,
+        identityBytes: pair.identity.bytes.length,
+      });
+    }
+  }
+
+  for (const [directoryName, directory] of identityDirectories) {
+    if (consumedIdentityDirectories.has(directoryName)) continue;
+    if (directory.final !== undefined) {
+      state.registerOrphanPrimaryIdentity(directory.final.record, directory.final.bytes.length);
+      state.fail("state_stale");
+      corruption();
+    }
+    if (directory.temporaries.length !== 0) {
+      state.fail("state_stale");
+      corruption();
+    }
+  }
+}
+
+async function scanAndRegisterCheckpoints(
+  paths: RepositoryLocalPaths,
+  expectedDevice: number,
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+  state: RepositoryLocalState,
+): Promise<void> {
+  const names = await listRepositoryLocalDirectory(
+    paths.checkpoints,
+    expectedDevice,
+    PRIMARY_ENTRY_LIMIT,
+    hooks,
+  );
+  const records = new Map<string, LoadedRecord<RepositoryLocalCheckpointRecord>>();
+  const temporaries = names.filter((name) => name.endsWith(".tmp"));
+  const temporaryDestinations = new Set<string>();
+  for (const temporary of temporaries) {
+    const binding = parseTemporaryName(temporary);
+    if (
+      binding === undefined ||
+      !CHECKPOINT_FILE_PATTERN.test(binding.destinationName) ||
+      temporaryDestinations.has(binding.destinationName)
+    ) {
+      corruption();
+    }
+    temporaryDestinations.add(binding.destinationName);
+  }
+  for (const name of names.filter((entry) => !entry.endsWith(".tmp"))) {
+    if (!CHECKPOINT_FILE_PATTERN.test(name)) corruption();
+    const loaded = await readValidatedRecord(
+      path.join(paths.checkpoints, name),
+      REPOSITORY_LOCAL_LIMITS.max_checkpoint_record_bytes,
+      expectedDevice,
+      hooks,
+      validateRepositoryLocalCheckpointRecord,
+      temporaryDestinations.has(name) ? 2 : 1,
+    );
+    if (repositoryLocalCheckpointFileName(loaded.record.checkpoint_id) !== name) corruption();
+    records.set(name, loaded);
+  }
+  for (const temporary of temporaries) {
+    const binding = parseTemporaryName(temporary);
+    if (binding === undefined || !CHECKPOINT_FILE_PATTERN.test(binding.destinationName)) {
+      corruption();
+    }
+    const final = records.get(binding.destinationName);
+    await cleanupBoundTemporary(
+      paths.checkpoints,
+      temporary,
+      binding.destinationName,
+      final?.record.checkpoint_record_digest,
+      REPOSITORY_LOCAL_LIMITS.max_checkpoint_record_bytes,
+      expectedDevice,
+      hooks,
+      final !== undefined,
+    );
+  }
+  if (records.size !== 0) {
+    await syncRepositoryLocalDirectory(paths.checkpoints, hooks, "checkpoint");
+  }
+  const ordered = [...records.values()].sort((left, right) => {
+    if (left.record.stream_ref !== right.record.stream_ref) {
+      return left.record.stream_ref < right.record.stream_ref ? -1 : 1;
+    }
+    return left.record.range_start - right.record.range_start;
+  });
+  for (const checkpoint of ordered) {
+    const stream = state.streams.get(checkpoint.record.stream_ref);
+    if (stream === undefined) corruption();
+    try {
+      state.registerCheckpoint(stream, checkpoint.record, checkpoint.bytes.length);
+    } catch {
+      corruption();
+    }
+  }
+}
+
+async function scanRecoveryPending(
+  paths: RepositoryLocalPaths,
+  expectedDevice: number,
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+): Promise<ReadonlyMap<string, LoadedRecord<RepositoryLocalRecoveryPendingRecord>>> {
+  const names = await listRepositoryLocalDirectory(
+    paths.pending,
+    expectedDevice,
+    RECOVERY_ENTRY_LIMIT,
+    hooks,
+  );
+  const records = new Map<string, LoadedRecord<RepositoryLocalRecoveryPendingRecord>>();
+  const temporaries = names.filter((name) => name.endsWith(".tmp"));
+  const temporaryDestinations = new Set<string>();
+  for (const temporary of temporaries) {
+    const binding = parseTemporaryName(temporary);
+    if (
+      binding === undefined ||
+      !CHECKPOINT_FILE_PATTERN.test(binding.destinationName) ||
+      temporaryDestinations.has(binding.destinationName)
+    ) {
+      corruption();
+    }
+    temporaryDestinations.add(binding.destinationName);
+  }
+  for (const name of names.filter((entry) => !entry.endsWith(".tmp"))) {
+    if (!CHECKPOINT_FILE_PATTERN.test(name)) corruption();
+    const loaded = await readValidatedRecord(
+      path.join(paths.pending, name),
+      REPOSITORY_LOCAL_LIMITS.max_recovery_record_bytes,
+      expectedDevice,
+      hooks,
+      validateRepositoryLocalRecoveryPendingRecord,
+      temporaryDestinations.has(name) ? 2 : 1,
+    );
+    if (`${repositoryLocalReferencePathDigest(loaded.record.fact.recovery_id)}.json` !== name) {
+      corruption();
+    }
+    records.set(name, loaded);
+  }
+  for (const temporary of temporaries) {
+    const binding = parseTemporaryName(temporary);
+    if (binding === undefined || !CHECKPOINT_FILE_PATTERN.test(binding.destinationName)) {
+      corruption();
+    }
+    const final = records.get(binding.destinationName);
+    await cleanupBoundTemporary(
+      paths.pending,
+      temporary,
+      binding.destinationName,
+      final?.record.recovery_pending_record_digest,
+      REPOSITORY_LOCAL_LIMITS.max_recovery_record_bytes,
+      expectedDevice,
+      hooks,
+      final !== undefined,
+    );
+  }
+  return records;
+}
+
+async function scanRecoveryIdentityDirectories(
+  paths: RepositoryLocalPaths,
+  expectedDevice: number,
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+): Promise<ReadonlyMap<string, RecoveryIdentityDirectory>> {
+  const result = new Map<string, RecoveryIdentityDirectory>();
+  const names = await listRepositoryLocalDirectory(
+    paths.recoveryIdentities,
+    expectedDevice,
+    RECOVERY_ENTRY_LIMIT,
+    hooks,
+  );
+  for (const name of names) {
+    if (!RAW_DIGEST_PATTERN.test(name)) corruption();
+    const directoryPath = path.join(paths.recoveryIdentities, name);
+    const entries = await listRepositoryLocalDirectory(
+      directoryPath,
+      expectedDevice,
+      IDENTITY_DIRECTORY_ENTRY_LIMIT,
+      hooks,
+    );
+    const finalName = repositoryLocalIdentityVersionFileName(0);
+    const temporaries = entries.filter((entry) => entry.endsWith(".tmp"));
+    if (
+      temporaries.length > 1 ||
+      entries.some((entry) => entry !== finalName && !temporaries.includes(entry))
+    ) {
+      corruption();
+    }
+    let final: LoadedRecord<RepositoryLocalRecoveryIdentityRecord> | undefined;
+    if (entries.includes(finalName)) {
+      final = await readValidatedRecord(
+        path.join(directoryPath, finalName),
+        REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes,
+        expectedDevice,
+        hooks,
+        validateRepositoryLocalRecoveryIdentityRecord,
+        temporaries.length === 1 ? 2 : 1,
+      );
+      if (repositoryLocalReferencePathDigest(final.record.recovery_id) !== name) corruption();
+    }
+    result.set(name, {
+      directoryPath,
+      pathDigest: name,
+      ...(final === undefined ? {} : { final }),
+      temporaries,
+    });
+  }
+  return result;
+}
+
+function prevalidateRecoveryState(
+  pending: ReadonlyMap<string, LoadedRecord<RepositoryLocalRecoveryPendingRecord>>,
+  identityDirectories: ReadonlyMap<string, RecoveryIdentityDirectory>,
+  state: RepositoryLocalState,
+): void {
+  const recoveryIds = new Set<string>();
+  const consumedIdentityDirectories = new Set<string>();
+  for (const loadedPending of pending.values()) {
+    const recoveryId = loadedPending.record.fact.recovery_id;
+    if (recoveryIds.has(recoveryId)) corruption();
+    recoveryIds.add(recoveryId);
+    const identityDirectoryName = repositoryLocalReferencePathDigest(recoveryId);
+    const identityDirectory = identityDirectories.get(identityDirectoryName);
+    if (identityDirectory === undefined) corruption();
+    consumedIdentityDirectories.add(identityDirectoryName);
+    const expectedIdentity = createRepositoryLocalRecoveryIdentityRecord(loadedPending.record);
+    if (
+      (identityDirectory.final !== undefined &&
+        !recoveryIdentityMatchesPending(identityDirectory.final.record, loadedPending.record)) ||
+      (identityDirectory.temporaries[0] !== undefined &&
+        identityDirectory.temporaries[0] !==
+          temporaryName(
+            repositoryLocalIdentityVersionFileName(0),
+            expectedIdentity.recovery_identity_record_digest,
+          ))
+    ) {
+      corruption();
+    }
+  }
+  for (const [directoryName, directory] of identityDirectories) {
+    if (
+      !consumedIdentityDirectories.has(directoryName) &&
+      (directory.final !== undefined || directory.temporaries.length !== 0)
+    ) {
+      corruption();
+    }
+  }
+  if (
+    recoveryIds.size > REPOSITORY_LOCAL_LIMITS.max_pending_recovery_facts ||
+    recoveryIds.size > REPOSITORY_LOCAL_LIMITS.max_recovery_identities ||
+    recoveryIds.size * REPOSITORY_LOCAL_LIMITS.recovery_identity_reservation_bytes >
+      REPOSITORY_LOCAL_LIMITS.max_recovery_bytes
+  ) {
+    state.fail("capacity_exhausted");
+    throw unavailable();
+  }
+}
+
+async function cleanupRecoveryIdentityTemporaries(
+  paths: RepositoryLocalPaths,
+  pending: ReadonlyMap<string, LoadedRecord<RepositoryLocalRecoveryPendingRecord>>,
+  identityDirectories: ReadonlyMap<string, RecoveryIdentityDirectory>,
+  expectedDevice: number,
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+): Promise<void> {
+  if (pending.size !== 0) {
+    await syncRepositoryLocalDirectory(paths.pending, hooks, "recovery_record");
+  }
+  for (const loadedPending of pending.values()) {
+    const identityDirectory = identityDirectories.get(
+      repositoryLocalReferencePathDigest(loadedPending.record.fact.recovery_id),
+    );
+    if (identityDirectory === undefined) corruption();
+    const temporary = identityDirectory.temporaries[0];
+    if (temporary === undefined) continue;
+    const expectedIdentity = createRepositoryLocalRecoveryIdentityRecord(loadedPending.record);
+    await cleanupBoundTemporary(
+      identityDirectory.directoryPath,
+      temporary,
+      repositoryLocalIdentityVersionFileName(0),
+      expectedIdentity.recovery_identity_record_digest,
+      REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes,
+      expectedDevice,
+      hooks,
+      identityDirectory.final !== undefined,
+    );
+  }
+}
+
+async function resolveRecoveryState(
+  paths: RepositoryLocalPaths,
+  pending: ReadonlyMap<string, LoadedRecord<RepositoryLocalRecoveryPendingRecord>>,
+  identityDirectories: ReadonlyMap<string, RecoveryIdentityDirectory>,
+  expectedDevice: number,
+  hooks: RepositoryLocalFilesystemHooks | undefined,
+  state: RepositoryLocalState,
+  now: string,
+): Promise<void> {
+  const consumed = new Set<string>();
+  for (const [pendingName, loadedPending] of pending) {
+    const recoveryId = loadedPending.record.fact.recovery_id;
+    const identityDirectoryName = repositoryLocalReferencePathDigest(recoveryId);
+    const identityDirectory = identityDirectories.get(identityDirectoryName);
+    if (identityDirectory === undefined) corruption();
+    consumed.add(identityDirectoryName);
+    const expectedIdentity = createRepositoryLocalRecoveryIdentityRecord(loadedPending.record);
+    const finalName = repositoryLocalIdentityVersionFileName(0);
+    if (
+      identityDirectory.final !== undefined &&
+      !recoveryIdentityMatchesPending(identityDirectory.final.record, loadedPending.record)
+    ) {
+      corruption();
+    }
+    if (identityDirectory.final === undefined) {
+      const bytes = canonicalRepositoryLocalBytes(expectedIdentity);
+      await publishRepositoryLocalFile(
+        identityDirectory.directoryPath,
+        finalName,
+        temporaryName(finalName, expectedIdentity.recovery_identity_record_digest),
+        bytes,
+        REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes,
+        expectedDevice,
+        "recovery_identity",
+        hooks,
+      );
+    }
+    await syncRepositoryLocalDirectory(identityDirectory.directoryPath, hooks, "recovery_identity");
+    const reloadedPending = await readValidatedRecord(
+      path.join(paths.pending, pendingName),
+      REPOSITORY_LOCAL_LIMITS.max_recovery_record_bytes,
+      expectedDevice,
+      hooks,
+      validateRepositoryLocalRecoveryPendingRecord,
+    );
+    const reloadedIdentity = await readValidatedRecord(
+      path.join(identityDirectory.directoryPath, finalName),
+      REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes,
+      expectedDevice,
+      hooks,
+      validateRepositoryLocalRecoveryIdentityRecord,
+    );
+    if (
+      !reloadedPending.bytes.equals(loadedPending.bytes) ||
+      !recoveryIdentityMatchesPending(reloadedIdentity.record, reloadedPending.record)
+    ) {
+      corruption();
+    }
+    state.registerRecovery({
+      pending: reloadedPending.record,
+      identity: reloadedIdentity.record,
+      pendingBytes: reloadedPending.bytes.length,
+      identityBytes: reloadedIdentity.bytes.length,
+    });
+    const observedAt = reloadedPending.record.fact.original_observed_at;
+    const age = Date.parse(now) - Date.parse(observedAt);
+    if (
+      !Number.isFinite(age) ||
+      compareAuditTimestamps(now, observedAt) < 0 ||
+      age > REPOSITORY_LOCAL_LIMITS.pending_max_age_milliseconds
+    ) {
+      state.fail(
+        age > REPOSITORY_LOCAL_LIMITS.pending_max_age_milliseconds
+          ? "pending_expired"
+          : "state_stale",
+      );
+      corruption();
+    }
+  }
+  for (const [directoryName, directory] of identityDirectories) {
+    if (consumed.has(directoryName)) continue;
+    if (directory.final !== undefined) {
+      state.registerOrphanRecoveryIdentity(directory.final.record);
+      state.fail("state_stale");
+      corruption();
+    }
+    if (directory.temporaries.length !== 0) {
+      state.fail("state_stale");
+      corruption();
+    }
+  }
+}
+
+function mapFilesystemReason(
+  state: RepositoryLocalState,
+  error: RepositoryLocalFilesystemError,
+): void {
+  if (error.reason === "capacity_exhausted") {
+    state.fail("capacity_exhausted");
+    return;
+  }
+  if (error.ambiguous) {
+    state.fail("io_ambiguous");
+    return;
+  }
+  switch (error.reason) {
+    case "unsupported_filesystem":
+      state.fail("filesystem_unsupported");
+      return;
+    case "unsafe_metadata":
+      state.fail("unsafe_metadata");
+      return;
+    case "corruption_detected":
+    case "publication_conflict":
+      state.fail("state_corrupt");
+      return;
+    case "io_failure":
+    case "lock_unavailable":
+      state.fail("io_failure");
+      return;
+  }
+}
+
+class RepositoryLocalProfileCore {
+  readonly store: AuditStore;
+  readonly journal: RecoveryJournal;
+  private queue: Promise<void> = Promise.resolve();
+  private closed = false;
+
+  constructor(
+    private readonly paths: RepositoryLocalPaths,
+    private readonly expectedDevice: number,
+    private readonly profile: RepositoryLocalProfileRecord,
+    private readonly lock: RepositoryLocalOwnedLock,
+    private readonly state: RepositoryLocalState,
+    private readonly clock: RepositoryLocalClock,
+    private readonly hooks: RepositoryLocalFilesystemHooks | undefined,
+  ) {
+    this.store = Object.freeze({
+      findById: (eventId: string) => this.findById(eventId),
+      tail: (streamRef: string) => this.tail(streamRef),
+      append: (event: ProtectedAuditEvent, candidateDigest: string) =>
+        this.appendPrimary(event, candidateDigest),
+    });
+    this.journal = Object.freeze({
+      append: (fact: RecoveryFact) => this.appendRecovery(fact),
+    });
+  }
+
+  pendingFacts(): AsyncIterable<RecoveryFact> {
+    const profile = this;
+    return {
+      async *[Symbol.asyncIterator](): AsyncGenerator<RecoveryFact> {
+        const pass = await profile.materializePendingFacts();
+        for (const fact of pass.facts) {
+          profile.assertPendingPassActive(pass.started);
+          yield fact;
+          profile.assertPendingPassActive(pass.started);
+        }
+      },
+    };
+  }
+
+  diagnostic(): RepositoryLocalHealthDiagnostic {
+    try {
+      this.assertPendingBacklogFresh();
+    } catch (error: unknown) {
+      this.translate(error);
+    }
+    return freezeDeep(structuredClone(this.state.diagnostic()));
+  }
+
+  async completeRequiredStartupCheckpoints(): Promise<void> {
+    for (const stream of this.state.streams.values()) {
+      if (this.state.uncheckpointedCount(stream) === REPOSITORY_LOCAL_LIMITS.checkpoint_interval) {
+        await this.publishCheckpoint(stream);
+      }
+    }
+  }
+
+  close(): Promise<void> {
+    const operation = this.queue.then(async () => {
+      if (this.closed) return;
+      this.state.setPhase("closing");
+      try {
+        await verifyRepositoryLocalWriterLock(this.paths, this.lock, this.hooks);
+        try {
+          this.assertPendingBacklogFresh();
+        } catch (error: unknown) {
+          this.translate(error);
+        }
+        if (!this.state.isFailed()) {
+          for (const stream of this.state.streams.values()) {
+            try {
+              this.assertPendingBacklogFresh();
+            } catch (error: unknown) {
+              this.translate(error);
+              break;
+            }
+            if (this.state.uncheckpointedCount(stream) > 0) {
+              await this.publishCheckpoint(stream);
+            }
+          }
+        }
+        await releaseRepositoryLocalWriterLock(this.paths, this.lock, this.hooks);
+        this.closed = true;
+        this.state.setPhase("closed");
+      } catch (error: unknown) {
+        throw this.translate(error);
+      }
+    });
+    this.queue = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    return operation;
+  }
+
+  private run<T>(
+    phase: "pending_read" | "primary_append" | "recovery_append",
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const result = this.queue.then(async () => {
+      if (this.closed) throw unavailable();
+      this.state.setPhase(phase);
+      try {
+        await verifyRepositoryLocalWriterLock(this.paths, this.lock, this.hooks);
+        this.assertPendingBacklogFresh();
+        return await operation();
+      } catch (error: unknown) {
+        throw this.translate(error);
+      } finally {
+        if (!this.closed && !this.state.isFailed()) this.state.setPhase("ready");
+      }
+    });
+    this.queue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
+  private translate(error: unknown): AuditError {
+    if (error instanceof RepositoryLocalFilesystemError) {
+      mapFilesystemReason(this.state, error);
+      return unavailable();
+    }
+
+    if (error instanceof RepositoryLocalFormatError) {
+      this.state.fail("state_corrupt");
+      return new AuditError("audit_integrity_failure");
+    }
+    if (error instanceof AuditError) {
+      if (error.code === "audit_duplicate_conflict") {
+        this.state.fail("duplicate_conflict");
+      } else if (error.code === "audit_integrity_failure") {
+        this.state.fail("state_corrupt");
+      } else if (error.code === "audit_unavailable" && !this.state.isFailed()) {
+        this.state.fail("io_failure");
+      }
+      return error;
+    }
+    this.state.fail("io_failure");
+    return unavailable();
+  }
+
+  private assertObservationFresh(observedAt: string, now: string): void {
+    const age = Date.parse(now) - Date.parse(observedAt);
+    if (!Number.isFinite(age) || compareAuditTimestamps(now, observedAt) < 0) {
+      this.state.fail("state_stale");
+      throw unavailable();
+    }
+    if (age > REPOSITORY_LOCAL_LIMITS.pending_max_age_milliseconds) {
+      this.state.fail("pending_expired");
+      throw unavailable();
+    }
+  }
+
+  private assertPendingBacklogFresh(): void {
+    if (this.state.recoveriesById.size === 0) return;
+    const now = this.clock.nowIso();
+    for (const entry of this.state.recoveriesById.values()) {
+      this.assertObservationFresh(entry.pending.fact.original_observed_at, now);
+    }
+  }
+
+  private assertPendingPassActive(started: number): void {
+    if (this.closed) throw unavailable();
+    try {
+      this.assertPendingBacklogFresh();
+    } catch (error: unknown) {
+      throw this.translate(error);
+    }
+    this.state.assertReadable();
+    if (
+      this.clock.monotonic() - started >
+      REPOSITORY_LOCAL_LIMITS.pending_iterator_max_milliseconds
+    ) {
+      this.state.setPhase("pending_read");
+      this.state.fail("pending_read_bound");
+      throw unavailable();
+    }
+  }
+
+  private findById(eventId: string) {
+    return this.run("pending_read", async () => {
+      if (!isRepositoryLocalReference(eventId)) {
+        throw new AuditError("audit_candidate_invalid");
+      }
+      this.state.assertReadable();
+      const found = this.state.findPrimary(eventId);
+      return found === undefined
+        ? undefined
+        : {
+            event: found.commit.event,
+            candidate_digest: found.commit.candidate_digest,
+            durability: "durable" as const,
+          };
+    });
+  }
+
+  private tail(streamRef: string) {
+    return this.run("pending_read", async () => {
+      if (!isRepositoryLocalReference(streamRef)) {
+        throw new AuditError("audit_candidate_invalid");
+      }
+      this.state.assertReadable();
+      return this.state.tail(streamRef);
+    });
+  }
+
+  private appendPrimary(
+    event: ProtectedAuditEvent,
+    candidateDigest: string,
+  ): Promise<AuditCommitReceipt> {
+    return this.run("primary_append", async () => {
+      const commit = freezeDeep(createRepositoryLocalPrimaryCommitRecord(event, candidateDigest));
+      const existing = this.state.findPrimary(commit.event.event_id);
+      if (existing !== undefined) {
+        if (existing.commit.candidate_digest !== commit.candidate_digest) {
+          throw new AuditError("audit_duplicate_conflict");
+        }
+        if (this.state.isFailed() && !this.state.allowsCapacityDuplicate()) {
+          throw unavailable();
+        }
+        return receiptFromPrimaryCommit(existing.commit, true);
+      }
+      if (this.state.hasRetainedPrimaryIdentity(commit.event.event_id)) {
+        throw new AuditError("audit_duplicate_conflict");
+      }
+      this.state.assertWritable();
+      if (commit.event.integrity.writer_ref !== this.profile.writer_ref) {
+        throw new AuditError("audit_integrity_failure");
+      }
+      const streamRef = commit.event.integrity.stream_ref;
+      let stream = this.state.streams.get(streamRef);
+      const createsStream = stream === undefined;
+      const streamRecord =
+        stream === undefined
+          ? createRepositoryLocalStreamRecord(
+              streamRef,
+              this.profile.writer_ref,
+              commit.event.committed_at,
+            )
+          : stream.metadata;
+      const streamBytes = canonicalRepositoryLocalBytes(streamRecord);
+      const commitBytes = canonicalRepositoryLocalBytes(commit);
+      const identity = freezeDeep(createRepositoryLocalPrimaryIdentityRecord(commit));
+      const identityBytes = canonicalRepositoryLocalBytes(identity);
+      const tail = stream?.commits.at(-1)?.commit.event;
+      const expectedSequence = tail === undefined ? 0 : tail.integrity.sequence + 1;
+      const expectedPrevious = tail?.integrity.event_hash ?? AUDIT_GENESIS_HASH;
+      const genesisHash =
+        commit.event.event_type === "audit.stream_opened.v1"
+          ? (commit.event.payload.value as Readonly<{ genesis_hash?: unknown }>).genesis_hash
+          : undefined;
+      if (
+        commit.event.integrity.sequence !== expectedSequence ||
+        commit.event.integrity.previous_event_hash !== expectedPrevious ||
+        (expectedSequence === 0 &&
+          (commit.event.event_type !== "audit.stream_opened.v1" ||
+            genesisHash !== AUDIT_GENESIS_HASH)) ||
+        (expectedSequence !== 0 && commit.event.event_type === "audit.stream_opened.v1")
+      ) {
+        throw new AuditError("audit_integrity_failure");
+      }
+      const preparedCheckpoint =
+        stream !== undefined &&
+        this.state.uncheckpointedCount(stream) + 1 === REPOSITORY_LOCAL_LIMITS.checkpoint_interval
+          ? this.prepareCheckpoint(stream, commit.event)
+          : undefined;
+      const availableBytes = await repositoryLocalAvailableBytes(
+        this.paths.runtimeRoot,
+        this.hooks,
+      );
+      this.state.assertCanAppendPrimary(
+        commitBytes.length,
+        identityBytes.length,
+        createsStream,
+        streamBytes.length,
+        preparedCheckpoint?.bytes.length ?? 0,
+        availableBytes,
+      );
+
+      const streamDirectoryPath = path.join(
+        this.paths.streams,
+        repositoryLocalReferencePathDigest(streamRef),
+      );
+      await ensureDurableRepositoryLocalDirectory(
+        streamDirectoryPath,
+        this.paths.streams,
+        this.expectedDevice,
+        this.hooks,
+      );
+      const commitsDirectoryPath = path.join(streamDirectoryPath, "commits");
+      await ensureDurableRepositoryLocalDirectory(
+        commitsDirectoryPath,
+        streamDirectoryPath,
+        this.expectedDevice,
+        this.hooks,
+      );
+      const identityDirectoryPath = path.join(
+        this.paths.primaryIdentities,
+        repositoryLocalReferencePathDigest(commit.event.event_id),
+      );
+      await ensureDurableRepositoryLocalDirectory(
+        identityDirectoryPath,
+        this.paths.primaryIdentities,
+        this.expectedDevice,
+        this.hooks,
+      );
+      if (createsStream) {
+        await publishRepositoryLocalFile(
+          streamDirectoryPath,
+          "stream.json",
+          temporaryName("stream.json", streamRecord.stream_record_digest),
+          streamBytes,
+          REPOSITORY_LOCAL_LIMITS.max_checkpoint_record_bytes,
+          this.expectedDevice,
+          "stream",
+          this.hooks,
+        );
+        await syncRepositoryLocalDirectory(streamDirectoryPath, this.hooks, "stream");
+        this.state.registerStream(streamRecord, streamBytes.length);
+        stream = this.state.streams.get(streamRef);
+        if (stream === undefined) corruption();
+      }
+      if (stream === undefined) corruption();
+      const sequenceName = repositoryLocalSequenceFileName(commit.event.integrity.sequence);
+      await publishRepositoryLocalFile(
+        commitsDirectoryPath,
+        sequenceName,
+        temporaryName(sequenceName, commit.primary_commit_record_digest),
+        commitBytes,
+        REPOSITORY_LOCAL_LIMITS.max_primary_commit_record_bytes,
+        this.expectedDevice,
+        "primary_record",
+        this.hooks,
+      );
+      await syncRepositoryLocalDirectory(commitsDirectoryPath, this.hooks, "primary_record");
+      const identityName = repositoryLocalIdentityVersionFileName(0);
+      await publishRepositoryLocalFile(
+        identityDirectoryPath,
+        identityName,
+        temporaryName(identityName, identity.primary_identity_record_digest),
+        identityBytes,
+        REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes,
+        this.expectedDevice,
+        "primary_identity",
+        this.hooks,
+      );
+      await syncRepositoryLocalDirectory(identityDirectoryPath, this.hooks, "primary_identity");
+      const entry: RepositoryLocalPrimaryEntry = {
+        commit,
+        identity,
+        commitBytes: commitBytes.length,
+        identityBytes: identityBytes.length,
+      };
+      this.state.registerPrimary(stream, entry);
+      this.state.updateCapacityHealth();
+      if (preparedCheckpoint !== undefined) {
+        await this.publishCheckpoint(stream, preparedCheckpoint);
+      }
+      return receiptFromPrimaryCommit(commit, false);
+    });
+  }
+
+  private appendRecovery(factValue: RecoveryFact): Promise<Readonly<{ durability: "durable" }>> {
+    return this.run("recovery_append", async () => {
+      const fact = validateRecoveryFactShape(factValue);
+      const factDigest = computeRecoveryFactDigest(fact);
+      const existing = this.state.findRecovery(fact.recovery_id);
+      if (existing !== undefined) {
+        if (existing.pending.fact_digest !== factDigest) {
+          throw new AuditError("audit_duplicate_conflict");
+        }
+        if (this.state.isFailed() && !this.state.allowsCapacityDuplicate()) {
+          throw unavailable();
+        }
+        return { durability: "durable" as const };
+      }
+      if (this.state.hasRetainedRecoveryIdentity(fact.recovery_id)) {
+        throw new AuditError("audit_duplicate_conflict");
+      }
+      this.state.assertWritable();
+      const appendedAt = this.clock.nowIso();
+      this.assertObservationFresh(fact.original_observed_at, appendedAt);
+      const pending = freezeDeep(createRepositoryLocalRecoveryPendingRecord(fact, appendedAt));
+      const availableBytes = await repositoryLocalAvailableBytes(
+        this.paths.runtimeRoot,
+        this.hooks,
+      );
+      this.state.assertCanAppendRecovery(availableBytes);
+      const pendingBytes = canonicalRepositoryLocalBytes(pending);
+      const identity = freezeDeep(createRepositoryLocalRecoveryIdentityRecord(pending));
+      const identityBytes = canonicalRepositoryLocalBytes(identity);
+      const pathDigest = repositoryLocalReferencePathDigest(fact.recovery_id);
+      const identityDirectoryPath = path.join(this.paths.recoveryIdentities, pathDigest);
+      await ensureDurableRepositoryLocalDirectory(
+        identityDirectoryPath,
+        this.paths.recoveryIdentities,
+        this.expectedDevice,
+        this.hooks,
+      );
+      const pendingName = `${pathDigest}.json`;
+      await publishRepositoryLocalFile(
+        this.paths.pending,
+        pendingName,
+        temporaryName(pendingName, pending.recovery_pending_record_digest),
+        pendingBytes,
+        REPOSITORY_LOCAL_LIMITS.max_recovery_record_bytes,
+        this.expectedDevice,
+        "recovery_record",
+        this.hooks,
+      );
+      await syncRepositoryLocalDirectory(this.paths.pending, this.hooks, "recovery_record");
+      const identityName = repositoryLocalIdentityVersionFileName(0);
+      await publishRepositoryLocalFile(
+        identityDirectoryPath,
+        identityName,
+        temporaryName(identityName, identity.recovery_identity_record_digest),
+        identityBytes,
+        REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes,
+        this.expectedDevice,
+        "recovery_identity",
+        this.hooks,
+      );
+      await syncRepositoryLocalDirectory(identityDirectoryPath, this.hooks, "recovery_identity");
+      const entry: RepositoryLocalRecoveryEntry = {
+        pending,
+        identity,
+        pendingBytes: pendingBytes.length,
+        identityBytes: identityBytes.length,
+      };
+      this.state.registerRecovery(entry);
+      this.state.updateCapacityHealth();
+      return { durability: "durable" as const };
+    });
+  }
+
+  private materializePendingFacts(): Promise<PendingFactPass> {
+    return this.run("pending_read", async () => {
+      this.state.assertReadable();
+      const started = this.clock.monotonic();
+      let totalBytes = 0;
+      const result: RecoveryFact[] = [];
+      for (const entry of this.state.pendingSnapshot()) {
+        if (
+          result.length >= REPOSITORY_LOCAL_LIMITS.max_pending_recovery_facts ||
+          this.clock.monotonic() - started >
+            REPOSITORY_LOCAL_LIMITS.pending_iterator_max_milliseconds
+        ) {
+          this.state.fail("pending_read_bound");
+          throw unavailable();
+        }
+        const digest = repositoryLocalReferencePathDigest(entry.pending.fact.recovery_id);
+        const loadedPending = await readValidatedRecord(
+          path.join(this.paths.pending, `${digest}.json`),
+          REPOSITORY_LOCAL_LIMITS.max_recovery_record_bytes,
+          this.expectedDevice,
+          this.hooks,
+          validateRepositoryLocalRecoveryPendingRecord,
+        );
+        const loadedIdentity = await readValidatedRecord(
+          path.join(
+            this.paths.recoveryIdentities,
+            digest,
+            repositoryLocalIdentityVersionFileName(0),
+          ),
+          REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes,
+          this.expectedDevice,
+          this.hooks,
+          validateRepositoryLocalRecoveryIdentityRecord,
+        );
+        totalBytes += loadedPending.bytes.length;
+        if (
+          !Number.isSafeInteger(totalBytes) ||
+          totalBytes > REPOSITORY_LOCAL_LIMITS.pending_iterator_max_input_bytes ||
+          !recoveryIdentityMatchesPending(loadedIdentity.record, loadedPending.record) ||
+          loadedPending.record.fact_digest !== entry.pending.fact_digest ||
+          this.clock.monotonic() - started >
+            REPOSITORY_LOCAL_LIMITS.pending_iterator_max_milliseconds
+        ) {
+          this.state.fail("pending_read_bound");
+          throw unavailable();
+        }
+        result.push(freezeDeep(structuredClone(loadedPending.record.fact)));
+      }
+      return { facts: result, started };
+    });
+  }
+
+  private prepareCheckpoint(
+    stream: RepositoryLocalStreamState,
+    terminal: ProtectedAuditEvent,
+  ): PreparedCheckpoint {
+    const rangeStart = stream.checkpoints.at(-1)?.range_end ?? -1;
+    const first = rangeStart + 1;
+    if (
+      terminal.integrity.stream_ref !== stream.metadata.stream_ref ||
+      first > terminal.integrity.sequence
+    ) {
+      throw new AuditError("audit_integrity_failure");
+    }
+    const checkpoint = freezeDeep(
+      createRepositoryLocalCheckpointRecord({
+        stream_ref: stream.metadata.stream_ref,
+        range_start: first,
+        range_end: terminal.integrity.sequence,
+        terminal_event_hash: terminal.integrity.event_hash,
+        previous_checkpoint_ref: stream.checkpoints.at(-1)?.checkpoint_id ?? null,
+        writer_ref: this.profile.writer_ref,
+        created_at: this.clock.nowIso(),
+      }),
+    );
+    return { record: checkpoint, bytes: canonicalRepositoryLocalBytes(checkpoint) };
+  }
+
+  private async publishCheckpoint(
+    stream: RepositoryLocalStreamState,
+    reserved?: PreparedCheckpoint,
+  ): Promise<void> {
+    const terminal = stream.commits.at(-1)?.commit.event;
+    if (terminal === undefined) return;
+    const prepared = reserved ?? this.prepareCheckpoint(stream, terminal);
+    if (reserved === undefined) {
+      if (
+        this.state.usage.checkpointMetadataBytes + prepared.bytes.length >
+        REPOSITORY_LOCAL_LIMITS.max_checkpoint_deletion_metadata_bytes
+      ) {
+        this.state.fail("capacity_exhausted");
+        throw unavailable();
+      }
+      const available = await repositoryLocalAvailableBytes(this.paths.runtimeRoot, this.hooks);
+      if (available < BigInt(2 * REPOSITORY_LOCAL_LIMITS.max_checkpoint_record_bytes)) {
+        this.state.fail("capacity_exhausted");
+        throw unavailable();
+      }
+    }
+    const name = repositoryLocalCheckpointFileName(prepared.record.checkpoint_id);
+    await publishRepositoryLocalFile(
+      this.paths.checkpoints,
+      name,
+      temporaryName(name, prepared.record.checkpoint_record_digest),
+      prepared.bytes,
+      REPOSITORY_LOCAL_LIMITS.max_checkpoint_record_bytes,
+      this.expectedDevice,
+      "checkpoint",
+      this.hooks,
+    );
+    await syncRepositoryLocalDirectory(this.paths.checkpoints, this.hooks, "checkpoint");
+    this.state.registerCheckpoint(stream, prepared.record, prepared.bytes.length);
+    this.state.updateCapacityHealth();
+  }
+}
+
+async function openRepositoryLocalAuditProfileInternal(
+  options: RepositoryLocalQualificationOptions,
+): Promise<RepositoryLocalAuditProfile> {
+  if (!isRepositoryLocalReference(options.writerRef)) {
+    throw new AuditError("audit_candidate_invalid");
+  }
+  const clock = createClock(options);
+  const state = new RepositoryLocalState();
+  let paths: RepositoryLocalPaths | undefined;
+  let lock: RepositoryLocalOwnedLock | undefined;
+  try {
+    paths = await resolveTrustedRepositoryLocalPaths(
+      options.trustedRepositoryRoot,
+      options.filesystemHooks,
+    );
+    const expectedDevice = await ensureRepositoryLocalRuntimeRoot(paths, options.filesystemHooks);
+    const openedAt = clock.nowIso();
+    lock = await acquireRepositoryLocalWriterLock(
+      paths,
+      options.writerRef,
+      openedAt,
+      expectedDevice,
+      options.filesystemHooks,
+    );
+    await qualifyRepositoryLocalFilesystem(paths, expectedDevice, options.filesystemHooks);
+    if (!(await fileExistsWithoutFollowing(paths.profile))) {
+      await ensureRepositoryLocalTopology(paths, expectedDevice, options.filesystemHooks);
+    }
+    await assertBoundedStartupTemporaryState(paths, expectedDevice, options.filesystemHooks);
+    const profile = await loadOrCreateProfile(
+      paths,
+      options.writerRef,
+      openedAt,
+      expectedDevice,
+      options.filesystemHooks,
+    );
+    await assertClosedStaticTopology(paths, expectedDevice, options.filesystemHooks);
+    await verifyRepositoryLocalWriterLock(paths, lock, options.filesystemHooks);
+
+    const streams = await scanStreams(
+      paths,
+      expectedDevice,
+      options.filesystemHooks,
+      profile.writer_ref,
+      state,
+    );
+    const primaryIdentityDirectories = await scanPrimaryIdentityDirectories(
+      paths,
+      expectedDevice,
+      options.filesystemHooks,
+      profile.writer_ref,
+    );
+    prevalidatePrimaryState(streams, primaryIdentityDirectories, state);
+    await cleanupPrimaryIdentityTemporaries(
+      streams,
+      primaryIdentityDirectories,
+      expectedDevice,
+      options.filesystemHooks,
+    );
+    await resolvePrimaryState(
+      streams,
+      primaryIdentityDirectories,
+      expectedDevice,
+      options.filesystemHooks,
+      state,
+    );
+    await scanAndRegisterCheckpoints(paths, expectedDevice, options.filesystemHooks, state);
+    for (const stream of state.streams.values()) {
+      const uncheckpointed = state.uncheckpointedCount(stream);
+      if (uncheckpointed > REPOSITORY_LOCAL_LIMITS.checkpoint_interval) {
+        state.fail("checkpoint_invalid");
+        corruption();
+      }
+    }
+
+    const pending = await scanRecoveryPending(paths, expectedDevice, options.filesystemHooks);
+    const recoveryIdentityDirectories = await scanRecoveryIdentityDirectories(
+      paths,
+      expectedDevice,
+      options.filesystemHooks,
+    );
+    prevalidateRecoveryState(pending, recoveryIdentityDirectories, state);
+    await cleanupRecoveryIdentityTemporaries(
+      paths,
+      pending,
+      recoveryIdentityDirectories,
+      expectedDevice,
+      options.filesystemHooks,
+    );
+    await resolveRecoveryState(
+      paths,
+      pending,
+      recoveryIdentityDirectories,
+      expectedDevice,
+      options.filesystemHooks,
+      state,
+      clock.nowIso(),
+    );
+    state.assertStartupBounds();
+    state.updateCapacityHealth();
+    const core = new RepositoryLocalProfileCore(
+      paths,
+      expectedDevice,
+      profile,
+      lock,
+      state,
+      clock,
+      options.filesystemHooks,
+    );
+    await core.completeRequiredStartupCheckpoints();
+    const availableBytes = await repositoryLocalAvailableBytes(
+      paths.runtimeRoot,
+      options.filesystemHooks,
+    );
+    if (availableBytes < state.requiredFreeBytesForNextWrite()) {
+      state.fail("capacity_exhausted");
+    }
+    state.setPhase("ready");
+    return Object.freeze({
+      store: core.store,
+      journal: core.journal,
+      pendingFacts: () => core.pendingFacts(),
+      diagnostic: () => core.diagnostic(),
+      close: () => core.close(),
+    });
+  } catch (error: unknown) {
+    if (lock !== undefined && paths !== undefined && !lock.released) {
+      if (error instanceof RepositoryLocalFilesystemError && error.ambiguous) {
+        try {
+          await lock.handle.close();
+        } catch {
+          // The persistent lock remains the fail-closed recovery boundary.
+        }
+      } else {
+        try {
+          await releaseRepositoryLocalWriterLock(paths, lock, options.filesystemHooks);
+        } catch {
+          try {
+            await lock.handle.close();
+          } catch {
+            // The persistent lock remains when clean release cannot be proven.
+          }
+        }
+      }
+    }
+    if (error instanceof RepositoryLocalFilesystemError) {
+      mapFilesystemReason(state, error);
+    } else if (error instanceof RepositoryLocalFormatError) {
+      state.fail("state_corrupt");
+    } else if (error instanceof AuditError && error.code === "audit_candidate_invalid") {
+      throw error;
+    } else if (!state.isFailed()) {
+      state.fail("state_corrupt");
+    }
+    throw unavailable();
+  }
+}
+
+export function openRepositoryLocalAuditProfile(
+  options: RepositoryLocalAuditProfileOptions,
+): Promise<RepositoryLocalAuditProfile> {
+  return openRepositoryLocalAuditProfileInternal(options);
+}
+
+export function openRepositoryLocalAuditProfileForQualification(
+  options: RepositoryLocalQualificationOptions,
+): Promise<RepositoryLocalAuditProfile> {
+  return openRepositoryLocalAuditProfileInternal(options);
+}

--- a/test/runtime/audit-writer.test.ts
+++ b/test/runtime/audit-writer.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { chmod, mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
 import {
   AUDIT_REGISTRY,
@@ -13,6 +16,11 @@ import {
   recordAfterProviderStart,
   type RecoveryFact,
 } from "../../packages/audit/src/lifecycle.js";
+import {
+  openRepositoryLocalAuditProfileForQualification,
+  type RepositoryLocalAuditProfile,
+} from "../../packages/audit/src/repository-local.js";
+import type { RepositoryLocalFilesystemEvent } from "../../packages/audit/src/repository-local-filesystem.js";
 import {
   AUDIT_GENESIS_HASH,
   AuditWriter,
@@ -335,6 +343,10 @@ function preEffectCandidates(): readonly AuditCandidate[] {
   ];
 }
 
+const alwaysReady = Object.freeze({
+  assertReadyForProviderStart: async (): Promise<void> => undefined,
+});
+
 async function committedChain() {
   const store = new InMemoryAuditStore();
   const writer = new AuditWriter({
@@ -501,6 +513,7 @@ test("rejects every non-explicit allow before provider invocation", async () => 
           throw new Error("invalid authorization must not reach the writer");
         },
       },
+      readiness: alwaysReady,
       startProvider: async () => {
         starts += 1;
         return "started";
@@ -692,6 +705,7 @@ test("binds planning to its decision and rejects stale planning authorization at
         throw new Error("stale authorization must fail before commit");
       },
     },
+    readiness: alwaysReady,
     startProvider: async () => {
       starts += 1;
       return "started";
@@ -785,6 +799,7 @@ test("fails closed before provider start unless every receipt is durable", async
   const volatile = await commitBeforeProviderStart({
     candidates: preEffectCandidates(),
     writer,
+    readiness: alwaysReady,
     startProvider: async () => {
       starts += 1;
       return "started";
@@ -802,6 +817,7 @@ test("fails closed before provider start unless every receipt is durable", async
   const incomplete = await commitBeforeProviderStart({
     candidates: [candidate()],
     writer: durableWriter,
+    readiness: alwaysReady,
     startProvider: async () => {
       starts += 1;
       return "started";
@@ -813,6 +829,7 @@ test("fails closed before provider start unless every receipt is durable", async
   const durable = await commitBeforeProviderStart({
     candidates: preEffectCandidates(),
     writer: durableWriter,
+    readiness: alwaysReady,
     startProvider: async () => {
       starts += 1;
       return "started";
@@ -820,6 +837,93 @@ test("fails closed before provider start unless every receipt is durable", async
   });
   assert.deepEqual(durable, { status: "started", value: "started" });
   assert.equal(starts, 1);
+});
+
+test("final capacity and failed-health duplicates never authorize provider start", async () => {
+  const createdRoot = await mkdtemp(path.join(tmpdir(), "audit-readiness-capacity-"));
+  await chmod(createdRoot, 0o700);
+  const root = await realpath(createdRoot);
+  let profile: RepositoryLocalAuditProfile | undefined;
+  let closed = false;
+  try {
+    let armed = false;
+    let remainingIdentitySyncs = 0;
+    const hooks = {
+      filesystemKindOverride: "ext" as const,
+      availableBytesOverride: BigInt(Number.MAX_SAFE_INTEGER),
+      onEvent: (event: RepositoryLocalFilesystemEvent) => {
+        if (armed && event === "primary_identity.after_directory_sync") {
+          remainingIdentitySyncs -= 1;
+          if (remainingIdentitySyncs === 0) hooks.availableBytesOverride = 0n;
+        }
+      },
+    };
+    profile = await openRepositoryLocalAuditProfileForQualification({
+      trustedRepositoryRoot: root,
+      writerRef: "writer.test",
+      now: () => new Date("2026-08-06T07:00:01.000Z"),
+      filesystemHooks: hooks,
+    });
+    const writer = new AuditWriter({
+      store: profile.store,
+      streamRef: "stream.test",
+      writerRef: "writer.test",
+      now: () => new Date("2026-08-06T07:00:01.000Z"),
+    });
+    await writer.commit(streamCandidate());
+    const candidates = preEffectCandidates();
+    armed = true;
+    remainingIdentitySyncs = candidates.length;
+    let starts = 0;
+    let durableReceipts = 0;
+    const exhausted = await commitBeforeProviderStart({
+      candidates,
+      writer: {
+        commit: async (item) => {
+          const receipt = await writer.commit(item);
+          assert.equal(receipt.durability, "durable");
+          durableReceipts += 1;
+          return receipt;
+        },
+      },
+      readiness: profile.readiness,
+      startProvider: async () => {
+        starts += 1;
+        return "started";
+      },
+    });
+    assert.deepEqual(exhausted, { status: "denied", code: "audit_unavailable" });
+    assert.equal(remainingIdentitySyncs, 0);
+    assert.equal(durableReceipts, candidates.length);
+    assert.equal(profile.diagnostic().reason, "capacity_exhausted");
+    assert.equal(starts, 0);
+
+    let duplicateReceipts = 0;
+    const duplicates = await commitBeforeProviderStart({
+      candidates,
+      writer: {
+        commit: async (item) => {
+          const receipt = await writer.commit(item);
+          assert.equal(receipt.duplicate, true);
+          duplicateReceipts += 1;
+          return receipt;
+        },
+      },
+      readiness: profile.readiness,
+      startProvider: async () => {
+        starts += 1;
+        return "started";
+      },
+    });
+    assert.deepEqual(duplicates, { status: "denied", code: "audit_unavailable" });
+    assert.equal(duplicateReceipts, candidates.length);
+    assert.equal(starts, 0);
+    await profile.close();
+    closed = true;
+  } finally {
+    if (profile !== undefined && !closed) await profile.close();
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 test("journals one bounded fact after start, withholds success, and never retries", async () => {

--- a/test/runtime/fixtures/repository-local-crash-child.ts
+++ b/test/runtime/fixtures/repository-local-crash-child.ts
@@ -1,0 +1,62 @@
+import { AuditError } from "../../../packages/audit/src/contract.js";
+import { openRepositoryLocalAuditProfileForQualification } from "../../../packages/audit/src/repository-local.js";
+import {
+  FIXED_NOW,
+  WRITER_REF,
+  candidateDigest,
+  protectedGenesisEvent,
+  recoveryFact,
+} from "../repository-local-test-fixtures.js";
+
+const [, , mode, repositoryRoot, crashEvent, crashOccurrenceValue] = process.argv;
+if (
+  repositoryRoot === undefined ||
+  (mode !== "primary" && mode !== "recovery" && mode !== "expect-lock")
+) {
+  process.exit(64);
+}
+
+if (mode === "expect-lock") {
+  try {
+    const profile = await openRepositoryLocalAuditProfileForQualification({
+      trustedRepositoryRoot: repositoryRoot,
+      writerRef: WRITER_REF,
+      now: () => new Date(FIXED_NOW),
+      filesystemHooks: { filesystemKindOverride: "apfs" },
+    });
+    await profile.close();
+    process.exit(65);
+  } catch (error: unknown) {
+    process.exit(error instanceof AuditError && error.code === "audit_unavailable" ? 0 : 66);
+  }
+}
+
+if (crashEvent === undefined) process.exit(67);
+const crashOccurrence = crashOccurrenceValue === undefined ? 1 : Number(crashOccurrenceValue);
+if (!Number.isSafeInteger(crashOccurrence) || crashOccurrence < 1) process.exit(69);
+let armed = false;
+let occurrence = 0;
+const profile = await openRepositoryLocalAuditProfileForQualification({
+  trustedRepositoryRoot: repositoryRoot,
+  writerRef: WRITER_REF,
+  now: () => new Date(FIXED_NOW),
+  filesystemHooks: {
+    filesystemKindOverride: "apfs",
+    onEvent: (event) => {
+      if (armed && event === crashEvent) {
+        occurrence += 1;
+        if (occurrence === crashOccurrence) process.exit(86);
+      }
+    },
+  },
+});
+armed = true;
+
+if (mode === "primary") {
+  const event = protectedGenesisEvent();
+  await profile.store.append(event, candidateDigest(event));
+} else {
+  await profile.journal.append(recoveryFact());
+}
+await profile.close();
+process.exit(68);

--- a/test/runtime/fixtures/repository-local-crash-child.ts
+++ b/test/runtime/fixtures/repository-local-crash-child.ts
@@ -22,7 +22,7 @@ if (mode === "expect-lock") {
       trustedRepositoryRoot: repositoryRoot,
       writerRef: WRITER_REF,
       now: () => new Date(FIXED_NOW),
-      filesystemHooks: { filesystemKindOverride: "apfs" },
+      filesystemHooks: { filesystemKindOverride: "ext" },
     });
     await profile.close();
     process.exit(65);
@@ -41,7 +41,7 @@ const profile = await openRepositoryLocalAuditProfileForQualification({
   writerRef: WRITER_REF,
   now: () => new Date(FIXED_NOW),
   filesystemHooks: {
-    filesystemKindOverride: "apfs",
+    filesystemKindOverride: "ext",
     onEvent: (event) => {
       if (armed && event === crashEvent) {
         occurrence += 1;

--- a/test/runtime/repository-local-audit.test.ts
+++ b/test/runtime/repository-local-audit.test.ts
@@ -1,0 +1,1188 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+  chmod,
+  copyFile,
+  link,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rename,
+  rm,
+  symlink,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { AuditError, compareAuditTimestamps } from "../../packages/audit/src/contract.js";
+import {
+  canonicalRepositoryLocalBytes,
+  createRepositoryLocalCheckpointRecord,
+  parseCanonicalRepositoryLocalBytes,
+  REPOSITORY_LOCAL_CHECKPOINT_LIMITATION,
+  REPOSITORY_LOCAL_LIMITS,
+  repositoryLocalReferencePathDigest,
+  validateRepositoryLocalCheckpointRecord,
+  validateRepositoryLocalProfileRecord,
+} from "../../packages/audit/src/repository-local-contract.js";
+import {
+  openRepositoryLocalAuditProfileForQualification,
+  type RepositoryLocalAuditProfile,
+} from "../../packages/audit/src/repository-local.js";
+import type {
+  RepositoryLocalFilesystemEvent,
+  RepositoryLocalFilesystemHooks,
+} from "../../packages/audit/src/repository-local-filesystem.js";
+import {
+  listRepositoryLocalDirectory,
+  RepositoryLocalFilesystemError,
+} from "../../packages/audit/src/repository-local-filesystem.js";
+import { canonicalAuditJson } from "../../packages/audit/src/writer.js";
+import {
+  D1,
+  FIXED_LATER,
+  FIXED_NOW,
+  STREAM_REF,
+  WRITER_REF,
+  candidateDigest,
+  protectedGenesisEvent,
+  protectedRequestEvent,
+  recoveryFact,
+} from "./repository-local-test-fixtures.js";
+
+const RUNTIME_PARTS = [".yukh", "runtime", "audit-v1"] as const;
+
+async function repositoryRoot(prefix: string): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), prefix));
+  await chmod(root, 0o700);
+  return realpath(root);
+}
+
+function runtime(root: string, ...parts: string[]): string {
+  return path.join(root, ...RUNTIME_PARTS, ...parts);
+}
+
+function profileOptions(
+  root: string,
+  overrides: Readonly<{
+    now?: () => Date;
+    monotonicNow?: () => number;
+    hooks?: RepositoryLocalFilesystemHooks;
+  }> = {},
+) {
+  return {
+    trustedRepositoryRoot: root,
+    writerRef: WRITER_REF,
+    now: overrides.now ?? (() => new Date(FIXED_NOW)),
+    ...(overrides.monotonicNow === undefined ? {} : { monotonicNow: overrides.monotonicNow }),
+    filesystemHooks: {
+      filesystemKindOverride: "apfs" as const,
+      ...overrides.hooks,
+    },
+  };
+}
+
+async function openProfile(
+  root: string,
+  overrides: Parameters<typeof profileOptions>[1] = {},
+): Promise<RepositoryLocalAuditProfile> {
+  return openRepositoryLocalAuditProfileForQualification(profileOptions(root, overrides));
+}
+
+async function expectUnavailable(promise: Promise<unknown>): Promise<void> {
+  await assert.rejects(
+    promise,
+    (error: unknown) => error instanceof AuditError && error.code === "audit_unavailable",
+  );
+}
+
+async function initialize(root: string): Promise<void> {
+  const profile = await openProfile(root);
+  await profile.close();
+}
+
+async function appendPrimaryChain(
+  profile: RepositoryLocalAuditProfile,
+): Promise<
+  readonly [ReturnType<typeof protectedGenesisEvent>, ReturnType<typeof protectedRequestEvent>]
+> {
+  const genesis = protectedGenesisEvent();
+  await profile.store.append(genesis, candidateDigest(genesis));
+  const request = protectedRequestEvent(genesis);
+  await profile.store.append(request, candidateDigest(request));
+  return [genesis, request];
+}
+
+function streamDirectory(root: string): string {
+  return runtime(root, "primary", "streams", repositoryLocalReferencePathDigest(STREAM_REF));
+}
+
+function commitPath(root: string, sequence: number): string {
+  return path.join(
+    streamDirectory(root),
+    "commits",
+    `${sequence.toString().padStart(20, "0")}.json`,
+  );
+}
+
+function primaryIdentityPath(root: string, eventId: string): string {
+  return runtime(
+    root,
+    "primary",
+    "identities",
+    repositoryLocalReferencePathDigest(eventId),
+    "00000000.json",
+  );
+}
+
+test("primary store is durable, concurrent-idempotent, and conflict-fatal", async () => {
+  const root = await repositoryRoot("repository-local-primary-");
+  try {
+    const profile = await openProfile(root);
+    const event = protectedGenesisEvent();
+    const [first, second] = await Promise.all([
+      profile.store.append(event, candidateDigest(event)),
+      profile.store.append(event, candidateDigest(event)),
+    ]);
+    assert.deepEqual([first.duplicate, second.duplicate].sort(), [false, true]);
+    assert.equal(first.durability, "durable");
+    assert.equal(second.durability, "durable");
+    assert.equal(canonicalAuditJson(first.event), canonicalAuditJson(second.event));
+    await profile.close();
+
+    const reopened = await openProfile(root, {
+      now: () => new Date(FIXED_LATER),
+    });
+    const found = await reopened.store.findById(event.event_id);
+    assert.deepEqual(found, {
+      event,
+      candidate_digest: candidateDigest(event),
+      durability: "durable",
+    });
+    assert.equal((await reopened.store.append(event, candidateDigest(event))).duplicate, true);
+
+    const conflict = protectedGenesisEvent({
+      subjectRef: "service.conflicting-audit",
+    });
+    await assert.rejects(
+      reopened.store.append(conflict, candidateDigest(conflict)),
+      (error: unknown) => error instanceof AuditError && error.code === "audit_duplicate_conflict",
+    );
+    assert.deepEqual(reopened.diagnostic(), {
+      ...reopened.diagnostic(),
+      phase: "primary_append",
+      state: "failed",
+      reason: "duplicate_conflict",
+    });
+    await expectUnavailable(reopened.store.append(event, candidateDigest(event)));
+    assert.equal(JSON.stringify(reopened.diagnostic()).includes(root), false);
+    await reopened.close();
+
+    const verified = await openProfile(root, {
+      now: () => new Date(FIXED_LATER),
+    });
+    assert.deepEqual((await verified.store.findById(event.event_id))?.event, event);
+    await verified.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("recovery journal preserves exact facts and replays deterministic read-only order", async () => {
+  const root = await repositoryRoot("repository-local-recovery-");
+  try {
+    const profile = await openProfile(root);
+    const facts = [
+      recoveryFact(3, { observedAt: "2026-08-07T11:03:00.000Z" }),
+      recoveryFact(1, { observedAt: "2026-08-07T11:01:00.000Z" }),
+      recoveryFact(2, { observedAt: "2026-08-07T11:02:00.000Z" }),
+    ];
+    for (const fact of facts) {
+      assert.deepEqual(await profile.journal.append(fact), {
+        durability: "durable",
+      });
+    }
+    assert.deepEqual(await profile.journal.append(facts[0]!), {
+      durability: "durable",
+    });
+    const firstPass = [];
+    for await (const fact of profile.pendingFacts()) {
+      assert(Object.isFrozen(fact));
+      firstPass.push(fact);
+    }
+    assert.deepEqual(
+      firstPass.map((fact) => fact.recovery_id),
+      [facts[1]!.recovery_id, facts[2]!.recovery_id, facts[0]!.recovery_id],
+    );
+    const secondPass = [];
+    for await (const fact of profile.pendingFacts()) secondPass.push(fact);
+    assert.deepEqual(secondPass, firstPass);
+
+    const conflict = recoveryFact(3, { eventId: "event.conflicting-recovery" });
+    await assert.rejects(
+      profile.journal.append(conflict),
+      (error: unknown) => error instanceof AuditError && error.code === "audit_duplicate_conflict",
+    );
+    assert.equal(profile.diagnostic().state, "failed");
+    await expectUnavailable(profile.journal.append(facts[0]!));
+    await profile.close();
+
+    const reopened = await openProfile(root, {
+      now: () => new Date(FIXED_LATER),
+    });
+    const afterRestart = [];
+    for await (const fact of reopened.pendingFacts()) afterRestart.push(fact);
+    assert.deepEqual(afterRestart, firstPass);
+    assert.deepEqual(await readdir(runtime(root, "recovery", "acknowledged")), []);
+    await reopened.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("overdue recovery facts fail a live profile before any further durable effect", async () => {
+  const liveRoot = await repositoryRoot("repository-local-live-overdue-");
+  const staleAppendRoot = await repositoryRoot("repository-local-stale-append-");
+  let now = FIXED_NOW;
+  try {
+    const live = await openProfile(liveRoot, {
+      now: () => new Date(now),
+    });
+    const recorded = protectedGenesisEvent();
+    await live.store.append(recorded, candidateDigest(recorded));
+    const fact = recoveryFact();
+    await live.journal.append(fact);
+    now = "2026-09-07T12:00:01.000Z";
+    assert.equal(live.diagnostic().reason, "pending_expired");
+    const event = protectedGenesisEvent({
+      eventId: "event.overdue-denied",
+      streamRef: "stream.overdue-denied",
+    });
+    await expectUnavailable(live.store.append(event, candidateDigest(event)));
+    await expectUnavailable(live.journal.append(fact));
+    assert.equal(live.diagnostic().reason, "pending_expired");
+    await live.close();
+    assert.deepEqual(await readdir(runtime(liveRoot, "primary", "checkpoints")), []);
+
+    const staleAppend = await openProfile(staleAppendRoot, {
+      now: () => new Date("2026-09-07T12:00:01.000Z"),
+    });
+    await expectUnavailable(staleAppend.journal.append(recoveryFact()));
+    assert.equal(staleAppend.diagnostic().reason, "pending_expired");
+    assert.deepEqual(await readdir(runtime(staleAppendRoot, "recovery", "pending")), []);
+    await staleAppend.close();
+  } finally {
+    await rm(liveRoot, { recursive: true, force: true });
+    await rm(staleAppendRoot, { recursive: true, force: true });
+  }
+});
+
+test("closed records and local checkpoint claims are canonical and fixed", () => {
+  const checkpoint = createRepositoryLocalCheckpointRecord({
+    stream_ref: STREAM_REF,
+    range_start: 0,
+    range_end: 9,
+    terminal_event_hash: D1,
+    previous_checkpoint_ref: null,
+    writer_ref: WRITER_REF,
+    created_at: FIXED_NOW,
+  });
+  assert.equal(checkpoint.event_count, 10);
+  assert.equal(checkpoint.limitation, REPOSITORY_LOCAL_CHECKPOINT_LIMITATION);
+  assert.equal(checkpoint.authority_ref, "repository_local_writer_v1");
+  assert.equal(checkpoint.algorithm, "sha256_local_checkpoint_v1");
+  assert.equal(
+    checkpoint.checkpoint_id,
+    "sha256:241c45517b6633182ef2015ef96ffa5bf54018ca32c466c5be3cbf671a7c79df",
+  );
+  assert.deepEqual(
+    validateRepositoryLocalCheckpointRecord(
+      parseCanonicalRepositoryLocalBytes(canonicalRepositoryLocalBytes(checkpoint)),
+    ),
+    checkpoint,
+  );
+  assert.throws(() =>
+    parseCanonicalRepositoryLocalBytes(Buffer.from(`${JSON.stringify(checkpoint)}\n`, "utf8")),
+  );
+  assert.throws(() => validateRepositoryLocalCheckpointRecord({ ...checkpoint, unknown: true }));
+  assert.equal(REPOSITORY_LOCAL_LIMITS.recovery_identity_reservation_bytes, 16 * 1024);
+  assert.equal(
+    REPOSITORY_LOCAL_LIMITS.max_recovery_identities *
+      REPOSITORY_LOCAL_LIMITS.recovery_identity_reservation_bytes,
+    REPOSITORY_LOCAL_LIMITS.max_recovery_bytes,
+  );
+  assert.equal(compareAuditTimestamps("2026-08-07T12:00:00Z", "2026-08-07T12:00:00.1Z"), -1);
+  assert.equal(
+    compareAuditTimestamps("2026-08-07T12:00:00.100000000Z", "2026-08-07T12:00:00.1Z"),
+    0,
+  );
+});
+
+test("clean shutdown publishes one honest checkpoint per changed stream", async () => {
+  const root = await repositoryRoot("repository-local-checkpoints-");
+  try {
+    const profile = await openProfile(root);
+    const first = protectedGenesisEvent();
+    const second = protectedGenesisEvent({
+      eventId: "event.repository-local-second-stream",
+      streamRef: "stream.repository-local-second",
+    });
+    await profile.store.append(first, candidateDigest(first));
+    await profile.store.append(second, candidateDigest(second));
+    await profile.close();
+
+    const files = await readdir(runtime(root, "primary", "checkpoints"));
+    assert.equal(files.length, 2);
+    for (const file of files) {
+      const parsed = validateRepositoryLocalCheckpointRecord(
+        parseCanonicalRepositoryLocalBytes(
+          await readFile(runtime(root, "primary", "checkpoints", file)),
+        ),
+      );
+      assert.equal(parsed.range_start, 0);
+      assert.equal(parsed.range_end, 0);
+      assert.equal(parsed.event_count, 1);
+      assert.equal(parsed.limitation, "local_unwitnessed_not_complete");
+    }
+    const reopened = await openProfile(root, {
+      now: () => new Date(FIXED_LATER),
+    });
+    assert.equal(reopened.diagnostic().state, "healthy");
+    await reopened.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("the per-stream checkpoint interval commits at exactly 1,000 records", async () => {
+  const root = await repositoryRoot("repository-local-checkpoint-interval-");
+  try {
+    const options = profileOptions(root);
+    const mutableHooks = options.filesystemHooks as {
+      filesystemKindOverride: "apfs";
+      availableBytesOverride?: bigint;
+    };
+    const profile = await openRepositoryLocalAuditProfileForQualification(options);
+    let previous = protectedGenesisEvent();
+    await profile.store.append(previous, candidateDigest(previous));
+    for (
+      let sequence = 1;
+      sequence < REPOSITORY_LOCAL_LIMITS.checkpoint_interval - 1;
+      sequence += 1
+    ) {
+      previous = protectedRequestEvent(previous, sequence);
+      await profile.store.append(previous, candidateDigest(previous));
+    }
+    assert.deepEqual(await readdir(runtime(root, "primary", "checkpoints")), []);
+    const thresholdEvent = protectedRequestEvent(
+      previous,
+      REPOSITORY_LOCAL_LIMITS.checkpoint_interval - 1,
+    );
+    mutableHooks.availableBytesOverride = 0n;
+    await expectUnavailable(profile.store.append(thresholdEvent, candidateDigest(thresholdEvent)));
+    await assert.rejects(lstat(commitPath(root, REPOSITORY_LOCAL_LIMITS.checkpoint_interval - 1)), {
+      code: "ENOENT",
+    });
+    assert.deepEqual(await readdir(runtime(root, "primary", "checkpoints")), []);
+    await profile.close();
+
+    const resumed = await openProfile(root, {
+      now: () => new Date(FIXED_LATER),
+    });
+    await resumed.store.append(thresholdEvent, candidateDigest(thresholdEvent));
+    const files = await readdir(runtime(root, "primary", "checkpoints"));
+    assert.equal(files.length, 1);
+    const checkpoint = validateRepositoryLocalCheckpointRecord(
+      parseCanonicalRepositoryLocalBytes(
+        await readFile(runtime(root, "primary", "checkpoints", files[0]!)),
+      ),
+    );
+    assert.equal(checkpoint.range_start, 0);
+    assert.equal(checkpoint.range_end, 999);
+    assert.equal(checkpoint.event_count, 1_000);
+    await resumed.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("publication is atomic no-replace and never overwrites a destination", async () => {
+  const root = await repositoryRoot("repository-local-no-replace-");
+  let injectConflict = false;
+  try {
+    const profile = await openProfile(root, {
+      hooks: {
+        onEvent: async (event) => {
+          if (injectConflict && event === "primary_record.before_temp_create") {
+            injectConflict = false;
+            await writeFile(commitPath(root, 0), "sentinel", {
+              mode: 0o600,
+              flag: "wx",
+            });
+          }
+        },
+      },
+    });
+    injectConflict = true;
+    const event = protectedGenesisEvent();
+    await expectUnavailable(profile.store.append(event, candidateDigest(event)));
+    assert.equal(await readFile(commitPath(root, 0), "utf8"), "sentinel");
+    assert.equal(profile.diagnostic().state, "failed");
+    await profile.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("persistent lock, paths, links, ownership, modes, and filesystem support fail closed", async (t) => {
+  await t.test("stale lock is retained and never auto-stolen", async () => {
+    const root = await repositoryRoot("repository-local-stale-lock-");
+    try {
+      await initialize(root);
+      const lockPath = runtime(root, "writer.lock");
+      await writeFile(lockPath, "stale-lock", { mode: 0o600, flag: "wx" });
+      await expectUnavailable(openProfile(root));
+      assert.equal(await readFile(lockPath, "utf8"), "stale-lock");
+      await unlink(lockPath);
+      const recovered = await openProfile(root);
+      await recovered.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("non-canonical and traversal roots are rejected", async () => {
+    const root = await repositoryRoot("repository-local-path-");
+    try {
+      const nonCanonical = `${root}${path.sep}..${path.sep}${path.basename(root)}`;
+      await expectUnavailable(openProfile(nonCanonical));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("repository roots inside .git are rejected", async () => {
+    const outer = await repositoryRoot("repository-local-git-root-");
+    try {
+      const gitRoot = path.join(outer, ".git");
+      await mkdir(gitRoot, { mode: 0o700 });
+      await expectUnavailable(openProfile(gitRoot));
+    } finally {
+      await rm(outer, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("symlink roots and runtime components are rejected", async () => {
+    const root = await repositoryRoot("repository-local-symlink-");
+    const alias = `${root}-alias`;
+    const target = `${root}-runtime-target`;
+    try {
+      await symlink(root, alias);
+      await expectUnavailable(openProfile(alias));
+      await mkdir(path.join(root, ".yukh"), { mode: 0o700 });
+      await mkdir(target, { mode: 0o700 });
+      await symlink(target, path.join(root, ".yukh", "runtime"));
+      await expectUnavailable(openProfile(root));
+    } finally {
+      await rm(alias, { force: true });
+      await rm(target, { recursive: true, force: true });
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("unsafe directory and file modes are rejected", async () => {
+    const root = await repositoryRoot("repository-local-modes-");
+    try {
+      await initialize(root);
+      await chmod(runtime(root), 0o755);
+      await expectUnavailable(openProfile(root));
+      await chmod(runtime(root), 0o700);
+      const profile = await openProfile(root);
+      const event = protectedGenesisEvent();
+      await profile.store.append(event, candidateDigest(event));
+      await profile.close();
+      await chmod(commitPath(root, 0), 0o644);
+      await expectUnavailable(openProfile(root));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("hard-linked committed files are rejected", async () => {
+    const root = await repositoryRoot("repository-local-hardlink-");
+    const hardLink = `${root}-profile-link`;
+    try {
+      await initialize(root);
+      await link(runtime(root, "profile.json"), hardLink);
+      await expectUnavailable(openProfile(root));
+      assert.equal((await lstat(hardLink)).nlink, 2);
+    } finally {
+      await rm(hardLink, { force: true });
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("simulated wrong ownership is rejected", async () => {
+    const root = await repositoryRoot("repository-local-owner-");
+    try {
+      await expectUnavailable(
+        openProfile(root, {
+          hooks: {
+            metadataOverride: (_label, metadata) => ({
+              ...metadata,
+              owner: metadata.owner + 1,
+            }),
+          },
+        }),
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("unsupported filesystems are rejected before readiness", async () => {
+    const root = await repositoryRoot("repository-local-unsupported-fs-");
+    try {
+      await expectUnavailable(
+        openProfile(root, {
+          hooks: { filesystemKindOverride: "unsupported" },
+        }),
+      );
+      const qualified = await openProfile(root);
+      await qualified.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("directory enumeration aborts at its caller bound", async () => {
+    const root = await repositoryRoot("repository-local-directory-bound-");
+    try {
+      await writeFile(path.join(root, "first"), "x", { mode: 0o600 });
+      await writeFile(path.join(root, "second"), "x", { mode: 0o600 });
+      await assert.rejects(
+        listRepositoryLocalDirectory(root, (await lstat(root)).dev, 1),
+        (error: unknown) =>
+          error instanceof RepositoryLocalFilesystemError && error.reason === "corruption_detected",
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+test("corruption, gaps, substitution, stale facts, and unknown state fail without repair", async (t) => {
+  await t.test("non-canonical profile bytes", async () => {
+    const root = await repositoryRoot("repository-local-noncanonical-");
+    try {
+      await initialize(root);
+      const profilePath = runtime(root, "profile.json");
+      const parsed = validateRepositoryLocalProfileRecord(
+        parseCanonicalRepositoryLocalBytes(await readFile(profilePath)),
+      );
+      await writeFile(profilePath, JSON.stringify(parsed, null, 2), { mode: 0o600 });
+      await expectUnavailable(openProfile(root));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("truncated and oversized commits", async () => {
+    for (const kind of ["truncated", "oversized"] as const) {
+      const root = await repositoryRoot(`repository-local-${kind}-`);
+      try {
+        const profile = await openProfile(root);
+        const event = protectedGenesisEvent();
+        await profile.store.append(event, candidateDigest(event));
+        await profile.close();
+        const file = commitPath(root, 0);
+        const original = await readFile(file);
+        await writeFile(
+          file,
+          kind === "truncated"
+            ? original.subarray(0, Math.floor(original.length / 2))
+            : Buffer.alloc(REPOSITORY_LOCAL_LIMITS.max_primary_commit_record_bytes + 1, 0x61),
+          { mode: 0o600 },
+        );
+        await expectUnavailable(openProfile(root));
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    }
+  });
+
+  await t.test("identity completion requires a validated final record", async () => {
+    for (const kind of ["primary", "recovery"] as const) {
+      const root = await repositoryRoot(`repository-local-validated-${kind}-`);
+      let failAt: RepositoryLocalFilesystemEvent | undefined;
+      try {
+        const profile = await openProfile(root, {
+          hooks: {
+            onEvent: (event) => {
+              if (event === failAt) {
+                throw Object.assign(new Error("simulated ambiguous publication"), {
+                  code: "EIO",
+                });
+              }
+            },
+          },
+        });
+        if (kind === "primary") {
+          const event = protectedGenesisEvent();
+          failAt = "primary_record.before_directory_sync";
+          await expectUnavailable(profile.store.append(event, candidateDigest(event)));
+          await profile.close();
+          await writeFile(commitPath(root, 0), "not-canonical", { mode: 0o600 });
+          const identity = primaryIdentityPath(root, event.event_id);
+          await expectUnavailable(openProfile(root));
+          await assert.rejects(lstat(identity), { code: "ENOENT" });
+        } else {
+          const fact = recoveryFact();
+          failAt = "recovery_record.before_directory_sync";
+          await expectUnavailable(profile.journal.append(fact));
+          await profile.close();
+          const digest = repositoryLocalReferencePathDigest(fact.recovery_id);
+          const pendingPath = runtime(root, "recovery", "pending", `${digest}.json`);
+          const identity = runtime(root, "recovery", "identities", digest, "00000000.json");
+          await writeFile(pendingPath, "not-canonical", { mode: 0o600 });
+          await expectUnavailable(openProfile(root));
+          await assert.rejects(lstat(identity), { code: "ENOENT" });
+        }
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    }
+  });
+
+  await t.test("all identity temporaries validate before any identity completion", async () => {
+    for (const kind of ["primary", "recovery"] as const) {
+      const root = await repositoryRoot(`repository-local-global-temp-${kind}-`);
+      const externalLink = `${root}-identity-link`;
+      try {
+        const profile = await openProfile(root);
+        let missingIdentity: string;
+        let laterIdentity: string;
+        let recordDigest: string;
+        if (kind === "primary") {
+          const [first, second] = await appendPrimaryChain(profile);
+          await profile.close();
+          missingIdentity = primaryIdentityPath(root, first.event_id);
+          laterIdentity = primaryIdentityPath(root, second.event_id);
+          const parsed = JSON.parse(await readFile(laterIdentity, "utf8")) as Readonly<{
+            primary_identity_record_digest: string;
+          }>;
+          recordDigest = parsed.primary_identity_record_digest;
+        } else {
+          const first = recoveryFact(0);
+          const second = recoveryFact(1);
+          await profile.journal.append(first);
+          await profile.journal.append(second);
+          await profile.close();
+          missingIdentity = runtime(
+            root,
+            "recovery",
+            "identities",
+            repositoryLocalReferencePathDigest(first.recovery_id),
+            "00000000.json",
+          );
+          laterIdentity = runtime(
+            root,
+            "recovery",
+            "identities",
+            repositoryLocalReferencePathDigest(second.recovery_id),
+            "00000000.json",
+          );
+          const parsed = JSON.parse(await readFile(laterIdentity, "utf8")) as Readonly<{
+            recovery_identity_record_digest: string;
+          }>;
+          recordDigest = parsed.recovery_identity_record_digest;
+        }
+        await unlink(missingIdentity);
+        await link(laterIdentity, externalLink);
+        const temporary = path.join(
+          path.dirname(laterIdentity),
+          `.00000000.json.${recordDigest.slice("sha256:".length)}.tmp`,
+        );
+        await writeFile(temporary, "x", { mode: 0o600, flag: "wx" });
+        await expectUnavailable(openProfile(root));
+        await assert.rejects(lstat(missingIdentity), { code: "ENOENT" });
+      } finally {
+        await rm(externalLink, { force: true });
+        await rm(root, { recursive: true, force: true });
+      }
+    }
+  });
+
+  await t.test("missing and reordered sequence records", async () => {
+    for (const kind of ["missing", "reordered"] as const) {
+      const root = await repositoryRoot(`repository-local-${kind}-sequence-`);
+      try {
+        const profile = await openProfile(root);
+        const [, request] = await appendPrimaryChain(profile);
+        await profile.close();
+        if (kind === "missing") {
+          await unlink(commitPath(root, 0));
+          await unlink(primaryIdentityPath(root, request.event_id));
+        } else {
+          await rename(commitPath(root, 1), commitPath(root, 2));
+        }
+        await expectUnavailable(openProfile(root));
+        if (kind === "missing") {
+          await assert.rejects(lstat(primaryIdentityPath(root, request.event_id)), {
+            code: "ENOENT",
+          });
+        }
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    }
+  });
+
+  await t.test("symlink substitution is rejected without following", async () => {
+    const root = await repositoryRoot("repository-local-record-symlink-");
+    const target = `${root}-commit-copy`;
+    try {
+      const profile = await openProfile(root);
+      const event = protectedGenesisEvent();
+      await profile.store.append(event, candidateDigest(event));
+      await profile.close();
+      const file = commitPath(root, 0);
+      await copyFile(file, target);
+      await unlink(file);
+      await symlink(target, file);
+      await expectUnavailable(openProfile(root));
+    } finally {
+      await rm(target, { force: true });
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("mismatched identity and orphan identity are retained", async () => {
+    for (const kind of ["mismatch", "orphan"] as const) {
+      const root = await repositoryRoot(`repository-local-identity-${kind}-`);
+      try {
+        const profile = await openProfile(root);
+        const event = protectedGenesisEvent();
+        await profile.store.append(event, candidateDigest(event));
+        await profile.close();
+        const identityPath = primaryIdentityPath(root, event.event_id);
+        if (kind === "mismatch") {
+          const identity = JSON.parse(await readFile(identityPath, "utf8")) as Record<
+            string,
+            unknown
+          >;
+          identity.candidate_digest = `sha256:${"9".repeat(64)}`;
+          await writeFile(identityPath, canonicalAuditJson(identity), { mode: 0o600 });
+        } else {
+          await unlink(commitPath(root, 0));
+        }
+        await expectUnavailable(openProfile(root));
+        assert.equal((await lstat(identityPath)).isFile(), true);
+        await expectUnavailable(openProfile(root));
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    }
+  });
+
+  await t.test("invalid checkpoint and stale pending fact", async () => {
+    const checkpointRoot = await repositoryRoot("repository-local-bad-checkpoint-");
+    const staleRoot = await repositoryRoot("repository-local-stale-fact-");
+    try {
+      const profile = await openProfile(checkpointRoot);
+      const event = protectedGenesisEvent();
+      await profile.store.append(event, candidateDigest(event));
+      await profile.close();
+      const checkpointName = (await readdir(runtime(checkpointRoot, "primary", "checkpoints")))[0]!;
+      const checkpointPath = runtime(checkpointRoot, "primary", "checkpoints", checkpointName);
+      const checkpoint = JSON.parse(await readFile(checkpointPath, "utf8")) as Record<
+        string,
+        unknown
+      >;
+      checkpoint.limitation = "independently_witnessed";
+      await writeFile(checkpointPath, canonicalAuditJson(checkpoint), { mode: 0o600 });
+      await expectUnavailable(openProfile(checkpointRoot));
+
+      const stale = await openProfile(staleRoot);
+      await stale.journal.append(recoveryFact());
+      await stale.close();
+      await expectUnavailable(
+        openProfile(staleRoot, {
+          now: () => new Date("2026-09-07T12:00:01.000Z"),
+        }),
+      );
+    } finally {
+      await rm(checkpointRoot, { recursive: true, force: true });
+      await rm(staleRoot, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("unknown topology entries", async () => {
+    const root = await repositoryRoot("repository-local-unknown-");
+    try {
+      await initialize(root);
+      await writeFile(runtime(root, "unknown.json"), "{}", { mode: 0o600 });
+      await expectUnavailable(openProfile(root));
+      assert.equal(await readFile(runtime(root, "unknown.json"), "utf8"), "{}");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("missing closed-topology directories are not recreated", async () => {
+    const root = await repositoryRoot("repository-local-missing-topology-");
+    try {
+      await initialize(root);
+      const missing = runtime(root, "recovery", "quarantine");
+      await rm(missing, { recursive: true });
+      await expectUnavailable(openProfile(root));
+      await assert.rejects(lstat(missing), { code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("multiple impossible transaction temporaries are retained", async () => {
+    const root = await repositoryRoot("repository-local-multiple-temporaries-");
+    try {
+      await initialize(root);
+      const directory = runtime(root, "primary", "checkpoints");
+      const names = ["a", "b"].map((value) => `.${value.repeat(64)}.json.${value.repeat(64)}.tmp`);
+      for (const name of names) {
+        await writeFile(path.join(directory, name), "x", {
+          mode: 0o600,
+          flag: "wx",
+        });
+      }
+      await expectUnavailable(openProfile(root));
+      assert.deepEqual((await readdir(directory)).sort(), names);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+test("simulated I/O, disk-full, and free-space failures are closed and restart-safe", async (t) => {
+  await t.test("disk-full during a temporary write preserves no commit", async () => {
+    const root = await repositoryRoot("repository-local-enospc-");
+    let failure: RepositoryLocalFilesystemEvent | undefined;
+    try {
+      const profile = await openProfile(root, {
+        hooks: {
+          onEvent: (event) => {
+            if (event === failure) {
+              throw Object.assign(new Error("sensitive disk error"), {
+                code: "ENOSPC",
+              });
+            }
+          },
+        },
+      });
+      failure = "primary_record.during_temp_write";
+      const event = protectedGenesisEvent();
+      await expectUnavailable(profile.store.append(event, candidateDigest(event)));
+      assert.equal(profile.diagnostic().state, "failed");
+      assert.equal(profile.diagnostic().reason, "capacity_exhausted");
+      assert.equal(JSON.stringify(profile.diagnostic()).includes("sensitive disk error"), false);
+      await profile.close();
+
+      const restarted = await openProfile(root, {
+        now: () => new Date(FIXED_LATER),
+      });
+      assert.equal(await restarted.store.findById(event.event_id), undefined);
+      await restarted.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("ambiguous I/O after publication completes only on restart", async () => {
+    const root = await repositoryRoot("repository-local-eio-");
+    let failure: RepositoryLocalFilesystemEvent | undefined;
+    try {
+      const profile = await openProfile(root, {
+        hooks: {
+          onEvent: (event) => {
+            if (event === failure) {
+              throw Object.assign(new Error("sensitive io error"), { code: "EIO" });
+            }
+          },
+        },
+      });
+      failure = "primary_record.before_directory_sync";
+      const event = protectedGenesisEvent();
+      await expectUnavailable(profile.store.append(event, candidateDigest(event)));
+      assert.equal(profile.diagnostic().reason, "io_ambiguous");
+      await profile.close();
+
+      const restarted = await openProfile(root, {
+        now: () => new Date(FIXED_LATER),
+      });
+      assert.deepEqual((await restarted.store.findById(event.event_id))?.event, event);
+      assert.equal((await restarted.store.append(event, candidateDigest(event))).duplicate, true);
+      await restarted.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("insufficient free space denies before record creation", async () => {
+    const root = await repositoryRoot("repository-local-free-space-");
+    try {
+      const profile = await openProfile(root, {
+        hooks: {
+          availableBytesOverride: BigInt(
+            2 *
+              (REPOSITORY_LOCAL_LIMITS.max_primary_commit_record_bytes +
+                REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes),
+          ),
+        },
+      });
+      assert.equal(profile.diagnostic().state, "failed");
+      assert.equal(profile.diagnostic().reason, "capacity_exhausted");
+      const event = protectedGenesisEvent();
+      await expectUnavailable(profile.store.append(event, candidateDigest(event)));
+      assert.equal(profile.diagnostic().reason, "capacity_exhausted");
+      assert.deepEqual(
+        await readdir(path.join(streamDirectory(root), "commits")).catch(() => []),
+        [],
+      );
+      await profile.close();
+
+      const healthy = await openProfile(root);
+      await healthy.store.append(event, candidateDigest(event));
+      await healthy.close();
+      const constrained = await openProfile(root, {
+        hooks: {
+          availableBytesOverride: BigInt(
+            2 *
+              (REPOSITORY_LOCAL_LIMITS.max_primary_commit_record_bytes +
+                REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes),
+          ),
+        },
+      });
+      assert.equal(constrained.diagnostic().state, "failed");
+      assert.deepEqual((await constrained.store.findById(event.event_id))?.event, event);
+      assert.equal((await constrained.store.append(event, candidateDigest(event))).duplicate, true);
+      const next = protectedRequestEvent(event);
+      await expectUnavailable(constrained.store.append(next, candidateDigest(next)));
+      await constrained.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("recovery disk-full preserves no pending fact", async () => {
+    const root = await repositoryRoot("repository-local-recovery-enospc-");
+    let failure: RepositoryLocalFilesystemEvent | undefined;
+    try {
+      const profile = await openProfile(root, {
+        hooks: {
+          onEvent: (event) => {
+            if (event === failure) {
+              throw Object.assign(new Error("sensitive recovery disk error"), {
+                code: "ENOSPC",
+              });
+            }
+          },
+        },
+      });
+      failure = "recovery_record.during_temp_write";
+      const fact = recoveryFact();
+      await expectUnavailable(profile.journal.append(fact));
+      assert.equal(profile.diagnostic().state, "failed");
+      assert.equal(profile.diagnostic().reason, "capacity_exhausted");
+      assert.equal(
+        JSON.stringify(profile.diagnostic()).includes("sensitive recovery disk error"),
+        false,
+      );
+      await profile.close();
+
+      const restarted = await openProfile(root, {
+        now: () => new Date(FIXED_LATER),
+      });
+      const pending = [];
+      for await (const recovered of restarted.pendingFacts()) pending.push(recovered);
+      assert.deepEqual(pending, []);
+      await restarted.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("ambiguous recovery I/O completes only on restart", async () => {
+    const root = await repositoryRoot("repository-local-recovery-eio-");
+    let failure: RepositoryLocalFilesystemEvent | undefined;
+    try {
+      const profile = await openProfile(root, {
+        hooks: {
+          onEvent: (event) => {
+            if (event === failure) {
+              throw Object.assign(new Error("sensitive recovery io error"), {
+                code: "EIO",
+              });
+            }
+          },
+        },
+      });
+      failure = "recovery_record.before_directory_sync";
+      const fact = recoveryFact();
+      await expectUnavailable(profile.journal.append(fact));
+      assert.equal(profile.diagnostic().reason, "io_ambiguous");
+      await profile.close();
+
+      const restarted = await openProfile(root, {
+        now: () => new Date(FIXED_LATER),
+      });
+      const pending = [];
+      for await (const recovered of restarted.pendingFacts()) pending.push(recovered);
+      assert.deepEqual(pending, [fact]);
+      assert.deepEqual(await restarted.journal.append(fact), {
+        durability: "durable",
+      });
+      await restarted.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("insufficient free space denies recovery before record creation", async () => {
+    const root = await repositoryRoot("repository-local-recovery-free-space-");
+    try {
+      const requiredFree =
+        2 *
+        (REPOSITORY_LOCAL_LIMITS.max_recovery_record_bytes +
+          REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes);
+      const profile = await openProfile(root, {
+        hooks: {
+          availableBytesOverride: BigInt(requiredFree - 1),
+        },
+      });
+      const fact = recoveryFact();
+      await expectUnavailable(profile.journal.append(fact));
+      assert.equal(profile.diagnostic().state, "failed");
+      assert.equal(profile.diagnostic().reason, "capacity_exhausted");
+      assert.deepEqual(await readdir(runtime(root, "recovery", "pending")), []);
+      await profile.close();
+
+      const restarted = await openProfile(root);
+      await restarted.journal.append(fact);
+      await restarted.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+test("511/512/513 recovery capacity uses the full 16 KiB lifetime reservation", async () => {
+  const root = await repositoryRoot("repository-local-capacity-");
+  try {
+    const profile = await openProfile(root);
+    for (let index = 0; index < 511; index += 1) {
+      await profile.journal.append(recoveryFact(index));
+    }
+    assert.equal(profile.diagnostic().counts.recovery_identities, 511);
+    assert.equal(profile.diagnostic().state, "degraded");
+    assert.equal(profile.diagnostic().capacity.recovery_bytes, "degraded");
+
+    const boundary = recoveryFact(511);
+    assert.deepEqual(await profile.journal.append(boundary), {
+      durability: "durable",
+    });
+    assert.equal(profile.diagnostic().counts.recovery_identities, 512);
+    assert.equal(profile.diagnostic().state, "failed");
+    assert.equal(profile.diagnostic().reason, "capacity_exhausted");
+    assert.equal(profile.diagnostic().capacity.recovery_bytes, "exhausted");
+    assert.deepEqual(await profile.journal.append(boundary), {
+      durability: "durable",
+    });
+    await expectUnavailable(profile.journal.append(recoveryFact(512)));
+
+    let replayCount = 0;
+    for await (const _fact of profile.pendingFacts()) replayCount += 1;
+    assert.equal(replayCount, 512);
+    await profile.close();
+
+    const restarted = await openProfile(root, {
+      now: () => new Date(FIXED_LATER),
+    });
+    assert.equal(restarted.diagnostic().state, "failed");
+    assert.equal(restarted.diagnostic().reason, "capacity_exhausted");
+    assert.deepEqual(await restarted.journal.append(boundary), {
+      durability: "durable",
+    });
+    await expectUnavailable(restarted.journal.append(recoveryFact(512)));
+    await restarted.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("pending iterator enforces its injected 30-second bound without acknowledgement", async () => {
+  const root = await repositoryRoot("repository-local-iterator-bound-");
+  let monotonic = 0;
+  try {
+    const profile = await openProfile(root, {
+      monotonicNow: () => monotonic,
+    });
+    const fact = recoveryFact();
+    await profile.journal.append(fact);
+    const iterator = profile.pendingFacts()[Symbol.asyncIterator]();
+    assert.deepEqual(await iterator.next(), { done: false, value: fact });
+    monotonic = 30_001;
+    await assert.rejects(
+      iterator.next(),
+      (error: unknown) => error instanceof AuditError && error.code === "audit_unavailable",
+    );
+    assert.equal(profile.diagnostic().reason, "pending_read_bound");
+    await expectUnavailable(profile.journal.append(fact));
+    assert.deepEqual(await readdir(runtime(root, "recovery", "acknowledged")), []);
+    await profile.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("adapter has no network/provider surface and performs zero network calls", async () => {
+  const root = await repositoryRoot("repository-local-network-free-");
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = 0;
+  globalThis.fetch = (async () => {
+    fetchCalls += 1;
+    throw new Error("network must remain unreachable");
+  }) as typeof fetch;
+  try {
+    const profile = await openProfile(root, {
+      hooks: { availableBytesOverride: 0n },
+    });
+    const event = protectedGenesisEvent();
+    await expectUnavailable(profile.store.append(event, candidateDigest(event)));
+    await profile.close();
+    assert.equal(fetchCalls, 0);
+
+    const source = await readFile(
+      path.join(process.cwd(), "packages", "audit", "src", "repository-local.ts"),
+      "utf8",
+    );
+    assert.equal(/from ["']node:(?:http|https|net|tls|dns)["']|fetch\s*\(/.test(source), false);
+    assert.equal(source.includes("provider"), false);
+    assert.equal("acknowledge" in profile, false);
+    assert.equal("retain" in profile, false);
+    assert.equal("export" in profile, false);
+    assert.equal(createHash("sha256").update(source).digest("hex").length, 64);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("repository-local runtime state is ignored without hiding tracked project config", async () => {
+  const ignore = await readFile(path.join(process.cwd(), ".gitignore"), "utf8");
+  assert.match(ignore, /^\.yukh\/runtime\/$/m);
+  assert.equal(ignore.includes(".yukh/\n"), false);
+});

--- a/test/runtime/repository-local-audit.test.ts
+++ b/test/runtime/repository-local-audit.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   chmod,
@@ -73,6 +74,7 @@ function profileOptions(
     now?: () => Date;
     monotonicNow?: () => number;
     hooks?: RepositoryLocalFilesystemHooks;
+    startupPrimaryScanLimits?: Readonly<{ maxRecords: number; maxBytes: number }>;
   }> = {},
 ) {
   return {
@@ -80,8 +82,11 @@ function profileOptions(
     writerRef: WRITER_REF,
     now: overrides.now ?? (() => new Date(FIXED_NOW)),
     ...(overrides.monotonicNow === undefined ? {} : { monotonicNow: overrides.monotonicNow }),
+    ...(overrides.startupPrimaryScanLimits === undefined
+      ? {}
+      : { startupPrimaryScanLimits: overrides.startupPrimaryScanLimits }),
     filesystemHooks: {
-      filesystemKindOverride: "apfs" as const,
+      filesystemKindOverride: "ext" as const,
       ...overrides.hooks,
     },
   };
@@ -311,6 +316,8 @@ test("closed records and local checkpoint claims are canonical and fixed", () =>
   );
   assert.throws(() => validateRepositoryLocalCheckpointRecord({ ...checkpoint, unknown: true }));
   assert.equal(REPOSITORY_LOCAL_LIMITS.recovery_identity_reservation_bytes, 16 * 1024);
+  assert.equal(REPOSITORY_LOCAL_LIMITS.max_event_identities, 8_192);
+  assert.equal(REPOSITORY_LOCAL_LIMITS.max_primary_committed_bytes, 64 * 1024 * 1024);
   assert.equal(
     REPOSITORY_LOCAL_LIMITS.max_recovery_identities *
       REPOSITORY_LOCAL_LIMITS.recovery_identity_reservation_bytes,
@@ -359,12 +366,60 @@ test("clean shutdown publishes one honest checkpoint per changed stream", async 
   }
 });
 
+test("startup commit budgets are global across stream directories", async () => {
+  const root = await repositoryRoot("repository-local-global-scan-budget-");
+  try {
+    const profile = await openProfile(root);
+    const first = protectedGenesisEvent();
+    const second = protectedGenesisEvent({
+      eventId: "event.repository-local-scan-budget-second",
+      streamRef: "stream.repository-local-scan-budget-second",
+    });
+    await profile.store.append(first, candidateDigest(first));
+    await profile.store.append(second, candidateDigest(second));
+    await profile.close();
+
+    const firstPath = commitPath(root, 0);
+    const secondPath = runtime(
+      root,
+      "primary",
+      "streams",
+      repositoryLocalReferencePathDigest(second.integrity.stream_ref),
+      "commits",
+      "00000000000000000000.json",
+    );
+    const sizes = [(await lstat(firstPath)).size, (await lstat(secondPath)).size];
+    const singleDirectoryByteAllowance = Math.max(...sizes);
+    assert(sizes.every((size) => size <= singleDirectoryByteAllowance));
+    assert(sizes.reduce((total, size) => total + size, 0) > singleDirectoryByteAllowance);
+
+    await expectUnavailable(
+      openProfile(root, {
+        startupPrimaryScanLimits: {
+          maxRecords: 1,
+          maxBytes: REPOSITORY_LOCAL_LIMITS.max_primary_committed_bytes,
+        },
+      }),
+    );
+    await expectUnavailable(
+      openProfile(root, {
+        startupPrimaryScanLimits: {
+          maxRecords: REPOSITORY_LOCAL_LIMITS.max_event_identities,
+          maxBytes: singleDirectoryByteAllowance,
+        },
+      }),
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("the per-stream checkpoint interval commits at exactly 1,000 records", async () => {
   const root = await repositoryRoot("repository-local-checkpoint-interval-");
   try {
     const options = profileOptions(root);
     const mutableHooks = options.filesystemHooks as {
-      filesystemKindOverride: "apfs";
+      filesystemKindOverride: "ext";
       availableBytesOverride?: bigint;
     };
     const profile = await openRepositoryLocalAuditProfileForQualification(options);
@@ -542,6 +597,71 @@ test("persistent lock, paths, links, ownership, modes, and filesystem support fa
       );
     } finally {
       await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("APFS fails closed for direct and inherited ACL state", async () => {
+    const cleanRoot = await repositoryRoot("repository-local-apfs-clean-");
+    try {
+      await expectUnavailable(
+        openProfile(cleanRoot, {
+          hooks: { filesystemKindOverride: "apfs" },
+        }),
+      );
+    } finally {
+      await rm(cleanRoot, { recursive: true, force: true });
+    }
+    if (process.platform !== "darwin") return;
+
+    for (const kind of ["direct", "inherited"] as const) {
+      const root = await repositoryRoot(`repository-local-apfs-acl-${kind}-`);
+      try {
+        if (kind === "direct") {
+          await initialize(root);
+          const target = runtime(root);
+          const added = spawnSync(
+            "/bin/chmod",
+            ["+a", "everyone allow write,delete_child,file_inherit,directory_inherit", target],
+            { encoding: "utf8" },
+          );
+          assert.equal(added.error, undefined);
+          assert.equal(added.status, 0, added.stderr);
+          assert.equal(added.stdout, "");
+          const listed = spawnSync("/bin/ls", ["-lde", target], { encoding: "utf8" });
+          assert.equal(listed.error, undefined);
+          assert.equal(listed.status, 0, listed.stderr);
+          assert.equal(listed.stderr, "");
+          assert.match(listed.stdout, /everyone allow .*delete_child/);
+        } else {
+          const added = spawnSync(
+            "/bin/chmod",
+            ["+a", "everyone allow write,delete_child,file_inherit,directory_inherit", root],
+            { encoding: "utf8" },
+          );
+          assert.equal(added.error, undefined);
+          assert.equal(added.status, 0, added.stderr);
+          assert.equal(added.stdout, "");
+        }
+
+        await expectUnavailable(
+          openProfile(root, {
+            hooks: { filesystemKindOverride: "apfs" },
+          }),
+        );
+        if (kind === "inherited") {
+          const listed = spawnSync("/bin/ls", ["-lde", runtime(root)], { encoding: "utf8" });
+          assert.equal(listed.error, undefined);
+          assert.equal(listed.status, 0, listed.stderr);
+          assert.equal(listed.stderr, "");
+          assert.match(listed.stdout, /everyone inherited allow .*delete_child/);
+        }
+      } finally {
+        const cleared = spawnSync("/bin/chmod", ["-RN", root], { encoding: "utf8" });
+        assert.equal(cleared.error, undefined);
+        assert.equal(cleared.status, 0, cleared.stderr);
+        assert.equal(cleared.stdout, "");
+        await rm(root, { recursive: true, force: true });
+      }
     }
   });
 
@@ -1054,15 +1174,23 @@ test("simulated I/O, disk-full, and free-space failures are closed and restart-s
   await t.test("insufficient free space denies recovery before record creation", async () => {
     const root = await repositoryRoot("repository-local-recovery-free-space-");
     try {
-      const requiredFree =
+      const recoveryRequiredFree =
         2 *
         (REPOSITORY_LOCAL_LIMITS.max_recovery_record_bytes +
           REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes);
-      const profile = await openProfile(root, {
+      const startupRequiredFree =
+        2 *
+        (REPOSITORY_LOCAL_LIMITS.max_primary_commit_record_bytes +
+          REPOSITORY_LOCAL_LIMITS.max_identity_record_bytes +
+          REPOSITORY_LOCAL_LIMITS.max_checkpoint_record_bytes);
+      const options = profileOptions(root, {
         hooks: {
-          availableBytesOverride: BigInt(requiredFree - 1),
+          availableBytesOverride: BigInt(startupRequiredFree),
         },
       });
+      const profile = await openRepositoryLocalAuditProfileForQualification(options);
+      assert.equal(profile.diagnostic().state, "healthy");
+      options.filesystemHooks.availableBytesOverride = BigInt(recoveryRequiredFree - 1);
       const fact = recoveryFact();
       await expectUnavailable(profile.journal.append(fact));
       assert.equal(profile.diagnostic().state, "failed");
@@ -1089,6 +1217,7 @@ test("511/512/513 recovery capacity uses the full 16 KiB lifetime reservation", 
     assert.equal(profile.diagnostic().counts.recovery_identities, 511);
     assert.equal(profile.diagnostic().state, "degraded");
     assert.equal(profile.diagnostic().capacity.recovery_bytes, "degraded");
+    await profile.readiness.assertReadyForProviderStart();
 
     const boundary = recoveryFact(511);
     assert.deepEqual(await profile.journal.append(boundary), {
@@ -1098,6 +1227,7 @@ test("511/512/513 recovery capacity uses the full 16 KiB lifetime reservation", 
     assert.equal(profile.diagnostic().state, "failed");
     assert.equal(profile.diagnostic().reason, "capacity_exhausted");
     assert.equal(profile.diagnostic().capacity.recovery_bytes, "exhausted");
+    await expectUnavailable(profile.readiness.assertReadyForProviderStart());
     assert.deepEqual(await profile.journal.append(boundary), {
       durability: "durable",
     });
@@ -1113,6 +1243,7 @@ test("511/512/513 recovery capacity uses the full 16 KiB lifetime reservation", 
     });
     assert.equal(restarted.diagnostic().state, "failed");
     assert.equal(restarted.diagnostic().reason, "capacity_exhausted");
+    await expectUnavailable(restarted.readiness.assertReadyForProviderStart());
     assert.deepEqual(await restarted.journal.append(boundary), {
       durability: "durable",
     });

--- a/test/runtime/repository-local-crash.test.ts
+++ b/test/runtime/repository-local-crash.test.ts
@@ -67,7 +67,7 @@ function options(root: string, later = false) {
     trustedRepositoryRoot: root,
     writerRef: WRITER_REF,
     now: () => new Date(later ? FIXED_LATER : FIXED_NOW),
-    filesystemHooks: { filesystemKindOverride: "apfs" as const },
+    filesystemHooks: { filesystemKindOverride: "ext" as const },
   };
 }
 
@@ -253,7 +253,7 @@ test("record publication and directory sync precede all identity writes", async 
     const profile = await openRepositoryLocalAuditProfileForQualification({
       ...options(root),
       filesystemHooks: {
-        filesystemKindOverride: "apfs",
+        filesystemKindOverride: "ext",
         onEvent: (event) => {
           events.push(event);
         },

--- a/test/runtime/repository-local-crash.test.ts
+++ b/test/runtime/repository-local-crash.test.ts
@@ -1,0 +1,312 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmod, mkdtemp, realpath, rm, unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { AuditError } from "../../packages/audit/src/contract.js";
+import { openRepositoryLocalAuditProfileForQualification } from "../../packages/audit/src/repository-local.js";
+import type { RepositoryLocalFilesystemEvent } from "../../packages/audit/src/repository-local-filesystem.js";
+import {
+  FIXED_LATER,
+  FIXED_NOW,
+  WRITER_REF,
+  candidateDigest,
+  protectedGenesisEvent,
+  recoveryFact,
+} from "./repository-local-test-fixtures.js";
+
+const childPath = fileURLToPath(
+  new URL("./fixtures/repository-local-crash-child.ts", import.meta.url),
+);
+const lockRelativePath = path.join(".yukh", "runtime", "audit-v1", "writer.lock");
+const PRIMARY_BOUNDARIES = [
+  "primary_record.before_temp_create",
+  "primary_record.during_temp_write",
+  "primary_record.after_temp_sync",
+  "primary_record.after_link",
+  "primary_record.after_publish",
+  "primary_record.before_directory_sync",
+  "primary_record.after_directory_sync",
+  "primary_identity.during_temp_write",
+  "primary_identity.after_link",
+  "primary_identity.after_publish",
+  "primary_identity.before_directory_sync",
+  "primary_identity.after_directory_sync",
+] as const;
+const RECOVERY_BOUNDARIES = [
+  "recovery_record.before_temp_create",
+  "recovery_record.during_temp_write",
+  "recovery_record.after_temp_sync",
+  "recovery_record.after_link",
+  "recovery_record.after_publish",
+  "recovery_record.before_directory_sync",
+  "recovery_record.after_directory_sync",
+  "recovery_identity.during_temp_write",
+  "recovery_identity.after_link",
+  "recovery_identity.after_publish",
+  "recovery_identity.before_directory_sync",
+  "recovery_identity.after_directory_sync",
+] as const;
+const DIRECTORY_BOUNDARIES = [
+  "directory.after_create",
+  "directory.after_self_sync",
+  "directory.after_parent_sync",
+] as const;
+const PRIMARY_DIRECTORY_NAMES = ["stream", "commits", "identity"] as const;
+
+async function repositoryRoot(prefix: string): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), prefix));
+  await chmod(root, 0o700);
+  return realpath(root);
+}
+
+function options(root: string, later = false) {
+  return {
+    trustedRepositoryRoot: root,
+    writerRef: WRITER_REF,
+    now: () => new Date(later ? FIXED_LATER : FIXED_NOW),
+    filesystemHooks: { filesystemKindOverride: "apfs" as const },
+  };
+}
+
+async function initialize(root: string): Promise<void> {
+  const profile = await openRepositoryLocalAuditProfileForQualification(options(root));
+  await profile.close();
+}
+
+function crashChild(
+  mode: "primary" | "recovery",
+  root: string,
+  boundary: string,
+  occurrence = 1,
+): void {
+  const result = spawnSync(
+    process.execPath,
+    ["--import", "tsx", childPath, mode, root, boundary, occurrence.toString()],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: process.env,
+      timeout: 30_000,
+    },
+  );
+  assert.equal(
+    result.status,
+    86,
+    `child did not crash at ${boundary}: stdout=${result.stdout} stderr=${result.stderr}`,
+  );
+  assert.equal(result.signal, null);
+}
+
+async function assertPersistentLockThenRemove(root: string): Promise<void> {
+  await assert.rejects(
+    openRepositoryLocalAuditProfileForQualification(options(root, true)),
+    (error: unknown) => error instanceof AuditError && error.code === "audit_unavailable",
+  );
+  await unlink(path.join(root, lockRelativePath));
+}
+
+test("real child-process primary crashes converge at every RFC append boundary", async (t) => {
+  for (const boundary of PRIMARY_BOUNDARIES) {
+    await t.test(boundary, async () => {
+      const root = await repositoryRoot("repository-local-primary-crash-");
+      try {
+        await initialize(root);
+        crashChild("primary", root, boundary);
+        await assertPersistentLockThenRemove(root);
+
+        const profile = await openRepositoryLocalAuditProfileForQualification(options(root, true));
+        const event = protectedGenesisEvent();
+        const committedBeforeCrash =
+          boundary !== "primary_record.before_temp_create" &&
+          boundary !== "primary_record.during_temp_write" &&
+          boundary !== "primary_record.after_temp_sync";
+        assert.equal(
+          (await profile.store.findById(event.event_id)) !== undefined,
+          committedBeforeCrash,
+        );
+        const receipt = await profile.store.append(event, candidateDigest(event));
+        assert.equal(receipt.duplicate, committedBeforeCrash);
+        assert.deepEqual(receipt.event, event);
+        await profile.close();
+
+        const repeated = await openRepositoryLocalAuditProfileForQualification(options(root, true));
+        assert.deepEqual((await repeated.store.findById(event.event_id))?.event, event);
+        assert.equal((await repeated.store.append(event, candidateDigest(event))).duplicate, true);
+        await repeated.close();
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test("real child-process recovery crashes converge at every RFC append boundary", async (t) => {
+  for (const boundary of RECOVERY_BOUNDARIES) {
+    await t.test(boundary, async () => {
+      const root = await repositoryRoot("repository-local-recovery-crash-");
+      try {
+        await initialize(root);
+        crashChild("recovery", root, boundary);
+        await assertPersistentLockThenRemove(root);
+
+        const profile = await openRepositoryLocalAuditProfileForQualification(options(root, true));
+        const committedBeforeCrash =
+          boundary !== "recovery_record.before_temp_create" &&
+          boundary !== "recovery_record.during_temp_write" &&
+          boundary !== "recovery_record.after_temp_sync";
+        const before: string[] = [];
+        for await (const fact of profile.pendingFacts()) before.push(fact.recovery_id);
+        assert.deepEqual(before, committedBeforeCrash ? [recoveryFact().recovery_id] : []);
+        assert.deepEqual(await profile.journal.append(recoveryFact()), {
+          durability: "durable",
+        });
+        const after: string[] = [];
+        for await (const fact of profile.pendingFacts()) after.push(fact.recovery_id);
+        assert.deepEqual(after, [recoveryFact().recovery_id]);
+        await profile.close();
+
+        const repeated = await openRepositoryLocalAuditProfileForQualification(options(root, true));
+        await assert.rejects(
+          repeated.journal.append(
+            recoveryFact(0, {
+              recoveryId: recoveryFact().recovery_id,
+              eventId: "event.recovery-conflict-after-restart",
+            }),
+          ),
+          (error: unknown) =>
+            error instanceof AuditError && error.code === "audit_duplicate_conflict",
+        );
+        assert.equal(repeated.diagnostic().state, "failed");
+        await repeated.close();
+
+        const replay = await openRepositoryLocalAuditProfileForQualification(options(root, true));
+        const replayed: string[] = [];
+        for await (const fact of replay.pendingFacts()) {
+          replayed.push(fact.recovery_id);
+        }
+        assert.deepEqual(replayed, [recoveryFact().recovery_id]);
+        await replay.close();
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test("real child crashes prove every new primary directory link is durable first", async (t) => {
+  for (const boundary of DIRECTORY_BOUNDARIES) {
+    for (const [index, directoryName] of PRIMARY_DIRECTORY_NAMES.entries()) {
+      await t.test(`${directoryName}:${boundary}`, async () => {
+        const root = await repositoryRoot("repository-local-primary-directory-crash-");
+        try {
+          await initialize(root);
+          crashChild("primary", root, boundary, index + 1);
+          await assertPersistentLockThenRemove(root);
+          const profile = await openRepositoryLocalAuditProfileForQualification(
+            options(root, true),
+          );
+          const event = protectedGenesisEvent();
+          assert.equal(await profile.store.findById(event.event_id), undefined);
+          assert.equal(
+            (await profile.store.append(event, candidateDigest(event))).duplicate,
+            false,
+          );
+          await profile.close();
+        } finally {
+          await rm(root, { recursive: true, force: true });
+        }
+      });
+    }
+  }
+});
+
+test("real child crashes prove the recovery identity directory is durable first", async (t) => {
+  for (const boundary of DIRECTORY_BOUNDARIES) {
+    await t.test(boundary, async () => {
+      const root = await repositoryRoot("repository-local-recovery-directory-crash-");
+      try {
+        await initialize(root);
+        crashChild("recovery", root, boundary);
+        await assertPersistentLockThenRemove(root);
+        const profile = await openRepositoryLocalAuditProfileForQualification(options(root, true));
+        const pending: string[] = [];
+        for await (const fact of profile.pendingFacts()) pending.push(fact.recovery_id);
+        assert.deepEqual(pending, []);
+        assert.deepEqual(await profile.journal.append(recoveryFact()), {
+          durability: "durable",
+        });
+        await profile.close();
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test("record publication and directory sync precede all identity writes", async () => {
+  const root = await repositoryRoot("repository-local-ordering-");
+  try {
+    const events: RepositoryLocalFilesystemEvent[] = [];
+    const profile = await openRepositoryLocalAuditProfileForQualification({
+      ...options(root),
+      filesystemHooks: {
+        filesystemKindOverride: "apfs",
+        onEvent: (event) => {
+          events.push(event);
+        },
+      },
+    });
+
+    events.length = 0;
+    const event = protectedGenesisEvent();
+    await profile.store.append(event, candidateDigest(event));
+    const recordWrite = events.indexOf("primary_record.before_temp_create");
+    const recordPublish = events.indexOf("primary_record.after_publish");
+    const recordSync = events.indexOf("primary_record.after_directory_sync");
+    const identityWrite = events.indexOf("primary_identity.before_temp_create");
+    assert(recordWrite >= 0);
+    assert(recordPublish > recordWrite);
+    assert(recordSync > recordPublish);
+    assert(identityWrite > recordSync);
+    assert(events.slice(0, recordWrite).lastIndexOf("directory.after_parent_sync") >= 0);
+
+    events.length = 0;
+    await profile.journal.append(recoveryFact());
+    const pendingWrite = events.indexOf("recovery_record.before_temp_create");
+    const pendingPublish = events.indexOf("recovery_record.after_publish");
+    const pendingSync = events.indexOf("recovery_record.after_directory_sync");
+    const recoveryIdentityWrite = events.indexOf("recovery_identity.before_temp_create");
+    assert(pendingWrite >= 0);
+    assert(pendingPublish > pendingWrite);
+    assert(pendingSync > pendingPublish);
+    assert(recoveryIdentityWrite > pendingSync);
+    assert(events.slice(0, pendingWrite).lastIndexOf("directory.after_parent_sync") >= 0);
+    await profile.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a second real process cannot acquire the live create-exclusive lock", async () => {
+  const root = await repositoryRoot("repository-local-lock-contention-");
+  try {
+    const profile = await openRepositoryLocalAuditProfileForQualification(options(root));
+    const result = spawnSync(
+      process.execPath,
+      ["--import", "tsx", childPath, "expect-lock", root],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: process.env,
+        timeout: 30_000,
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    await profile.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/test/runtime/repository-local-test-fixtures.ts
+++ b/test/runtime/repository-local-test-fixtures.ts
@@ -1,0 +1,177 @@
+import type { ProtectedAuditEvent } from "../../packages/audit/src/contract.js";
+import type { RecoveryFact } from "../../packages/audit/src/lifecycle.js";
+import {
+  computeProtectedEventCandidateDigest,
+  validateRepositoryLocalProtectedEvent,
+} from "../../packages/audit/src/repository-local-contract.js";
+import { AUDIT_GENESIS_HASH, computeAuditEventHash } from "../../packages/audit/src/writer.js";
+
+export const FIXED_NOW = "2026-08-07T12:00:00.000Z";
+export const FIXED_LATER = "2026-08-07T12:00:01.000Z";
+export const WRITER_REF = "writer.repository-local-test";
+export const STREAM_REF = "stream.repository-local-test";
+export const D1 = `sha256:${"1".repeat(64)}`;
+export const D2 = `sha256:${"2".repeat(64)}`;
+export const D3 = `sha256:${"3".repeat(64)}`;
+
+const NULL_CORRELATION = {
+  trace_ref: null,
+  request_ref: null,
+  authorization_request_ref: null,
+  authorization_decision_ref: null,
+  plan_ref: null,
+  approval_ref: null,
+  execution_ref: null,
+  verification_ref: null,
+  rollback_ref: null,
+} as const;
+
+export function protectedGenesisEvent(
+  overrides: Readonly<{
+    eventId?: string;
+    streamRef?: string;
+    subjectRef?: string;
+    committedAt?: string;
+  }> = {},
+): ProtectedAuditEvent {
+  const base = {
+    audit_event_version: 1 as const,
+    event_id: overrides.eventId ?? "event.repository-local-opened",
+    event_type: "audit.stream_opened.v1" as const,
+    classification: "operational" as const,
+    occurred_at: "2026-08-07T11:59:59.000Z",
+    committed_at: overrides.committedAt ?? FIXED_NOW,
+    producer: {
+      component_ref: "component.audit-writer",
+      instance_ref: "instance.repository-local-test",
+    },
+    correlation: NULL_CORRELATION,
+    causation: { parent_event_refs: [] },
+    subject: {
+      ref: overrides.subjectRef ?? "service.repository-local-audit",
+      kind: "system" as const,
+    },
+    capability: {
+      id: "audit.writer",
+      version: "1.0.0",
+      definition_digest: D1,
+    },
+    scope: {
+      resource_kind: "security-domain",
+      resource_set_ref: "resources.repository-local-audit",
+      resource_set_digest: D2,
+      environment_ref: "test",
+    },
+    outcome: { status: "accepted" as const, reason_codes: ["accepted" as const] },
+    payload: {
+      schema_ref: "audit.stream_opened.v1",
+      value: { genesis_hash: AUDIT_GENESIS_HASH },
+    },
+  };
+  const integrityWithoutHash = {
+    stream_ref: overrides.streamRef ?? STREAM_REF,
+    sequence: 0,
+    previous_event_hash: AUDIT_GENESIS_HASH,
+    algorithm: "sha256_chain_v1" as const,
+    writer_ref: WRITER_REF,
+  };
+  return validateRepositoryLocalProtectedEvent({
+    ...base,
+    integrity: {
+      ...integrityWithoutHash,
+      event_hash: computeAuditEventHash({
+        ...base,
+        integrity: integrityWithoutHash,
+      }),
+    },
+  });
+}
+
+export function protectedRequestEvent(
+  previous: ProtectedAuditEvent,
+  index = 1,
+): ProtectedAuditEvent {
+  const base = {
+    audit_event_version: 1 as const,
+    event_id: `event.repository-local-request-${index}`,
+    event_type: "request.accepted.v1" as const,
+    classification: "protected" as const,
+    occurred_at: "2026-08-07T11:59:59.500Z",
+    committed_at: FIXED_NOW,
+    producer: {
+      component_ref: "component.gateway",
+      instance_ref: "instance.repository-local-test",
+    },
+    correlation: {
+      ...NULL_CORRELATION,
+      trace_ref: `trace.repository-local-${index}`,
+      request_ref: `request.repository-local-${index}`,
+    },
+    causation: { parent_event_refs: [] },
+    subject: { ref: "subject.repository-local", kind: "workload" as const },
+    capability: {
+      id: "service.restart",
+      version: "1.0.0",
+      definition_digest: D1,
+    },
+    scope: {
+      resource_kind: "service",
+      resource_set_ref: "resources.repository-local",
+      resource_set_digest: D2,
+      environment_ref: "test",
+    },
+    outcome: { status: "accepted" as const, reason_codes: ["accepted" as const] },
+    payload: {
+      schema_ref: "audit.request_accepted.v1",
+      value: { request_digest: D3 },
+    },
+  };
+  const integrityWithoutHash = {
+    stream_ref: previous.integrity.stream_ref,
+    sequence: previous.integrity.sequence + 1,
+    previous_event_hash: previous.integrity.event_hash,
+    algorithm: "sha256_chain_v1" as const,
+    writer_ref: WRITER_REF,
+  };
+  return validateRepositoryLocalProtectedEvent({
+    ...base,
+    integrity: {
+      ...integrityWithoutHash,
+      event_hash: computeAuditEventHash({
+        ...base,
+        integrity: integrityWithoutHash,
+      }),
+    },
+  });
+}
+
+export function candidateDigest(event: ProtectedAuditEvent): string {
+  return computeProtectedEventCandidateDigest(event);
+}
+
+export function recoveryFact(
+  index = 0,
+  overrides: Readonly<{
+    recoveryId?: string;
+    eventId?: string;
+    observedAt?: string;
+  }> = {},
+): RecoveryFact {
+  return {
+    recovery_fact_version: 1,
+    recovery_id: overrides.recoveryId ?? `recovery.repository-local-${index}`,
+    event_id: overrides.eventId ?? `event.recovery-source-${index}`,
+    event_type: "execution.completed.v1",
+    original_observed_at:
+      overrides.observedAt ?? `2026-08-07T11:${String(index % 60).padStart(2, "0")}:00.000Z`,
+    original_observation_parent_event_ref: `event.recovery-parent-${index}`,
+    cause: "primary_writer_failed_after_provider_start",
+    trace_ref: `trace.recovery-${index}`,
+    request_ref: `request.recovery-${index}`,
+    execution_ref: `execution.recovery-${index}`,
+    plan_digest: D1,
+    attempt: 1,
+    observed_outcome: "effect_observed",
+    withheld_outcome: "completion_unknown",
+  };
+}


### PR DESCRIPTION
Closes #89.

## Deliverable

Implements accepted RFC-0010 `yukh-mcp/repository-local-audit-v1` behind the existing `AuditStore` and `RecoveryJournal` ports:

- closed canonical profile, primary, identity, recovery and checkpoint formats;
- canonical/no-follow filesystem qualification and atomic hard-link no-replace publication;
- persistent create-exclusive writer lock that is never auto-stolen;
- record-directory sync before identity publication;
- deterministic startup, recovery, idempotency/conflict and fail-closed health;
- bounded primary/recovery state, including 8 MiB / 512 identities / 16 KiB lifetime reservation;
- per-stream checkpoints and bounded read-only pending-fact iteration;
- repository-local ignored runtime state.

Real child-process tests cover every primary/recovery publication boundary, new-directory durability and lock exclusion. Qualification also covers canonical paths, symlink/hard-link/mode/ownership/filesystem rejection, corruption/stale state, ENOSPC/ambiguous I/O/free-space denial for primary and recovery, 511/512/513 capacity and zero network/provider calls.

## Evidence

Local validation on exact head `b780afd58cb4b24cb1350f143474b72a57cef9a2`:

- `npm run format:check` — pass
- `npm run typecheck -- --pretty false` — pass
- `npm run build` — pass
- targeted repository-local audit/crash suites — 82/82 pass
- `npm test` — runtime 126/126 pass; contract and supply-chain suites pass
- `mkdocs build --strict --quiet` — pass
- `git diff --check` — pass
- independent final review — three test gaps found and resolved: canonical macOS temp roots, post-restart recovery conflict, and recovery ENOSPC/ambiguous-I/O/free-space qualification

GitHub Actions is unavailable; no remote CI claim is made.

## Explicit non-authorizations

This PR does not implement or authorize recovery import/acknowledgement, retention/deletion, export, network access, gateway/provider registration or mutation, credentials/endpoints, Projects apply, deployment, production use, or a production-readiness claim.
