### PR TITLE
Revise RFC-0011 to accepted Projects Effect B semantics

### DIFF
--- a/.context/rfcs/RFC-0011-sandbox-github-projects-capability.md
+++ b/.context/rfcs/RFC-0011-sandbox-github-projects-capability.md
@@ -1,208 +1,206 @@
-# RFC-0011 - Sandbox GitHub Projects Effect B capability
+# RFC-0011 - Sandbox Projects add-dependency Effect B capability
 
 - Status: Proposed
 - Authors: Copilot
 - Created: 2026-08-09
+- Revised: 2026-08-09
 - Governing issue: https://github.com/nomed/yukh-mcp/issues/96
-- Suite decision: accepted `nomed/nomed.github.io` RFC-0005 on `main` at
-  `12d9215f10c4b7fb1762a5025367e3e81543800f` (PR #42)
+- Suite mission: accepted `nomed/nomed.github.io` RFC-0005 on `main` at
+  `12d9215f10c4b7fb1762a5025367e3e81543800f`
+- Autonomous-maintainer mandate: accepted `nomed/nomed.github.io` RFC-0007 at
+  `bb8628edf7a07c2af56f07e4f9140f58c851ef47`
+- Accepted Projects authority:
+  `nomed/yukh-projects@521be0d0ef1297579e84a6322dea29f80c2549dc`
+- Accepted Projects effects contract:
+  `docs/contracts/first-usable-preview-projects-v1.md`
+- Accepted compound-admission contract:
+  `docs/contracts/mcp-compound-approval-wrapper-v1.md`
 - Depends on: RFC-0001, RFC-0002, RFC-0003, RFC-0004, RFC-0005, RFC-0006,
   RFC-0010
-- Blocked by: https://github.com/nomed/yukh-projects/issues/150
 - Producer baseline:
   `nomed/yukh-projects v1.7.0@71784218366805922e5a12903eef9073f715f59f`
 
-This proposal is a contract-review gate only. It authorizes no implementation,
-registration, discovery, gateway wiring, workflow activation, endpoint,
-credential, OIDC trust, materializer, provider request, GitHub request,
-mutation, restore, deployment, preview tag, or readiness claim.
+This proposal is a contract-review record only. It authorizes no
+implementation, registration, discovery, gateway wiring, workflow activation,
+OIDC trust, materializer, credential, endpoint, provider call, GitHub request,
+mutation, teardown, deployment, release, preview tag, or readiness claim.
 
-RFC-0011 is blocked on acceptance and immutable publication of the
-Yukh Projects compound-approval bridge and MCP-safe controlled-apply wrapper
-contract governed by `nomed/yukh-projects#150`. No MCP registration skeleton or
-provider adapter may be implemented from this proposal while that dependency
-is unresolved.
+The Projects contracts and compound-admission schema are Accepted, but their
+acceptance is specification-only. RFC-0011 remains blocked until Projects
+separately implements and immutably publishes the bridge verifier and
+`runMcpEffectBControlledApplyV1` wrapper artifacts with source commits, artifact
+digests, provenance, SBOM, and conformance evidence. RFC-0011 must then pin
+those exact artifacts and receive its required acceptance before a separate
+implementation issue may proceed.
 
-RFC-0007 through RFC-0009 govern the separate Project 5 / issue 27 migration
-profile. RFC-0008 permanently rejects OIDC materialization only for that fixed
-profile. This RFC proposes a new, disjoint suite-preview sandbox profile and
-does not modify, reactivate, or reuse the Project 5 profile.
+RFC-0007 through RFC-0009 govern the unrelated Project 5 / issue 27 migration
+profile. Its static-token exception is not reused here.
+
+## Author conflict decision
+
+Accepted Projects effects v1 fixes Effect B as capability
+`projects.add-dependency.v1` with exactly one
+`add_dependency(201 blocks 202)` operation. The earlier Proposed RFC-0011
+instead named a status-setting capability. Those operations are not aliases and
+cannot exact-match one plan or approval.
+
+Under Accepted RFC-0007 at
+`bb8628edf7a07c2af56f07e4f9140f58c851ef47`, the author resolves this
+Proposed-versus-Accepted conflict by:
+
+1. **least authority expansion** - use the already accepted dependency
+   capability rather than introduce a second Effect B mutation;
+2. **already-Accepted semantics** - preserve Projects effects v1 exactly;
+3. **compatibility** - keep the Projects plan, approvals, bridge, wrapper,
+   postcondition, teardown, and evidence contracts aligned;
+4. **reversibility** - revise this Proposed record instead of reinterpreting an
+   Accepted operation; and
+5. **smallest diff in authority** - remove the unaccepted status and restore
+   capabilities without adding substitute authority.
+
+The immutable Class B author record for the exact review head is posted to
+governing issue #96. This decision is author-only and review-ready. It does not
+review, accept, merge, implement, or activate RFC-0011.
 
 ## Summary
 
-Define the first Yukh MCP Effect B mutation contract as
-`github.projects.item.status.set@1.0.0`. The capability may set exactly one
-preprovisioned synthetic GitHub Projects item from logical status
-`mcp_pending` to logical status `mcp_verified` in the
-`suite_preview_sandbox` environment. The item, repository, Project, field, and
-option are fixed by a later accepted sandbox deployment profile and cannot be
-selected through capability input.
+Define one Yukh MCP Effect B mutation contract:
+`projects.add-dependency.v1@1.0.0`. The capability may add exactly one
+dependency in the invented suite-preview sandbox:
 
-Effect B is a compound admission with two independent assertions:
+```text
+add_dependency(201 blocks 202)
+```
 
-- the strict MCP `ApprovalReceiptV1` binds the MCP plan, authenticated MCP
-  subject and context, capability definition, and provider identity through the
-  approved plan and operation-set digests; and
-- the strict Yukh Projects `SignedApprovalEnvelope` must bind a distinct
-  Projects plan, scope, operation set, protected environment, producer versions,
-  and the GitHub-observed authenticated principal under an accepted closed
-  schema.
+The repository is `example-org/example-repo`, the synthetic Project is `7`,
+the primary issue is `201`, and the related issue is `202`. These are fixed
+contract fixtures, not caller input and not authority to create or discover
+similarly named live resources.
 
-Neither assertion authorizes the other. An explicit producer-owned,
-independently verifiable cross-binding artifact must prove their exact
-relationship before provider admission. Its schema, canonicalization,
-signature, trust, and field names are not invented here; they are blocked on
-the accepted `nomed/yukh-projects#150` contract.
+Effect B requires one MCP plan `B-MCP` and a distinct nested Projects plan
+`B-Projects`. It also requires two independently authenticated approvals:
 
-The provider boundary is also blocked on an immutable MCP-safe Yukh Projects
-wrapper contract and artifact from that issue. It may execute only one
-`set_field_value` operation produced by a fresh exact Projects plan for logical
-field `status`. The MCP lifecycle owns capability authorization, MCP planning,
-MCP assertion enforcement, bridge enforcement, durable admission, result
-release, and independent verification. Yukh Projects retains authority over
-its assertion, Projects observation, reconciliation-plan semantics, mutation
-allowlisting, provider preconditions, Coordination nonce and fenced lease use,
-and final zero-drift reconciliation.
+- MCP `ApprovalReceiptV1` for `B-MCP`; and
+- the unchanged Projects `SignedApprovalEnvelope` v1 for `B-Projects`.
 
-Effect B is independent from suite RFC-0005 Effect A. It uses a different
-synthetic item and a disjoint operation set, and it shares no plan, approval,
-authorization decision, snapshot, nonce, lease, idempotency key, credential,
-verifier, materialization receipt, or audit chain with Effect A.
+The Accepted authenticated `yukh-projects-approval-bridge-v2` cross-binds both
+approvals, both plans, the fixed target, exact operation, producer and wrapper
+releases, postcondition, principals, nonces, lease bindings, policy, and expiry.
+The bridge is evidence, not authorization. Neither approval authorizes,
+derives, translates, or substitutes for the other.
 
-Restoration is a distinct
-`github.projects.item.status.restore@1.0.0` capability. It requires a fresh
-plan, authorization, approval, one-shot material package, Coordination
-admission, provider attempt, verification, and audit chain. Restore is never an
-implicit undo or automatic response to failure.
+The only permitted Projects boundary is the Accepted
+`runMcpEffectBControlledApplyV1` wrapper contract. The wrapper specification is
+Accepted; no executable wrapper or bridge-verifier artifact is published by
+the pinned authority commit. Direct composition of Projects primitives remains
+forbidden.
 
-## Motivation
-
-The suite RFC accepts component planning and implementation within component
-delivery gates, but the current Yukh MCP boundary remains deliberately inert:
-
-- RFC-0001 requires provider qualification, threat review, and immutable
-  registration evidence before a capability can enter the registry;
-- RFC-0006 says gateway wiring and provider mutation require a later RFC;
-- RFC-0007 adds no MCP capability or gateway provider surface;
-- RFC-0010 authorizes only disabled, network-free audit adapters; and
-- the mutation reference engine and synthetic setting fixture are explicitly
-  unregistered and network-free.
-
-Provider registration would cross new authentication, authorization,
-credential, network, GitHub, audit, verification, and recovery boundaries.
-Those boundaries cannot be inferred from the suite RFC or from the existence of
-the provider-neutral lifecycle engine.
+Effect B is independent from suite Effect A. Effect A uses synthetic issue
+`101` and exactly one `set_field_value(status, backlog -> ready)` operation.
+Effect B uses synthetic issues `201` and `202` and exactly one
+`add_dependency`. The effects share no authority-bearing plan, approval,
+snapshot, nonce, lease, idempotency key, credential, verifier, receipt, or
+audit chain.
 
 ## Goals
 
-- freeze one exact Effect B capability and one exact restore capability;
-- keep the public schemas free of provider identifiers, credentials, endpoints,
-  arbitrary fields, arbitrary values, queries, commands, and workflow inputs;
-- bind the target through one server-owned sandbox profile;
+- freeze one exact Effect B capability, target, operation, and postcondition;
+- preserve Accepted Projects semantics without reinterpretation;
+- keep public input free of target, relationship, provider, credential,
+  endpoint, query, command, workflow, policy, approval, or plan selectors;
 - require distinct planning and apply authorization decisions under RFC-0002;
-- require separately signed and verified MCP and Projects assertions;
-- require an accepted exact cross-binding bridge artifact without making
-  either assertion authority for the other;
-- use one atomic, one-shot OIDC material package with distinct read and write
-  credentials;
-- invoke only a future immutable MCP-safe Yukh Projects wrapper artifact
-  accepted under `nomed/yukh-projects#150`;
-- preserve Yukh Projects nonce, lease, precondition, mutation, and convergence
-  semantics without reimplementation;
-- durably commit all required RFC-0004 evidence and the RFC-0010 attempt
-  reservation before provider start;
-- verify through a separate read-only adapter that does not trust provider
-  output;
+- require separately signed and verified MCP and Projects approvals;
+- pin the Accepted bridge v2 and wrapper contract authority;
+- require future immutable executable artifacts before implementation;
+- preserve Projects nonce, fenced lease, precondition, one-attempt mutation,
+  targeted verification, and zero-drift semantics;
+- durably commit admission evidence before provider start;
+- independently verify the exact dependency postcondition;
 - preserve durable `completion_unknown` and prohibit automatic retry; and
-- make restoration independently governed and conflict detecting.
+- declare rollback unavailable because Accepted Projects contracts do not
+  authorize dependency removal.
 
 ## Non-goals
 
-- register or expose either capability;
-- add a tool to the ordinary gateway or demo;
-- implement a provider, verifier, materializer, approval adapter, identity
-  adapter, Coordination profile, or sandbox;
-- define or implement the producer-owned cross-binding artifact or wrapper;
-- directly compose Yukh Projects internal ports or exported primitives before
-  their MCP-safe wrapper contract is accepted;
-- enable a GitHub Actions workflow or request `id-token: write`;
-- configure OIDC federation, an Actions environment, a materializer origin, a
-  trust root, a Coordination endpoint, a GitHub App, or credentials;
-- call GitHub, Yukh Projects, Coordination, or a materializer;
-- reuse the Project 5 workflow, secret, target, policy, plan, or approval;
-- use `YUKH_PROJECTS_WRITE_TOKEN`, `GH_TOKEN`, or ambient `GITHUB_TOKEN`;
-- add a generic Projects field, GraphQL, REST, workflow-dispatch, shell, or
-  command capability;
-- approve a plan, perform Effect A or Effect B, restore state, deploy, publish a
-  preview, or claim production readiness; or
-- change accepted Yukh Projects planning or controlled-mutation semantics.
+- mark RFC-0011 Accepted;
+- register, expose, implement, invoke, or test a provider;
+- add a gateway tool, resource, prompt, demo path, or registry entry;
+- implement the bridge verifier or wrapper;
+- compose `verifySignedApproval`, `parseProtectedHostCapsule`,
+  `createControlledApplyHostFactory`, or `runApplyEntrypoint` in MCP;
+- enable OIDC, a workflow, `id-token: write`, a materializer, trust root,
+  Coordination endpoint, credential, GitHub App, or network path;
+- call GitHub, Projects, Coordination, or a materializer;
+- create or discover the invented repository, Project, or issues;
+- remove a dependency, restore state, or use effect authority for teardown;
+- reuse Effect A or Project 5 authority;
+- expose generic Projects, relationship, GraphQL, REST, workflow-dispatch,
+  shell, command, or HTTP capabilities;
+- publish an implementation artifact, release, deployment, or readiness claim;
+  or
+- change Accepted Projects planning, approval, controlled-apply, or teardown
+  semantics.
 
-## Preview profile
+## Fixed preview profile
 
-The logical profile identifier is
-`yukh-mcp/suite-preview-effect-b-status-v1`.
+The logical profile is
+`yukh-mcp/suite-preview-effect-b-add-dependency-v1`. It binds exactly:
 
-The profile binds exactly:
-
-- environment `suite_preview_sandbox`;
-- resource kind `github_project_item`;
-- one canonical logical resource reference `preview_effect_b_item`;
-- one preprovisioned synthetic repository, Project, issue, item, and single
-  select field resolved only from trusted deployment configuration;
-- logical field key `status`;
-- initial option key `mcp_pending`;
-- intended option key `mcp_verified`;
-- one native Yukh Projects `set_field_value` operation;
+- logical environment `suite_preview_sandbox`;
+- resource kind `github_issue_dependency`;
+- logical resource `preview_effect_b_dependency_201_blocks_202`;
+- invented repository `example-org/example-repo`;
+- invented Project `7`;
+- primary issue `201`;
+- related issue `202`;
+- relationship direction `201 blocks 202`;
+- capability `projects.add-dependency.v1@1.0.0`;
+- one Projects operation `add_dependency(201 blocks 202)`;
+- MCP plan `B-MCP`;
+- nested Projects plan `B-Projects`;
+- MCP Approval `B-MCP`;
+- Projects Approval `B-Projects`;
+- the canonical Accepted `effectBPostconditionBinding`;
+- bridge schema `yukh-projects-approval-bridge-v2`;
+- bridge profile `suite-preview-effect-b-v1`;
+- wrapper entrypoint contract `runMcpEffectBControlledApplyV1`;
+- wrapper entrypoint version `mcp-effect-b-controlled-apply-v1`;
 - Yukh Projects mode `apply`;
-- Yukh Projects v1.7.0 source commit
+- internal reconciliation mode `native-v1`;
+- producer baseline
   `71784218366805922e5a12903eef9073f715f59f`;
-- release artifact `yukh-projects-apply-library-1.7.0.js` with SHA-256
+- producer apply artifact `yukh-projects-apply-library-1.7.0.js` with SHA-256
   `e37a6d50f0cc862b4f8c68ec5b9be2386184a69c6800fcbb98cc132e46ffa9a2`;
-- the accepted v1.7.0 controlled-apply entrypoint, reconciliation-plan,
-  controlled-mutations, and protected-host-capsule contracts; and
-- a future immutable wrapper contract and artifact accepted under
-  `nomed/yukh-projects#150`, with separately recorded source and artifact
-  digests; and
-- one fixed policy commit and one fixed protected qualification workflow
-  identity selected by a later accepted deployment profile.
+  and
+- future immutable bridge-verifier, wrapper, MCP verifier, target-profile,
+  policy, and deployment bindings selected only by later accepted records.
 
-The concrete provider-native repository, Project, issue, item, field, and
-option identifiers are restricted deployment inputs. They are bound into
-protected digests but never capability input, public output, logs, issue text,
-repository policy examples, or public evidence.
+The invented fixture identifiers are immutable contract values. They are
+neither capability input nor permission to access provider state.
 
-The three environment domains remain distinct and are bound explicitly:
+The environment domains remain distinct:
 
-- MCP policy uses logical environment `suite_preview_sandbox`;
-- the accepted Yukh Projects reconciliation-plan operation remains
-  `environment: dry-run`; and
-- the approval, OIDC assertion, materializer policy, host capsule, and
-  controlled-apply entrypoint use one fixed protected workflow environment
-  selected by the later deployment profile.
+- MCP policy uses `suite_preview_sandbox`;
+- the Projects reconciliation operation retains its accepted planner
+  environment semantics; and
+- approvals, protected host, and controlled apply use one later fixed protected
+  workflow environment.
 
-No component infers one environment value from another or treats equality of
-display names as authority.
+No display-name equality grants authority.
 
-The suite compatibility matrix must prove that Effect A has a different item
-and does not contain the Effect B `status -> mcp_verified` operation. A shared
-repository, Project, compatibility matrix, or test window is not an
-authority-bearing binding.
-
-## Capability definitions
-
-### Set capability
+## Capability definition
 
 The exact RFC-0001 logical definition is:
 
 ```yaml
 contract_version: 1
 capability:
-  id: github.projects.item.status.set
+  id: projects.add-dependency.v1
   version: 1.0.0
-  summary: Mark one fixed suite-preview Project item as MCP verified
+  summary: Add the fixed suite-preview dependency from issue 201 to issue 202
   stability: experimental
 resource:
-  kinds: [github_project_item]
+  kinds: [github_issue_dependency]
   cardinality: one
 environment:
   required: true
@@ -214,29 +212,23 @@ input:
   schema:
     type: object
     additionalProperties: false
-    required: [expected_status, desired_status]
-    properties:
-      expected_status:
-        type: string
-        enum: [mcp_pending]
-        maxLength: 11
-      desired_status:
-        type: string
-        enum: [mcp_verified]
-        maxLength: 12
+    properties: {}
 output:
   schema:
     type: object
     additionalProperties: false
-    required: [changed, status, observation_ref, zero_drift]
+    required: [changed, relationship, dependency_present, observation_ref, zero_drift]
     properties:
       changed:
         type: boolean
         const: true
-      status:
+      relationship:
         type: string
-        enum: [mcp_verified]
-        maxLength: 12
+        enum: [blocks]
+        maxLength: 6
+      dependency_present:
+        type: boolean
+        const: true
       observation_ref:
         type: string
         pattern: "^[a-z][a-z0-9_.-]{0,127}$"
@@ -257,7 +249,7 @@ execution:
   timeout_ms: 120000
   max_attempts: 1
   concurrency: exclusive_scope
-  max_input_bytes: 128
+  max_input_bytes: 2
   max_output_bytes: 1024
 idempotency:
   classification: keyed
@@ -267,141 +259,39 @@ retry:
 verification:
   mode: required
   postconditions:
-    - project_item_status_matches
+    - projects_dependency_201_blocks_202_present
     - projects_fresh_zero_drift
 rollback:
-  mode: restore
+  mode: unavailable
+  rationale: Accepted Projects contracts do not authorize dependency removal.
+  recovery: Preserve the effect outcome and use separately governed sandbox teardown.
+  stop_conditions:
+    - dependency state is unknown or cannot be independently observed
+    - teardown authority or final-state verification is unavailable
+    - any reverse mutation would be required
 errors:
   taxonomy_version: 1
 ```
 
 The request must name exactly capability version `1.0.0`, logical resource
-`preview_effect_b_item`, environment `suite_preview_sandbox`, and the two enum
-input values above. Resource identity, owner, repository, Project, issue, item,
-field, option, policy path, workflow, endpoint, provider mode, credential,
-approval, nonce, lease, plan, query, and mutation document cannot be supplied
-through input.
+`preview_effect_b_dependency_201_blocks_202`, logical environment
+`suite_preview_sandbox`, and input `{}`. It cannot supply or override either
+issue, repository, Project, relationship direction, provider mode, policy,
+approval, plan, target, credential, endpoint, query, mutation document,
+postcondition, or teardown.
 
-The result is released only when `changed` and `zero_drift` are true, `status`
-is `mcp_verified`, and both registered postconditions independently verify.
-Prior convergence produces no Effect B mutation plan and cannot be presented as
-the consequential Effect B execution required by the suite RFC.
+Success requires `changed: true`, `relationship: blocks`,
+`dependency_present: true`, `zero_drift: true`, and both registered
+postconditions. The canonical postcondition digest must exact-match
+`effectBPostconditionBinding` in both Effect B approvals and bridge.
 
-### Restore capability
+Prior convergence produces no consequential Effect B plan and cannot be
+presented as the required effect execution.
 
-The exact restore definition is:
-
-```yaml
-contract_version: 1
-capability:
-  id: github.projects.item.status.restore
-  version: 1.0.0
-  summary: Restore one fixed suite-preview Project item from an exact snapshot
-  stability: experimental
-resource:
-  kinds: [github_project_item]
-  cardinality: one
-environment:
-  required: true
-operation:
-  model: typed
-  class: mutate
-  effects: [update]
-input:
-  schema:
-    type: object
-    additionalProperties: false
-    required:
-      - source_snapshot_digest
-      - original_execution_ref
-      - original_execution_digest
-      - original_plan_digest
-    properties:
-      source_snapshot_digest:
-        type: string
-        pattern: "^sha256:[0-9a-f]{64}$"
-        minLength: 71
-        maxLength: 71
-      original_execution_ref:
-        type: string
-        pattern: "^[a-z][a-z0-9_.-]{0,127}$"
-        minLength: 1
-        maxLength: 128
-      original_execution_digest:
-        type: string
-        pattern: "^sha256:[0-9a-f]{64}$"
-        minLength: 71
-        maxLength: 71
-      original_plan_digest:
-        type: string
-        pattern: "^sha256:[0-9a-f]{64}$"
-        minLength: 71
-        maxLength: 71
-output:
-  schema:
-    type: object
-    additionalProperties: false
-    required: [changed, status, observation_ref, zero_drift]
-    properties:
-      changed:
-        type: boolean
-      status:
-        type: string
-        enum: [mcp_pending]
-        maxLength: 11
-      observation_ref:
-        type: string
-        pattern: "^[a-z][a-z0-9_.-]{0,127}$"
-        minLength: 1
-        maxLength: 128
-      zero_drift:
-        type: boolean
-risk:
-  level: high
-  data_classes: [synthetic_project_metadata]
-mutation:
-  mode: planned
-  destructive: false
-approval:
-  mode: explicit
-execution:
-  timeout_ms: 120000
-  max_attempts: 1
-  concurrency: exclusive_scope
-  max_input_bytes: 512
-  max_output_bytes: 1024
-idempotency:
-  classification: keyed
-  key: required
-retry:
-  policy: never
-verification:
-  mode: required
-  postconditions:
-    - project_item_status_matches_source_snapshot
-    - projects_fresh_zero_drift
-rollback:
-  mode: unavailable
-  rationale: A second automatic restore could overwrite newer valid state.
-  recovery: Reconcile current state, then create a separately approved operator plan.
-  stop_conditions:
-    - current state differs from the exact restore precondition
-    - original execution or source snapshot binding cannot be verified
-    - outcome of this restore attempt is unknown
-errors:
-  taxonomy_version: 1
-```
-
-The restore planner resolves the prior value only from the exact protected
-source snapshot bound to the original plan and execution. Version 1 accepts a
-source value only when it is `mcp_pending` and the current value is exactly
-`mcp_verified`. A changed item, field, option, policy, original binding, or
-intervening legitimate state invalidates the restore plan. The requester cannot
-supply a replacement value.
-
-Restore's own rollback is `unavailable`: another automatic compensation chain
-would create recursive authority and could overwrite newer state. Failure or
-unknown restore completion requires operator reconciliation.
+Rollback is unavailable. Accepted Projects contracts do not authorize
+`remove_dependency`, and source rollback is never provider-state rollback.
+Teardown is owned by the separately governed sandbox boundary; it is not an MCP
+capability, Projects plan, compensation, or automatic response to failure.
 
 ## Planning and authorization
 
@@ -410,532 +300,403 @@ one-shot enforcement receipts.
 
 Planning proceeds only after:
 
-1. the authenticated subject is derived server-side;
-2. the exact definition, environment, profile, resource, and input validate;
-3. trusted resolvers produce the one canonical target and attribute snapshot;
-4. an exact current policy bundle is evaluated;
-5. the combined decision is `allow` with basis `explicit`;
-6. every constraint and planning obligation is enforceable; and
-7. a read-only Projects adapter produces a fresh bounded target snapshot.
+1. the authenticated MCP subject is derived server-side;
+2. the exact definition, profile, environment, resource, and empty input
+   validate;
+3. trusted resolvers produce the fixed invented target binding;
+4. a current policy bundle explicitly allows planning;
+5. every constraint and obligation is enforceable; and
+6. a read-only Projects adapter proves issues `201` and `202` are distinct,
+   belong to the same invented repository, the dependency is absent, and adding
+   it cannot create a cycle.
 
-No applicable allow, explicit deny, stale data, missing dependency, evaluator
-error, unknown field, conflicting constraint, unsupported obligation, or
-indeterminate result is a denial and produces no provider call.
+Any deny, missing allow, stale data, unknown field, dependency failure,
+conflicting constraint, unsupported obligation, or indeterminate result denies
+with zero provider calls.
 
-The MCP planner creates one RFC-0003 plan with one update step. Its operation
-digest binds the fixed profile, capability definition, normalized input,
-logical target, policy commit, Yukh Projects producer and future wrapper
-contract/artifact digests, fresh Projects plan ID, ordered one-operation digest,
-target snapshot, declared provider mode, Coordination epoch, verifier
-identities, and postconditions. The MCP `ApprovalReceiptV1` binds that exact
-plan and operation-set digest; it does not acquire Projects assertion semantics.
+The MCP planner creates `B-MCP` with one fixed update step. Its operation digest
+binds the definition, profile, empty input, fixed target, policy, Accepted
+Projects contract authority, future producer/wrapper/verifier artifact digests,
+nested plan `B-Projects`, exact one-operation digest, target snapshot,
+Coordination epoch, verifier identities, and postcondition.
 
-The embedded Projects plan must be executable, contain no diagnostic, contain
-exactly one `set_field_value` operation for logical field `status`, require the
-exact old value, and propose the exact desired option. Any schema creation,
-option creation, relationship, issue-type, additional field, clear, delete,
-remove, archive, batch, or second item operation invalidates the MCP plan.
+`B-Projects` must be fresh, executable, diagnostic-free, and contain exactly:
 
-Immediately before provider start, MCP obtains a new RFC-0002 apply decision
-from current server state. It must be distinct from the planning decision,
-issued after approval, explicitly allow the same exact bindings, and have every
-constraint and obligation enforced. Authentication, discovery, planning allow,
-approval, materialization, Coordination success, workflow admission, or
-provider capability cannot substitute for this decision.
+```text
+add_dependency(201 blocks 202)
+```
+
+Any field, schema, option, parent, Issue Type, second relationship, reversed
+relationship, different issue, caller-selected operation, delete, archive,
+batch, or second target invalidates both plans.
+
+Immediately before provider start, MCP obtains and enforces a fresh distinct
+apply authorization decision over the same exact bindings. Authentication,
+discovery, planning allow, approval, bridge possession, materialization,
+Coordination, credentials, workflow admission, or wrapper availability cannot
+substitute for that decision.
 
 ## Compound approval and bridge
 
-Effect B admission requires two separately signed, separately verified
-assertions plus one explicit reviewed cross-binding artifact.
+Effect B admission requires all three independently authenticated artifacts:
 
-### MCP assertion
+1. MCP `ApprovalReceiptV1` for `B-MCP`;
+2. unchanged Projects `SignedApprovalEnvelope` v1 for `B-Projects`; and
+3. authenticated `yukh-projects-approval-bridge-v2`.
 
-The MCP assertion is exactly the closed RFC-0003 `ApprovalReceiptV1`. It binds
-the exact MCP plan and digest, authenticated MCP subject and authentication
-context, capability definition, normalized input, resource set, environment,
-policy, target snapshot, and operation-set digest. The MCP plan operation digest
-also binds the future accepted wrapper identity and artifact digest, so the
-strict assertion covers the provider without adding fields to its schema.
+The MCP approval is verified only by the MCP-selected approval adapter and
+trust profile. The Projects approval is verified only by the Projects-selected
+v1 verifier and trust profile. Their subjects, authentication contexts,
+schemas, signers, trust roots, nonces, verification receipts, and authority
+remain distinct.
 
-The MCP assertion is verified only by the MCP approval adapter against an
-MCP-selected trust profile. Its nonce digest is distinct from the Projects
-nonce, is consumed only by the MCP lifecycle reservation/enforcement path, and
-never crosses into Yukh Projects as provider approval.
+The bridge contract is accepted at
+`nomed/yukh-projects@521be0d0ef1297579e84a6322dea29f80c2549dc`.
+Its closed wire schema, canonicalization, Ed25519 authentication, 32 KiB size
+limit, six-object depth limit, 15-minute maximum lifetime, exact field set,
+replay rules, and stable failures are authoritative. MCP must not invent,
+extend, translate, wrap, or partially validate it.
 
-### Projects assertion
+The bridge exact-matches at least:
 
-The Projects assertion is exactly the immutable producer's closed
-`SignedApprovalEnvelope` and `ApprovalClaims` schema, or a separately accepted
-version from `nomed/yukh-projects#150`. It binds the distinct Projects plan and
-operation digest, repository/Project/issue scope, `environment: apply`,
-protected environment, producer contract/planner/snapshot/entrypoint versions,
-expiry, nonce, key fingerprint, issuer, and Projects `subjectRef`.
+- both approval and plan digests;
+- both ordered operation-set digests;
+- authenticated MCP subject and context;
+- host-attested Projects principal;
+- fixed target and postcondition binding;
+- producer, wrapper, MCP verifier, target-profile, and policy digests;
+- distinct MCP and Projects nonce bindings;
+- Projects lease scope, holder, and Coordination epoch;
+- environment, protected environment, issuer, subject, trust root, and expiry.
 
-The upstream contract must define how `subjectRef` is derived from and bound to
-the GitHub-observed authenticated principal. RFC-0011 does not reinterpret that
-opaque value or add identity fields to the closed v1.7.0 assertion. The Projects
-assertion is verified only under the Projects-selected trust profile and is the
-only assertion presented to the controlled-apply producer.
+The bridge is evidence, not approval, authorization, credential, lease
+capability, provider result, or permission to invoke either component. Any
+missing, stale, replayed, substituted, incomparable, noncanonical, unauthenticated,
+or mismatched artifact denies before provider access.
 
-### Cross-binding bridge
+## Wrapper contract and artifact blocker
 
-Neither assertion can be parsed as, converted into, or substituted for the
-other. Their actors, subjects, plans, schemas, nonces, trust roots, verification
-receipts, and authority remain distinct.
+The Accepted MCP-safe wrapper contract exposes only:
 
-Before MCP apply admission, a producer-owned bridge artifact must establish
-exact equality or an explicitly accepted mapping across the MCP plan, Projects
-plan, fixed target, disjoint Effect B operation set, environments, policy
-commit, producer/wrapper identities, expiry window, and authenticated principals.
-The bridge is evidence of an exact compound relationship; it is not an
-approval, bearer capability, credential, authorization decision, or permission
-to invoke either component.
+```typescript
+runMcpEffectBControlledApplyV1(
+  invocation: McpEffectBControlledApplyInvocationV1,
+): Promise<McpEffectBControlledApplyResultV1>
+```
 
-The bridge artifact's identifier, schema fields, canonical bytes, signature
-domain, issuing authority, trust root, expiry, replay semantics, and validation
-API must be defined and accepted by `nomed/yukh-projects#150`. Until then, this
-RFC is blocked. MCP must not invent an extension object, overload assertion
-fields, compare only human-readable summaries, or trust a materializer-created
-ad hoc mapping.
+Its private invocation consists only of one-attempt, host-created,
+nonserializable, nonenumerable, single-use handles for verified MCP admission,
+Projects approval and trust, bridge and trust, protected capsule, distinct read
+and write credentials, and abort.
 
-Neither assertion or bridge is shared with Effect A. Approval cannot be inferred
-from authentication, chat, issue or Project state, workflow dispatch,
-environment review, OIDC claims, package retrieval, credential possession,
-Coordination outcome, provider response, or test status. Private signing keys
-never enter MCP, GitHub Actions, Yukh Projects, repository content, or evidence.
+The immutable wrapper release must fix capability
+`projects.add-dependency.v1`, profile
+`yukh-mcp/suite-preview-effect-b-add-dependency-v1`, the exact target, one
+`add_dependency(201 blocks 202)` operation, policy, producer, bridge, MCP
+verifier, transports, and result mapping. No caller may select a repository,
+Project, issue, relationship, operation, mode, provider, credential, endpoint,
+URL, query, document, verifier, or transport.
 
-## One-shot OIDC materialization
+The contract owns the reviewed sequence:
 
-The only proposed credential path is the OIDC-bound one-shot shape accepted by
-suite RFC-0005. A later deployment profile must fix the workflow file and
-commit, protected environment, repository identity, audience, materializer
-origin and trust, package schema, credential issuers and permissions, expiry,
-and teardown.
+1. verify the MCP approval and mint a single-use verified handle;
+2. authenticate and exact-match bridge v2;
+3. call `verifySignedApproval` on the unchanged Projects v1 assertion before
+   any provider-backed host construction;
+4. parse the protected capsule;
+5. require `apply-explicitly-enabled`, approved kind `add_blocked_by`, and
+   one-operation ceilings;
+6. create the fixed controlled-apply host once;
+7. exact-match the fresh one-operation plan;
+8. call `runApplyEntrypoint` once; and
+9. close every private handle without rewriting the effect outcome.
 
-The protected qualification workflow obtains one OIDC assertion. A fixed
-materializer verifies at least repository identity, workflow ref and digest,
-environment, event, run ID, run attempt equal to one, policy commit, MCP plan
-digest, Projects plan ID, both assertion digests, the accepted bridge artifact
-digest, operation-set digest, wrapper identity, profile, audience, issue and
-expiry. It then atomically returns one closed package no
-larger than 64 KiB containing:
+MCP may invoke only a future immutable implementation of that wrapper. It may
+not call Projects primitives directly or use a CLI, Action runner, workflow
+dispatcher, shell, dynamic import, package installer, generic HTTP client,
+GitHub SDK, GraphQL client, or REST client.
 
-1. one short-lived GitHub read credential;
-2. one distinct short-lived GitHub write credential;
-3. the exact signed MCP assertion and its independently selected trust root;
-4. the exact signed Projects assertion and its independently selected trust root;
-5. the accepted cross-binding bridge artifact and its trust material;
-6. one bounded Yukh Projects protected host capsule; and
-7. one single-use package receipt bound to the exact run and both plans.
+The pinned Projects commit accepts this contract but explicitly adds no
+executable export or release artifact. Implementation remains blocked until a
+separately reviewed Projects change publishes:
 
-The package is retrieved once with one direct TLS request, one deadline, no
-redirect, proxy discovery, refresh, polling, fallback, or retry. An ambiguous
-retrieval consumes the run and requires a new plan, approval, run, and package.
-It cannot trigger provider execution.
+- immutable bridge-verifier and wrapper source commits;
+- lowercase SHA-256 artifact digests;
+- protected-build provenance and SPDX SBOM;
+- reproducible-build evidence;
+- pinned producer, MCP verifier, target-profile, policy, and toolchain
+  bindings;
+- canonical and adversarial conformance vectors;
+- zero-provider-call evidence for every admission failure;
+- one-attempt and durable `completion_unknown` evidence; and
+- bounded redaction evidence.
 
-Materialization occurs before MCP can validate the assertions because the
-package delivers them and their independently selected trust roots. Retrieval
-itself grants no MCP authorization. MCP validates the package, verifies only
-the MCP assertion through its approval adapter, verifies the bridge through the
-accepted bridge validator, obtains and enforces the fresh apply authorization,
-reserves the attempt, and commits required audit evidence before the provider
-receives either credential. The wrapper independently verifies the Projects
-assertion through the accepted Projects verifier.
+RFC-0011 must pin those published values before any implementation review.
 
-Assertion, bridge, and trust-root files are private bounded regular files or
-equivalently bounded handles. The host capsule remains below the accepted Yukh
-Projects limit. Credentials are masked before any consumer step. The read
-credential is available only to fixed read adapters and the write credential
-only to the fixed controlled mutation transport. Both are removed in an
-unconditional finalizer. Cleanup failure cannot erase a possible effect and
-becomes operator-review evidence.
+## OIDC and credentials
 
-Repository inputs, environment variables, command arguments, workflow inputs,
-outputs, artifacts, caches, summaries, logs, errors, audit events, and model
-context contain no credential, token, key, proof, assertion bytes, bridge bytes,
-host capsule, package, receipt secret, endpoint, or provider identifier.
+This proposal preserves the suite's one-shot OIDC shape as a future deployment
+constraint only. It creates no OIDC trust, workflow permission, materializer,
+credential, or endpoint.
 
-## Coordination nonce and lease
+A later accepted deployment record must fix the workflow, commit, protected
+environment, repository identity, audience, materializer trust, package
+schema, issuers, permissions, expiry, and teardown. One atomic package may
+contain distinct short-lived read and write handles plus the exact approvals,
+bridge, trust material, capsule, and receipt. Retrieval grants no
+authorization, may not retry, and cannot trigger provider execution.
 
-Yukh Projects controlled apply remains authoritative for consuming the Projects
-assertion nonce and acquiring the repository-Project-issue fenced lease through
-the accepted protected host capsule. MCP must not preconsume that nonce or
-acquire a competing lease, because that would make the immutable producer
-reject the only attempt.
+Secrets, assertions, bridge bytes, trust material, capsules, packages,
+credentials, endpoints, and provider identifiers remain excluded from
+repository input, environment variables, command arguments, workflow output,
+artifacts, caches, summaries, logs, errors, audit, and model context.
 
-Before provider start, MCP independently:
+## Coordination, durable admission, and audit
 
-- consumes the distinct MCP assertion nonce through its own one-shot durable
-  lifecycle enforcement;
-- binds both assertion digests, both nonce digests, the accepted bridge digest,
-  positive Coordination epoch, lease scope digest, holder digest, and expected
-  provider operation into its durable reservation and audit records;
-- validates that the closed host capsule matches the approved profile and exact
-  protected binding; and
-- proves that no package, nonce, lease, or capability from Effect A is present.
+Projects remains the sole consumer of the Projects approval nonce and sole
+owner of the repository-Project-issue fenced lease. MCP consumes only its
+distinct nonce and must not acquire a competing lease.
 
-During the one provider attempt, the immutable Projects host:
+Before provider start, MCP durably commits:
 
-1. performs its complete fresh preflight;
-2. verifies the Projects assertion and consumes its exact nonce once;
-3. acquires the exact fenced lease;
-4. re-observes and recreates the same Projects plan;
-5. sends at most one allowlisted mutation request; and
-6. verifies and releases the lease under its accepted semantics.
-
-Only `consumed` and `acquired` satisfy the respective producer gates. Replay,
-conflict, stale epoch or fence, lease loss, malformed response, timeout, or
-Coordination unavailability stops without retry. Nonce or lease success is not
-approval, MCP authorization, provider success, or verification.
-
-## Provider boundary and upstream wrapper dependency
-
-The future provider is a Yukh MCP-owned adapter behind
-`LifecycleEffectPort`. It receives only the exact immutable MCP plan, execution
-reference, attempt number one, abort signal, and private runtime handles created
-from the validated package.
-
-The immutable v1.7.0 apply artifact actually exports
-`parseProtectedHostCapsule`, `createControlledApplyHostFactory`, and
-`runApplyEntrypoint`. The accepted v1.7.0 data flow parses the protected capsule,
-passes its bounded options into `createControlledApplyHostFactory`, calls the
-factory's `create` method with reconciliation mode `native-v1`, fixed requested
-scope, fixed policy source, and distinct read/write tokens, then passes the
-returned `scope` and `host` with the approved Projects plan ID, protected
-environment, Projects assertion, and Projects public key to
-`runApplyEntrypoint`.
-
-Those exports are producer primitives, not a reviewed MCP provider API.
-v1.7.0 does not export one function that accepts the compound admission,
-validates the bridge, fixes every host input, and returns one MCP-safe closed
-outcome. Direct consumer composition would create unreviewed glue across
-credentials, policy, host construction, approval, Coordination, network, and
-result mapping.
-
-RFC-0011 is therefore blocked on `nomed/yukh-projects#150`, which must accept
-and immutably publish one reproducible wrapper contract/artifact. The wrapper
-must own the exact composition above, accept the Projects assertion and accepted
-bridge only through closed bounded inputs, fix native mode and target scope,
-validate the bridge before provider access, and expose one narrow exported
-function with closed stable outcomes. Its source commit, artifact digest,
-provenance, SBOM, and conformance vectors become mandatory profile bindings.
-
-The MCP adapter may invoke only that future wrapper function. It may not invoke
-the v1.7.0 primitives directly, or invoke a CLI, shell, workflow dispatcher,
-generic Action runner, dynamic import path, package installer, GraphQL client,
-REST client, HTTP client, or GitHub SDK. It cannot construct a query, URL,
-method, header, mutation document, provider identifier, or credential.
-
-The wrapper receives fixed native mode `apply`, exact protected scope, policy
-commit, approved Projects plan ID, Projects assertion and trust-root handles,
-accepted bridge handle, host capsule handle, and distinct credential handles.
-It rejects any input or result that reports:
-
-- a different plan ID, scope, mode, producer, operation set, or target;
-- more than one operation;
-- an operation other than `set_field_value` for logical `status`;
-- any retry, deferral after provider start, continuation, partial selector, or
-  credential substitution;
-- an unknown diagnostic, nonzero remaining drift, or unverifiable output; or
-- provider-native identifiers or forbidden content.
-
-The adapter maps only closed producer outcomes to RFC-0003 step states. A
-producer return is an observation, never proof of MCP success.
-
-## Durable admission and audit
-
-The RFC-0010 repository-local lifecycle ledger and audit profile are candidate
-components for the ephemeral preview only. Their known single-process,
-same-host, finite-capacity, unwitnessed, and non-production limitations remain.
-A later operational gate must prove that those limitations are acceptable for
-the sandbox or select another accepted profile.
-
-Before provider start, the runtime must durably commit:
-
-- request, planning authorization evaluation, decision, and enforcement;
+- request and planning authorization evidence;
 - plan creation;
-- approval request and approval verification;
-- apply authorization evaluation, decision, and enforcement;
+- approval request and verification;
+- bridge verification;
+- fresh apply authorization evidence;
 - apply admission; and
 - the exact execution-attempt reservation.
 
-The attempt reservation binds the package receipt digest, MCP and Projects
-assertion digests and distinct nonce digests, accepted bridge artifact digest,
-Coordination epoch and scope digest, producer and wrapper artifact digests,
-both plan and operation-set digests, verifier identities, and Effect B
-disjointness evidence through accepted bounded references or obligation
-receipts. If the existing closed audit schemas cannot represent a required
-binding without weakening or omission, implementation is blocked pending a
-separate accepted RFC-0004 registry extension.
+The reservation binds the package receipt, both approval and nonce digests,
+bridge digest, Coordination epoch and lease digests, producer/wrapper/verifier
+artifact digests, both plans and operation sets, postcondition, target, and
+Effect A/B disjointness evidence.
 
-Audit readiness, health, capacity, classification, canonical validation, or
-commit failure before provider start denies, drops private handles, runs the
-unconditional cleanup path, and makes no provider call. Audit failure after
-possible provider start appends the accepted durable recovery fact, withholds
-success, records `completion_unknown`, and never retries.
+If existing RFC-0004 schemas cannot carry a required binding without omission,
+implementation is blocked pending a separately accepted registry extension.
+Audit unavailability before provider start denies with zero provider calls.
+Audit failure after possible effect withholds success, records durable
+`completion_unknown`, and never retries.
 
-Audit evidence contains only allowlisted references, digests, states, stable
-reason codes, counts, and duration buckets. It excludes raw MCP input,
-approval, credentials, OIDC claims, package, capsule, nonce, lease capability,
-provider observations, GitHub identifiers, URLs, queries, responses, errors,
-private timestamps, and synthetic item content.
+Evidence contains only allowlisted references, digests, states, stable reason
+codes, counts, and duration buckets. It excludes private identifiers, raw
+artifacts, target content, provider observations, queries, responses, errors,
+and timestamps.
 
 ## Independent verification
 
-MCP verification is separate from the provider and from the provider's own
-targeted and final convergence checks. It uses a separately constructed
-read-only adapter and cannot access the write credential, mutation transport,
-provider internals, provider response body, or cached provider observation.
+Projects controlled apply performs its accepted targeted verification and
+fresh final zero-operation reconciliation. That result is still only a provider
+observation to MCP.
 
-After an `effect_observed` provider result, the verifier:
+After `effect_observed`, a separate MCP read-only verifier:
 
-1. re-resolves the exact logical Effect B target from trusted profile state;
-2. obtains a fresh read-only Projects observation;
-3. verifies logical status `mcp_verified`;
-4. reruns the exact accepted Projects planner against the fixed policy;
-5. requires an executable plan with zero operations and zero diagnostics;
-6. binds the observation and zero-drift plan to the execution, MCP plan, fresh
-   apply authorization, resource, environment, producer, and verifier digests;
-7. emits only bounded evidence references; and
-8. permits success release only after terminal durable audit commit.
+1. re-resolves the fixed invented Effect B target;
+2. obtains a fresh observation independent of provider output;
+3. proves dependency `201 blocks 202` is present;
+4. reruns the Accepted Projects planner against the fixed policy;
+5. requires zero operations and zero diagnostics;
+6. exact-matches the canonical `effectBPostconditionBinding`;
+7. binds evidence to the execution, both plans, fresh authorization, producer,
+   wrapper, and verifier digests; and
+8. releases success only after terminal durable audit commit.
 
 Missing, stale, substituted, malformed, conflicting, unavailable, or nonzero
 verification is `verification_failed` or operator review. Provider
-acknowledgement and Yukh Projects output cannot substitute for MCP observation.
+acknowledgement cannot substitute for either verification chain.
 
-Restore verification follows the same procedure but requires status
-`mcp_pending` and zero drift against the exact restore plan.
+## Completion unknown, rollback, and teardown
 
-## Completion unknown and retry
-
-The effect boundary starts immediately before calling the future immutable
-MCP-safe Projects wrapper. After that point, abort, crash, timeout, process
-restart, lost response, producer ambiguity, Coordination ambiguity, lease loss,
-cleanup failure, audit failure, or conflicting observations produce
+The effect boundary begins immediately before the future immutable wrapper may
+construct provider-backed transports. Abort, crash, timeout, process restart,
+lost response, producer ambiguity, Coordination ambiguity, lease loss, cleanup
+failure, audit failure, or conflicting observations after that boundary yield
 `completion_unknown` unless independent evidence proves effect or no effect.
 
 `completion_unknown` is durable and terminal for the reservation. Exact replay
-returns the stored unknown result without another provider call. The system
-must not automatically retry, resume, redispatch, issue a replacement plan for
-the same unresolved intent, or run restore.
+returns the stored unknown outcome without another provider call. The system
+must not retry, resume, redispatch, issue replacement intent for the unresolved
+effect, remove the dependency, or trigger teardown automatically.
 
-Operator reconciliation first observes current state without mutation. Any
-later effect requires a new intent, plan, approval, OIDC run and package,
-idempotency key, nonce, lease, authorization decisions, reservation, provider
-attempt, verification, and audit chain.
+Rollback is unavailable because Accepted Projects contracts do not authorize
+dependency removal. Operator reconciliation is read-only. Accepted preview
+teardown is a distinct sandbox-owner lifecycle outside both Projects and MCP
+effect authority. It requires separate authorization and independent final
+state verification, does not rewrite the effect result, and cannot prove an
+unknown effect did not occur.
 
 ## Stable failure mapping
-
-Public results use existing bounded error codes:
 
 | Condition | Public result | Provider calls |
 | --- | --- | --- |
 | unknown, undisclosed, or unaccepted capability | `capability_not_found` | 0 |
-| malformed input or wrong logical profile | `schema_validation_failed` | 0 |
-| no explicit allow or explicit deny | `authorization_denied` | 0 |
+| malformed input or wrong fixed binding | `schema_validation_failed` | 0 |
+| authorization deny or no explicit allow | `authorization_denied` | 0 |
 | policy, identity, attribute, or obligation unavailable | `authorization_unavailable` | 0 |
-| stale or substituted plan, target, producer, or operation | `plan_invalidated` | 0 |
-| missing, rejected, expired, or mismatched MCP assertion | `approval_required` or `approval_denied` | 0 |
-| missing, rejected, expired, or mismatched Projects assertion or bridge | `approval_denied` | 0 |
+| stale or substituted plan, target, producer, wrapper, operation, or postcondition | `plan_invalidated` | 0 |
+| missing, rejected, expired, or mismatched MCP approval | `approval_required` or `approval_denied` | 0 |
+| invalid Projects approval or bridge | `approval_denied` | 0 |
 | package unavailable, invalid, replayed, or ambiguous | `authorization_unavailable` | 0 |
-| reservation conflict or exact duplicate before start | `apply_already_reserved` | 0 |
+| reservation conflict or duplicate before start | `apply_already_reserved` | 0 |
 | audit unavailable before start | `audit_unavailable` | 0 |
-| producer rejects before mutation and proves no effect | `provider_protocol_error` | 1 |
-| possible effect with unknown outcome | `operation_outcome_unknown` | 1 |
-| independent postcondition failure | `verification_failed` | 1 |
-| restore unavailable, failed, or unknown | `rollback_unavailable` or `rollback_failed` | 0 or 1 |
+| producer proves rejection before possible mutation | `provider_protocol_error` | 0 |
+| possible effect with unknown outcome | `operation_outcome_unknown` | at most 1 |
+| independent dependency or zero-drift verification failure | `verification_failed` | at most 1 |
+| rollback requested | `rollback_unavailable` | 0 |
 
-Protected evidence may use allowlisted reason codes to distinguish OIDC,
-materialization, Coordination, permission, rate, provider, verification, and
-cleanup causes. Raw dependency text is never retained or released.
+Raw dependency text and dependency identifiers are never retained in public
+errors or evidence.
 
-## Trust boundaries and threat analysis
+## Threat analysis
 
-Proposed boundaries are:
+Proposed boundaries include authenticated MCP subject to policy, both plans to
+their independent approvals, all three artifacts to bridge validation,
+protected workflow to materializer, private package to runtime handles, MCP
+admission to durable stores, protected capsule to Coordination, MCP adapter to
+the future immutable wrapper, distinct credentials to fixed transports,
+Projects state to independent verification, and effect outcome to separate
+teardown governance.
 
-- authenticated MCP subject to deny-by-default policy;
-- MCP plan to the MCP assertion authority;
-- Projects plan and observed principal to the Projects assertion authority;
-- both assertions to the producer-owned cross-binding bridge validator;
-- protected workflow OIDC assertion to fixed materializer;
-- materializer package to private runtime handles;
-- MCP admission to durable audit and reservation stores;
-- protected capsule to Coordination nonce and lease primitives;
-- MCP provider adapter to the future immutable Yukh Projects wrapper;
-- distinct credentials to fixed read and mutation transports;
-- GitHub Projects state to independent MCP verifier; and
-- original execution state to separately authorized restore.
+Primary threats are status-operation remnants, Effect A/B authority collapse,
+relationship reversal, issue substitution, second-operation widening,
+assertion-schema confusion, one assertion authorizing another, bridge replay,
+principal substitution, wrapper replacement, direct primitive composition,
+arbitrary network construction, nonce duplication, stale fencing, audit bypass,
+provider output treated as success, unsafe retry, reverse mutation presented as
+rollback, effect authority triggering teardown, and evidence disclosure.
 
-Primary threats are Effect A/B authority collapse, generic-field widening,
-subject or target substitution, assertion-schema confusion, one assertion
-authorizing the other, bridge substitution, assertion or package replay, OIDC
-claim substitution, credential confusion, host-capsule broadening, duplicate
-nonce consumption, stale fencing, wrapper replacement, direct composition of
-producer primitives, arbitrary network or query construction, pre-effect audit
-bypass, provider success treated as verification, unsafe retry after ambiguity,
-automatic restore, and evidence disclosure.
+Controls are exact Accepted semantics, empty input, server-owned fixed target,
+two fresh explicit authorizations, separately authenticated approvals,
+Accepted bridge v2, immutable artifact pinning, one-shot private handles,
+distinct credentials and nonces, producer-owned lease, durable
+audit-before-effect, one request, independent dependency and zero-drift
+verification, durable unknown completion, unavailable rollback, separately
+authorized teardown, and structural redaction.
 
-Controls are disjoint exact bindings, closed enum schemas, server-owned target
-resolution, two fresh explicit authorization decisions, two separately signed
-and verified assertions, an accepted non-authorizing bridge, one-shot package
-retrieval, separate credentials, immutable producer and wrapper artifact
-digests, producer-owned Coordination gates, durable reservation and
-audit-before-effect, one provider attempt, independent fresh zero-drift
-verification, durable unknown completion, separately authorized restore, and
-structural redaction.
-
-Residual risks include compromise of GitHub, the identity provider,
-materializer, approval authority, Coordination deployment, Yukh Projects
-artifact, sandbox host, effective user, kernel, filesystem, runner, trust roots,
-DNS/TLS, or synthetic target administrator. The repository-local stores do not
-provide production confidentiality, independent witnessing, backup, high
-availability, or disaster recovery. These risks are not accepted by this
-proposal.
+Residual risks include compromise of GitHub, identity or approval authorities,
+materializer, Coordination deployment, future artifacts, sandbox host, runner,
+trust roots, DNS/TLS, or synthetic target administrator. Repository-local
+stores remain single-process, unwitnessed, and non-production. This proposal
+accepts none of those operational risks.
 
 ## Compatibility
 
-This RFC does not change RFC-0001 through RFC-0010. It instantiates their
-accepted contracts for one proposed sandbox profile.
+This revision removes the nonconforming status and restore capability
+semantics from Proposed RFC-0011. It does not modify RFC-0001 through RFC-0010
+or any Accepted Projects record.
 
-RFC-0008 and RFC-0009 remain authoritative for the separate Project 5 /
-issue 27 profile. Their static single-token exception is forbidden here. This
-profile requires distinct short-lived read and write credentials and the suite
-RFC's OIDC one-shot materialization.
+The ordinary gateway continues to discover zero tools, resources, and prompts.
+The read-only demo and synthetic setting qualification remain unchanged.
 
-The ordinary gateway must continue to discover zero tools, resources, and
-prompts. The read-only demo and synthetic setting qualification remain
-unchanged. No accepted exact capability version may later be widened to another
-field, value, item, Project, repository, environment, mode, producer, provider,
-verification profile, credential path, retry rule, or restore behavior.
+No future implementation may widen this version to another relationship,
+direction, issue, Project, repository, environment, operation count, producer,
+wrapper, verifier, credential path, retry rule, rollback mode, or teardown
+authority. Such a change requires compatibility review and, where authority
+expands or semantics break, a new RFC and capability version.
 
-Any change to the schemas, bridge, assertion separation, target cardinality,
-operation type, scope, producer or wrapper baseline, materialization profile,
-Coordination ownership, error meaning, verification, retry, or restore
-authority requires compatibility review and, when authority expands or
-semantics break, a new RFC and capability version.
+## Validation and acceptance gates
 
-## Validation and acceptance evidence
+This Proposed record requires a distinct RFC-0007 independent read-only review
+on its exact head. The author cannot review, accept, merge, or execute it.
 
-RFC-0011 cannot be accepted for implementation until
-`nomed/yukh-projects#150` accepts and immutably publishes the bridge and wrapper
-contract/artifact. After both acceptances, a separate implementation issue may
-add only an unreachable, disabled registration skeleton and synthetic
-conformance tests unless a later accepted gate explicitly authorizes more.
-Tests must prove:
+Before RFC-0011 can be considered for acceptance:
 
-- canonical definition and schema validation with fixed digests;
-- ordinary gateway discovery remains empty and direct invocation is impossible;
-- exact Effect B target and operation-set disjointness from Effect A;
-- rejection of every unknown field, value, resource, environment, target,
-  capability version, producer, policy, operation, provider mode, and verifier;
-- zero provider calls for authentication, authorization, planning, approval,
-  materialization, precondition, reservation, audit, and package failures;
-- fresh planning and apply decisions are distinct, explicit, current, and
-  one-shot;
-- independent MCP and Projects assertion verification, strict schema rejection,
-  trust-root separation, principal binding, bridge substitution, and proof that
-  neither assertion authorizes the other;
-- package, assertion, and bridge replay, expiry, ambiguity, and cleanup failure;
-- distinct nonce enforcement, lease conflict/loss, epoch mismatch, and proof
-  that MCP does not preconsume the Projects assertion nonce;
-- immutable wrapper selection and proof that direct primitive composition, CLI,
-  shell, dynamic install, generic network, GraphQL, REST, and workflow-dispatch
-  paths are absent;
-- one exact provider attempt, exact result mapping, partial/unknown outcomes,
-  and no hidden retry;
-- independent verification rejects provider-only evidence and requires a fresh
-  zero-operation Projects plan;
-- crash/restart at every reservation, audit, provider, result, verification,
-  cleanup, and terminal boundary;
-- durable unknown completion returns without a second effect after restart;
-- restore requires entirely fresh authority and refuses changed state; and
-- records, errors, logs, outputs, artifacts, summaries, and diagnostics contain
-  no forbidden material.
+1. Projects must separately implement, qualify, and immutably publish the
+   Accepted bridge-verifier and wrapper artifacts;
+2. RFC-0011 must pin exact source and artifact digests plus provenance,
+   conformance, and compatibility evidence;
+3. any missing audit-schema binding must receive separate accepted authority;
+4. a distinct reviewer must confirm the revised contract and threat delta;
+5. all required checks must pass on the exact proposed head; and
+6. the applicable acceptance authority must explicitly accept the resulting
+   exact RFC text.
 
-No test may use a credential, real endpoint, GitHub request, workflow apply, or
-production data.
+Acceptance alone would still authorize no registration, credentials, network,
+provider, live mutation, deployment, or readiness. Those require later
+separate implementation, deployment, activation, and operational gates.
 
-## Rollout and rollback
+Future conformance tests must prove:
 
-1. Review this Proposed RFC, its threat-model delta, and suite RFC alignment.
-2. Accept and immutably publish the producer-owned bridge and wrapper contract
-   under `nomed/yukh-projects#150`.
-3. Update this RFC with the accepted contract, wrapper artifact, and immutable
-   digests without weakening either assertion boundary.
-4. Obtain explicit owner acceptance of this RFC or revise the proposal.
-5. After acceptance, open a separate implementation issue.
-6. Implement at most an unreachable, disabled registration skeleton and
-   network-free synthetic conformance fixtures under that issue.
-7. Require another accepted deployment RFC before configuring OIDC,
-   materializer, identity, approval, Coordination, audit, verifier, workflow,
-   target, credential, endpoint, or network paths.
-8. Require a separate activation review before gateway discovery or invocation.
-9. Require a separately reviewed exact Effect B plan and explicit human
-   authorization before one live synthetic apply.
-10. Require separate authorization for a zero-operation second observation,
-   restore, teardown, and operational-readiness acceptance.
+- canonical definition validation and fixed digest;
+- empty input and rejection of every unknown selector;
+- exact `projects.add-dependency.v1` identity;
+- exactly one `add_dependency(201 blocks 202)` operation;
+- no status-setting or dependency-removal path;
+- Effect A/B disjointness;
+- separate approval verification and bridge exact matching;
+- zero provider calls for every pre-effect denial;
+- immutable wrapper selection and absence of direct primitive, CLI, shell,
+  workflow, generic network, GraphQL, REST, and SDK paths;
+- distinct nonces and producer-owned lease;
+- one request, no hidden retry, and restart-stable `completion_unknown`;
+- independent dependency-presence and fresh zero-drift verification;
+- rollback unavailable and teardown outside effect authority; and
+- bounded redaction.
 
-Before acceptance, rollback is closing or revising this proposal. After a
-disabled skeleton, rollback removes only unreachable code and synthetic
-fixtures. It never deletes audit state or changes provider state. After a
-future effect, rollback is the separately authorized restore capability; source
-reversion alone cannot reverse GitHub state.
+No test may use a credential, provider endpoint, GitHub request, workflow apply,
+consumer data, or live sandbox.
+
+## Rollout
+
+1. Review this Proposed revision and threat-model delta.
+2. Obtain the required independent read-only review on the exact head.
+3. Wait for separately reviewed immutable Projects implementation artifacts.
+4. Pin those artifacts in a later RFC-0011 revision.
+5. Obtain explicit acceptance of that exact revision.
+6. Open a separate implementation issue only after acceptance.
+7. Keep any skeleton unreachable, disabled, and network-free until later gates.
+8. Require separate deployment and activation authority before discovery.
+9. Require fresh exact plans and independent approvals before any live
+   synthetic effect.
+10. Govern teardown and operational readiness independently.
+
+Before acceptance, rollback is closing or revising this proposal. Source
+reversion never changes provider state.
 
 ## Alternatives
 
-### Reuse the Project 5 single-token profile
+### Keep the status operation
 
-Rejected because it is a different target and migration authority, permanently
-selects a static secret path, and cannot satisfy suite RFC-0005 Effect B
-independence or OIDC materialization.
+Rejected. It conflicts with Accepted Projects
+`add_dependency(201 blocks 202)` semantics and expands authority.
 
-### Register the synthetic setting provider
+### Treat status and dependency operations as aliases
 
-Rejected because it proves lifecycle semantics only and has no GitHub Projects,
-Yukh Projects, credential, Coordination, or network boundary.
+Rejected. They have different targets, preconditions, plans, postconditions,
+provider operations, verification, and teardown implications.
 
-### Expose a generic field update
+### Add a dependency-removal restore capability
 
-Rejected because caller-selected field, value, Project, item, or operation
-would create a broad GitHub mutation capability and defeat policy review.
+Rejected. Accepted Projects contracts authorize no reverse mutation. Rollback
+is unavailable; teardown is separate sandbox-owner authority.
 
-### Dispatch a workflow from the provider
+### Expose a generic relationship update
 
-Rejected because it adds another GitHub authority and ambiguous asynchronous
-boundary, and workflow dispatch is not approval. The proposed provider remains
-blocked until a producer-owned MCP-safe wrapper is accepted.
+Rejected. Caller-selected issues, direction, or operation would create a broad
+mutation capability.
 
-### Let MCP consume the Projects assertion nonce first
+### Dispatch a workflow or compose Projects primitives in MCP
 
-Rejected because the immutable Projects controlled-apply host must consume it.
-Preconsumption would convert the only attempt into a replay denial. MCP binds
-the nonce digest and relies on its own durable reservation without duplicating
-the producer's Coordination gate.
+Rejected. Both create unreviewed authority and bypass the Accepted wrapper
+contract.
 
-### Trust the producer's final report as MCP verification
+### Trust provider success as MCP verification
 
-Rejected because Effect B requires MCP-owned independent postcondition
-verification and success release.
-
-### Restore automatically after failure
-
-Rejected because current state may be unknown or legitimately changed.
-Restore is a separate high-risk capability with fresh authority.
+Rejected. Effect B requires independent MCP observation and the shared
+canonical postcondition.
 
 ## Open questions
 
-The owner must explicitly decide:
+The owner or applicable future acceptance authority must decide:
 
-1. whether the exact capability and restore schemas are accepted;
-2. whether the accepted `nomed/yukh-projects#150` bridge schema and wrapper
-   artifact preserve both component authority boundaries;
-3. whether the existing RFC-0004 event schemas can carry every required
-   digest-bound obligation receipt or need a separate registry RFC;
-4. whether the repository-local audit and reservation profiles are acceptable
-   for the ephemeral preview qualification;
-5. which later deployment profile owns OIDC, materializer, both approval
-   trust profiles, bridge trust, wrapper loading,
-   Coordination, verifier, workflow, and sandbox target configuration; and
-6. which exact Effect A target and operation set prove disjointness.
+1. whether the exact capability definition is accepted after artifacts exist;
+2. whether published bridge-verifier, wrapper, MCP verifier, producer, policy,
+   and target-profile artifacts preserve both authority boundaries;
+3. whether RFC-0004 schemas represent every required obligation receipt;
+4. whether repository-local audit and reservation profiles are sufficient for
+   an ephemeral qualification;
+5. which deployment profile owns OIDC, materializer, trust, Coordination,
+   verifier, workflow, target, credentials, endpoint, and network; and
+6. which exact operational evidence is required before any activation.
 
-No open question may be resolved by implementation before explicit acceptance.
+No open question may be resolved by implementation under this Proposed record.

--- a/.context/sessions/SESSION-2026-08-09-01-effect-b-capability-rfc.md
+++ b/.context/sessions/SESSION-2026-08-09-01-effect-b-capability-rfc.md
@@ -2,67 +2,65 @@
 
 - Date: 2026-08-09
 - Governing issue: https://github.com/nomed/yukh-mcp/issues/96
-- Suite issue: https://github.com/nomed/nomed.github.io/issues/40
-- Suite RFC: accepted on `nomed/nomed.github.io` `main` at
-  `12d9215f10c4b7fb1762a5025367e3e81543800f` (PR #42)
-- Status: Proposed component RFC blocked on `nomed/yukh-projects#150`
+- Suite mission: accepted `nomed/nomed.github.io` RFC-0005 at
+  `12d9215f10c4b7fb1762a5025367e3e81543800f`
+- Autonomous mandate: accepted `nomed/nomed.github.io` RFC-0007 at
+  `bb8628edf7a07c2af56f07e4f9140f58c851ef47`
+- Projects authority:
+  `nomed/yukh-projects@521be0d0ef1297579e84a6322dea29f80c2549dc`
+- Status: Proposed component RFC; Accepted upstream specification exists,
+  executable bridge and wrapper artifacts remain unpublished
 
 ## Objective
 
-Advance accepted suite RFC-0005 only to the next reviewable Yukh MCP gate for
-Effect B.
+Advance accepted suite Effect B only to a conforming Yukh MCP contract-review
+gate.
 
-## Decision discovered
+## Author decision
 
-A new component RFC is required before any capability or provider registration.
-RFC-0001 requires registration and threat review; RFC-0006 reserves gateway and
-provider wiring for a later RFC; RFC-0007 adds no MCP capability surface; and
-RFC-0010 plus the current threat model explicitly forbid provider registration,
-Projects apply, credentials, endpoints, and live mutation.
+Accepted Projects effects v1 fixes capability `projects.add-dependency.v1` and
+exactly one `add_dependency(201 blocks 202)` operation. Earlier Proposed
+RFC-0011 used a conflicting status operation.
 
-RFC-0011 therefore remains Proposed. This session introduces no runtime,
-provider, registry, gateway, workflow, identity, credential, endpoint, network,
-mutation, restore, deployment, or readiness behavior.
+Under RFC-0007, the author selects the Accepted Projects semantic because it
+has least authority expansion, decisive already-Accepted semantics, compatible
+plans and approvals, reversible change to a Proposed record, and the smallest
+authority delta. The exact immutable author record is posted to issue #96.
+This session does not review, accept, merge, implement, or activate the change.
 
-Independent review established that the strict MCP `ApprovalReceiptV1` and
-Yukh Projects `SignedApprovalEnvelope` cannot be one envelope, and that the
-immutable v1.7.0 producer exports primitives rather than one reviewed MCP-safe
-wrapper. Issue `nomed/yukh-projects#150` now governs the required compound
-approval bridge and immutable wrapper contract/artifact. RFC-0011 is blocked on
-its acceptance and publication.
+## Revised proposed contract
 
-## Proposed contract
+RFC-0011 now proposes:
 
-RFC-0011 proposes:
-
-- `github.projects.item.status.set@1.0.0` for one fixed synthetic Effect B item;
-- a single `mcp_pending` to `mcp_verified` status operation through immutable
-  Yukh Projects v1.7.0 controlled apply;
-- a compound admission with separate MCP and Projects assertions plus an
-  accepted non-authorizing cross-binding bridge;
-- an MCP provider boundary blocked on a future immutable Yukh Projects wrapper
-  rather than direct composition of v1.7.0 primitives;
-- independent authorization, materialization, Coordination, durable audit,
-  verification, and evidence;
-- durable `completion_unknown` with no automatic retry; and
-- `github.projects.item.status.restore@1.0.0` as a separately planned and
-  approved restore lifecycle.
+- `projects.add-dependency.v1@1.0.0` for the fixed invented dependency
+  `201 blocks 202`;
+- one exact `add_dependency` operation and canonical
+  `effectBPostconditionBinding`;
+- separate MCP and Projects approvals plus Accepted authenticated
+  `yukh-projects-approval-bridge-v2`;
+- the Accepted `runMcpEffectBControlledApplyV1` wrapper contract;
+- no direct Projects primitive composition;
+- durable audit, one attempt, independent verification, and
+  `completion_unknown`;
+- unavailable rollback because dependency removal is not accepted; and
+- separately governed sandbox teardown outside MCP and Projects effect
+  authority.
 
 ## Context impact
 
-This non-authoritative session record navigates the proposed RFC and its
-governing records. It cannot accept RFC-0011 or authorize implementation.
+This non-authoritative session record navigates the Proposed RFC and accepted
+upstream authorities. It creates no runtime, registry, gateway, identity,
+credential, OIDC, endpoint, network, provider, mutation, teardown, deployment,
+release, or readiness behavior.
 
-The Project 5 / issue 27 profile remains governed by RFC-0007 through RFC-0009.
-Its static single-token exception is not reused. The proposed suite sandbox
-profile instead follows the OIDC-bound one-shot materialization decision in the
-accepted suite RFC.
+The Project 5 / issue 27 profile remains separate and unchanged.
 
 ## Required next gate
 
-Yukh Projects must first accept and immutably publish the bridge and wrapper
-contract/artifact governed by issue #150. RFC-0011 must then pin those accepted
-artifacts and receive explicit owner acceptance before a separate issue may
-implement even an unreachable disabled registration skeleton. Deployment,
-activation, credentials, network access, a live synthetic apply, restore, and
-operational readiness each retain later independent gates.
+1. Distinct RFC-0007 read-only review of the exact PR head.
+2. Separate Projects implementation and immutable publication of the accepted
+   bridge-verifier and MCP-safe wrapper artifacts.
+3. RFC-0011 revision pinning exact source and artifact digests.
+4. Explicit acceptance of that exact RFC revision.
+5. Separate implementation, deployment, activation, live-effect, teardown, and
+   readiness gates.

--- a/docs/reference/contracts.md
+++ b/docs/reference/contracts.md
@@ -10,7 +10,7 @@ access.
 | Authorization v1     | [RFC-0002](https://github.com/nomed/yukh-mcp/blob/main/.context/rfcs/RFC-0002-deny-by-default-authorization.md)                                                                                                                                | [Package and API](https://github.com/nomed/yukh-mcp/tree/main/contracts/authorization/v1)                                                                                       |
 | Mutation lifecycle   | [RFC-0003](https://github.com/nomed/yukh-mcp/blob/main/.context/rfcs/RFC-0003-bound-plan-approval-apply-lifecycle.md)                                                                                                                          | [`packages/lifecycle`](https://github.com/nomed/yukh-mcp/tree/main/packages/lifecycle/src): disabled, provider-neutral reference engine and repository-local reservation ledger |
 | Mutation qualification fixture | [Issue #94](https://github.com/nomed/yukh-mcp/issues/94), constrained by RFC-0001 through RFC-0004 and RFC-0010 | [Synthetic setting qualification](example-setting-qualification.md): in-memory, network-free, unregistered effect/verifier/restore fixture |
-| Sandbox Projects Effect B | [Proposed RFC-0011](https://github.com/nomed/yukh-mcp/blob/main/.context/rfcs/RFC-0011-sandbox-github-projects-capability.md), [issue #96](https://github.com/nomed/yukh-mcp/issues/96), blocked by [Yukh Projects #150](https://github.com/nomed/yukh-projects/issues/150) | Contract review only; compound-approval bridge and MCP-safe wrapper not accepted; no implementation, registration, credential, network, provider, or gateway path |
+| Sandbox Projects Effect B | [Proposed RFC-0011](https://github.com/nomed/yukh-mcp/blob/main/.context/rfcs/RFC-0011-sandbox-github-projects-capability.md), [issue #96](https://github.com/nomed/yukh-mcp/issues/96), conforming to Accepted [Projects #150](https://github.com/nomed/yukh-projects/issues/150) contracts at `main@521be0d` | Contract review only for `projects.add-dependency.v1` and exactly `add_dependency(201 blocks 202)`; executable bridge/wrapper artifacts remain unpublished; no implementation, registration, credential, network, provider, or gateway path |
 | Audit evidence       | [RFC-0004](https://github.com/nomed/yukh-mcp/blob/main/.context/rfcs/RFC-0004-structured-redacted-audit-evidence.md), [RFC-0010](https://github.com/nomed/yukh-mcp/blob/main/.context/rfcs/RFC-0010-repository-local-durable-audit-profile.md) | [Writer and repository-local profile](audit-writer.md)                                                                                                                          |
 | Coordination adapter | [RFC-0005](https://github.com/nomed/yukh-mcp/blob/main/.context/rfcs/RFC-0005-stable-coordination-consumer-adapter.md)                                                                                                                         | Synthetic loopback qualification only                                                                                                                                           |
 
@@ -33,12 +33,13 @@ The synthetic setting package is a provider fixture only. It qualifies exact
 effect, verification, idempotency, recovery, and separately authorized restore
 behavior but remains unreachable from gateway discovery or invocation.
 
-RFC-0011 is Proposed and has no implementation authority. The ordinary gateway
-must remain inert unless the owner first accepts the component contract and a
-later separately reviewed gate authorizes registration or activation.
-Acceptance itself is blocked until Yukh Projects defines and immutably
-publishes the two-assertion cross-binding bridge and MCP-safe controlled-apply
-wrapper governed by `nomed/yukh-projects#150`.
+RFC-0011 is Proposed and has no implementation authority. It conforms to the
+Accepted Projects Effect B and compound-admission specifications at
+`nomed/yukh-projects@521be0d0ef1297579e84a6322dea29f80c2549dc`.
+Projects has not implemented or published immutable bridge-verifier or
+`runMcpEffectBControlledApplyV1` wrapper artifacts. RFC-0011 must pin those
+future artifacts and receive acceptance before any separate implementation
+gate. The ordinary gateway remains inert.
 
 ## Validate the repository
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -629,40 +629,44 @@ approval issuance for Step 9, Step 9 execution, credentials/endpoints, external
 or production state, Projects apply, deployment, recovery automation, or any
 production-readiness claim.
 
-## Proposed sandbox Projects Effect B capability - 2026-08-09
+## Proposed sandbox Projects add-dependency Effect B capability - 2026-08-09
 
 - Governing issue: #96
 - Suite authority: accepted `nomed.github.io` RFC-0005 on `main` at
   `12d9215f10c4b7fb1762a5025367e3e81543800f` (PR #42)
+- Autonomous mandate: accepted `nomed.github.io` RFC-0007 at
+  `bb8628edf7a07c2af56f07e4f9140f58c851ef47`
+- Accepted Projects contract:
+  `nomed/yukh-projects@521be0d0ef1297579e84a6322dea29f80c2549dc`
 - Proposed component contract: RFC-0011
-- Blocking producer contract: `nomed/yukh-projects#150`
-- Scope: contract review for one fixed synthetic GitHub Projects status update
-  and one separately authorized restore capability
+- Scope: contract review for fixed capability `projects.add-dependency.v1`,
+  exactly one `add_dependency(201 blocks 202)` operation, and the Accepted
+  compound-admission contract
 - New live provider, credential, endpoint, network, gateway, or mutation
   boundary: none in this proposal
 
 | Threat | Proposed required control | Residual risk / later gate |
 | --- | --- | --- |
-| Effect A authority is reused or treated as approval for Effect B | different synthetic item and disjoint operation set; separate plans, authorization decisions, MCP and Projects assertions, bridge, snapshots, nonces, lease, idempotency key, package, credentials, verifier, and audit chain | the suite compatibility matrix must identify and independently verify both exact operation sets |
-| a caller widens the capability into arbitrary Projects, fields, values, GraphQL, REST, workflows, or commands | closed enum-only input, one server-owned logical resource, one status transition, fixed environment and native provider mode, and no provider identifiers or execution mechanics in public schemas | trusted deployment resolution and provider conformance require later accepted profiles and synthetic negative tests |
+| stale status semantics or Effect A authority is reused for Effect B | remove the nonconforming status capability; bind empty input to the Accepted fixed dependency target and one `add_dependency`; separate plans, approvals, bridge, snapshots, nonces, lease, credentials, verifiers, and audit chains | conformance tests must prove no status or dependency-removal path and exact Effect A/B disjointness |
+| a caller reverses or widens the relationship into arbitrary Projects, fields, values, GraphQL, REST, workflows, or commands | empty closed input, server-owned `201 blocks 202` target, one operation, fixed environment and native mode, and no provider identifiers or execution mechanics in public schemas | trusted target resolution and provider conformance require later accepted profiles and adversarial fixtures |
 | authentication, discovery, planning allow, either assertion, the bridge, workflow admission, OIDC, Coordination, credential possession, or provider output becomes MCP authorization | distinct fresh RFC-0002 planning and apply decisions; only exact explicit allow with enforced constraints and obligations can progress | production identity, policy, attribute, assertion, bridge, and obligation adapters remain unselected |
-| one approval envelope is forced through incompatible strict schemas or one assertion authorizes the other | strict MCP `ApprovalReceiptV1` and Projects `SignedApprovalEnvelope` remain separately signed and verified; an accepted producer-owned bridge proves exact cross-binding but grants no authority | bridge schema, trust, canonicalization, and principal mapping are blocked on `nomed/yukh-projects#150` |
+| one approval envelope is forced through incompatible strict schemas or one assertion authorizes the other | strict MCP `ApprovalReceiptV1` and unchanged Projects `SignedApprovalEnvelope` v1 remain separately authenticated; Accepted `yukh-projects-approval-bridge-v2` exact-matches them but grants no authority | executable bridge-verifier artifact and deployment trust profiles remain unpublished |
 | either assertion, its trust root, or the bridge is replayed, substituted, shared with Effect A, or selected by repository content | distinct plans, principals, schemas, trust profiles, nonces, expiry, verification receipts, and accepted cross-binding; neither assertion is presented as the other | identity, signing-key custody, trust-root delivery, and separation of duties require later deployment review |
 | OIDC claims or a one-shot package are replayed, broadened, redirected, logged, or treated as authority | fixed audience/workflow/environment/run/attempt/commit/both-plan binding; atomic one-shot bounded package; both assertions and bridge; distinct short-lived read/write credentials; direct TLS; no retry, fallback, output, artifact, cache, summary, or log | identity-provider, materializer, TLS, runner, and credential-issuer compromise remain operational dependencies |
 | MCP preconsumes the Projects assertion nonce or competes for the lease required by controlled apply | MCP consumes only its distinct assertion nonce and binds both nonce digests; the producer remains the sole consumer of the Projects nonce and fenced lease | exact host-capsule and Coordination deployment qualification remains a later gate |
-| direct composition of v1.7.0 primitives, wrapper replacement, dynamic execution, or a generic network path bypasses Projects semantics | v1.7.0 exports are documented but forbidden as a direct MCP boundary; implementation is blocked on an immutable producer-owned wrapper contract/artifact with fixed composition and no CLI, shell, dispatcher, dynamic install, generic HTTP, GraphQL, REST, or SDK path | wrapper contract, provenance, artifact, loader integrity, and sandbox-host risks are blocked on `nomed/yukh-projects#150` |
+| direct composition of v1.7.0 primitives, wrapper replacement, dynamic execution, or a generic network path bypasses Projects semantics | only the Accepted `runMcpEffectBControlledApplyV1` contract is eligible; direct primitives, CLI, shell, dispatcher, dynamic install, generic HTTP, GraphQL, REST, and SDK paths are forbidden | immutable wrapper implementation, provenance, SBOM, digest, conformance vectors, and loader integrity remain unpublished |
 | pre-effect audit outage permits mutation or post-start evidence failure hides a possible effect | durable RFC-0010 reservation and every required RFC-0004 pre-effect commit before provider start; post-start failure journals recovery, withholds success, and records `completion_unknown` | the existing event registry may need a separate RFC if it cannot represent every package, Coordination, producer, and verifier binding |
-| provider acknowledgement or final report is released as MCP success | separate read-only verifier re-resolves the target, observes status, reruns the Projects planner, and requires zero operations and zero diagnostics | verifier identity, observation integrity, and read-credential profile require later acceptance |
+| provider acknowledgement or final report is released as MCP success | separate read-only verifier proves `201 blocks 202`, exact `effectBPostconditionBinding`, and a fresh zero-operation Projects plan | verifier implementation, observation integrity, and read-credential profile require later acceptance |
 | crash, timeout, lost response, lease loss, cleanup failure, or conflicting observation triggers a duplicate effect | one durable attempt, retry `never`, restart-stable `completion_unknown`, no redispatch or replacement intent before reconciliation | operator reconciliation and recovery acknowledgement remain unimplemented |
-| restore runs automatically or overwrites newer legitimate state | distinct restore capability with exact source snapshot, original execution bindings, fresh plans/assertions/bridge/authorization/package/nonces/lease/audit, conflict-detecting preconditions, and explicit unavailable-rollback rationale, recovery, and stop conditions | restore can fail or become unknown and has no recursive automatic rollback |
+| reverse mutation or teardown is presented as automatic rollback | capability rollback is explicitly unavailable because dependency removal is not Accepted; teardown remains separate sandbox-owner authority and cannot rewrite effect outcome | teardown implementation, credentials, final-state verifier, and operational authority remain unselected |
 | credentials, approvals, capsules, provider identifiers, observations, or private target data enter evidence | closed structural projections with only allowlisted references, digests, states, stable codes, counts, and duration buckets | host, effective-user, runner, filesystem, and administrator compromise can still observe runtime material |
 
-RFC-0011 is **Proposed** and blocked on acceptance and immutable publication of
-the producer-owned bridge and wrapper contract/artifact under
-`nomed/yukh-projects#150`. This threat-model delta authorizes no implementation
-or operational authority. After that dependency, explicit owner acceptance is
-still required before a separate issue may add even an unreachable disabled
-registration skeleton. OIDC, both assertion authorities, bridge trust,
-materializer, Coordination, audit, verifier, workflow, target, credential,
-endpoint, network, gateway activation, live synthetic apply, restore,
-deployment, and operational readiness each require later explicit review.
+RFC-0011 is **Proposed**. Projects #150 accepted the bridge v2 and MCP-safe
+wrapper specifications, not an implementation or release. Immutable
+bridge-verifier and wrapper artifacts, provenance, SBOM, digests, and
+conformance evidence remain unpublished. RFC-0011 must pin those future
+artifacts and receive acceptance before a separate implementation issue.
+OIDC, assertion authorities, bridge trust, materializer, Coordination, audit,
+verifier, workflow, target, credentials, endpoints, network, gateway
+activation, live synthetic apply, teardown, deployment, and operational
+readiness each require later explicit review.

--- a/test/supply-chain/documentation.test.mjs
+++ b/test/supply-chain/documentation.test.mjs
@@ -37,3 +37,27 @@ test("the landing page starts with the runnable synthetic demo", async () => {
   assert.match(home, /not production-ready/i);
   assert.match(home, /ordinary gateway is inert/i);
 });
+
+test("Proposed RFC-0011 conforms to the Accepted Projects Effect B", async () => {
+  const [rfc, contracts, threatModel, session] = await Promise.all([
+    read(".context/rfcs/RFC-0011-sandbox-github-projects-capability.md"),
+    read("docs/reference/contracts.md"),
+    read("docs/security/threat-model.md"),
+    read(".context/sessions/SESSION-2026-08-09-01-effect-b-capability-rfc.md"),
+  ]);
+  const surface = `${rfc}\n${contracts}\n${threatModel}\n${session}`;
+
+  assert.match(rfc, /- Status: Proposed/);
+  assert.match(rfc, /projects\.add-dependency\.v1/);
+  assert.match(rfc, /add_dependency\(201 blocks 202\)/);
+  assert.match(rfc, /yukh-projects-approval-bridge-v2/);
+  assert.match(rfc, /runMcpEffectBControlledApplyV1/);
+  assert.match(rfc, /521be0d0ef1297579e84a6322dea29f80c2549dc/);
+  assert.match(rfc, /mode: unavailable/);
+  assert.match(rfc, /properties: \{\}/);
+  assert.doesNotMatch(surface, /github\.projects\.item\.status/);
+  assert.doesNotMatch(surface, /mcp_pending|mcp_verified/);
+  assert.doesNotMatch(surface, /set_field_value\(status\).*Effect B/);
+  assert.match(surface, /no implementation|implementation authority/i);
+  assert.match(surface, /artifact.*unpublished|unpublished.*artifact/i);
+});


### PR DESCRIPTION
## Summary

- revise Proposed RFC-0011 to conform to Accepted Projects authority at `nomed/yukh-projects@521be0d0ef1297579e84a6322dea29f80c2549dc`
- replace the nonconforming status capability with `projects.add-dependency.v1` and exactly one `add_dependency(201 blocks 202)` operation
- pin the Accepted `yukh-projects-approval-bridge-v2` and `runMcpEffectBControlledApplyV1` specification authority
- preserve the blocker on actual immutable bridge-verifier and wrapper implementation artifacts, digests, provenance, SBOM, and conformance evidence
- declare rollback unavailable and keep teardown outside MCP/Projects effect authority
- add documentation regression coverage proving stale status semantics do not return

## RFC-0007 role and decision

**Role: Author only.** Session `ef6cd994-3339-4dad-8a53-0e9dd1c98f3d` authored exact head `590574a67e3758b4267a7a225b211fd128639ac8`. The immutable Class B author decision is recorded in [issue #96](https://github.com/nomed/yukh-mcp/issues/96#issuecomment-5232483077).

Authority chain:

- Accepted autonomous-maintainer RFC-0007: `nomed/nomed.github.io@bb8628edf7a07c2af56f07e4f9140f58c851ef47`
- Accepted suite RFC-0005: `nomed/nomed.github.io@12d9215f10c4b7fb1762a5025367e3e81543800f`
- Accepted Projects effects and compound-admission contract: `nomed/yukh-projects@521be0d0ef1297579e84a6322dea29f80c2549dc`

The conflict is resolved by least authority expansion and decisive already-Accepted semantics. This author session will not review, accept, merge, execute, implement, publish, register, or activate this change. A distinct read-only reviewer and distinct executor/merger are required.

## Governance

Refs #96 and `nomed/yukh-projects#150`.

RFC-0011 remains **Proposed**. This PR is governance-only and inert. It grants no implementation, registration, runtime, provider, OIDC, credential, endpoint, network, GitHub mutation, teardown, deployment, release, or readiness authority.

## Remaining blockers

1. Projects must separately implement, qualify, and immutably publish the Accepted bridge-verifier and `runMcpEffectBControlledApplyV1` wrapper artifacts.
2. Publication must include exact source commits, artifact digests, provenance, SBOM, reproducible-build evidence, and conformance vectors.
3. RFC-0011 must pin those exact artifacts and receive acceptance on that exact revision.
4. Any later implementation, deployment, activation, live synthetic effect, teardown, and readiness steps require separate gates.

## Files

- `.context/rfcs/RFC-0011-sandbox-github-projects-capability.md`
- `.context/sessions/SESSION-2026-08-09-01-effect-b-capability-rfc.md`
- `docs/reference/contracts.md`
- `docs/security/threat-model.md`
- `test/supply-chain/documentation.test.mjs`

## Validation

- `python3 -m mkdocs build --strict`
- `node --test test/contracts/capability-contract.test.mjs test/supply-chain/documentation.test.mjs`
- embedded RFC capability validated with `contracts/capability/v1/validator.mjs`, including required `rollback.unavailable` metadata
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run format:check`
- `npx prettier --check test/supply-chain/documentation.test.mjs`
- stale semantic scan: no `github.projects.item.status`, `mcp_pending`, `mcp_verified`, status capability/profile, or status restore references outside negative regression assertions
- `git diff --check`
