### PR TITLE
Harden runtime crash-boundary synchronization

### DIFF
--- a/test/runtime/fixtures/crash-protocol.ts
+++ b/test/runtime/fixtures/crash-protocol.ts
@@ -1,0 +1,29 @@
+import { writeSync } from "node:fs";
+
+export type CrashProtocolEvent =
+  | {
+      readonly phase: "ready";
+      readonly fixture: "repository-local";
+      readonly mode: "primary" | "recovery";
+    }
+  | {
+      readonly phase: "ready";
+      readonly fixture: "lifecycle";
+    }
+  | {
+      readonly phase: "crash";
+      readonly fixture: "repository-local" | "lifecycle";
+      readonly boundary: string;
+      readonly occurrence: number;
+    };
+
+export function writeCrashProtocolEvent(event: CrashProtocolEvent): void {
+  writeSync(1, `${JSON.stringify(event)}\n`);
+}
+
+export function parseCrashProtocolEvents(output: string): CrashProtocolEvent[] {
+  return output
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as CrashProtocolEvent);
+}

--- a/test/runtime/fixtures/lifecycle-crash-child.ts
+++ b/test/runtime/fixtures/lifecycle-crash-child.ts
@@ -14,6 +14,7 @@ import {
   approvalFixture,
   planFixture,
 } from "../lifecycle-test-fixtures.js";
+import { writeCrashProtocolEvent } from "./crash-protocol.js";
 
 const [, , repositoryRoot, boundaryValue] = process.argv;
 const boundaries: readonly LifecycleBoundary[] = [
@@ -66,10 +67,19 @@ const engine = new LifecycleEngine({
   ledger,
   hooks: {
     onBoundary: (observed) => {
-      if (observed === boundary) process.exit(86);
+      if (observed === boundary) {
+        writeCrashProtocolEvent({
+          phase: "crash",
+          fixture: "lifecycle",
+          boundary: observed,
+          occurrence: 1,
+        });
+        process.exit(86);
+      }
     },
   },
 });
+writeCrashProtocolEvent({ phase: "ready", fixture: "lifecycle" });
 const plan = planFixture();
 await engine.execute({ plan, approval: approvalFixture(plan) });
 await ledger.close();

--- a/test/runtime/fixtures/repository-local-crash-child.ts
+++ b/test/runtime/fixtures/repository-local-crash-child.ts
@@ -7,6 +7,7 @@ import {
   protectedGenesisEvent,
   recoveryFact,
 } from "../repository-local-test-fixtures.js";
+import { writeCrashProtocolEvent } from "./crash-protocol.js";
 
 const [, , mode, repositoryRoot, crashEvent, crashOccurrenceValue] = process.argv;
 if (
@@ -45,12 +46,21 @@ const profile = await openRepositoryLocalAuditProfileForQualification({
     onEvent: (event) => {
       if (armed && event === crashEvent) {
         occurrence += 1;
-        if (occurrence === crashOccurrence) process.exit(86);
+        if (occurrence === crashOccurrence) {
+          writeCrashProtocolEvent({
+            phase: "crash",
+            fixture: "repository-local",
+            boundary: event,
+            occurrence,
+          });
+          process.exit(86);
+        }
       }
     },
   },
 });
 armed = true;
+writeCrashProtocolEvent({ phase: "ready", fixture: "repository-local", mode });
 
 if (mode === "primary") {
   const event = protectedGenesisEvent();

--- a/test/runtime/lifecycle-crash.test.ts
+++ b/test/runtime/lifecycle-crash.test.ts
@@ -21,6 +21,7 @@ import {
   approvalFixture,
   planFixture,
 } from "./lifecycle-test-fixtures.js";
+import { parseCrashProtocolEvents } from "./fixtures/crash-protocol.js";
 
 const scratchRoot = path.join(process.cwd(), ".audit-test-scratch");
 const childPath = fileURLToPath(new URL("./fixtures/lifecycle-crash-child.ts", import.meta.url));
@@ -63,7 +64,6 @@ test("real child crashes converge conservatively at every lifecycle boundary", a
           cwd: process.cwd(),
           encoding: "utf8",
           env: process.env,
-          timeout: 30_000,
         });
         assert.equal(
           child.status,
@@ -71,6 +71,15 @@ test("real child crashes converge conservatively at every lifecycle boundary", a
           `child did not crash at ${boundary}: stdout=${child.stdout} stderr=${child.stderr}`,
         );
         assert.equal(child.signal, null);
+        assert.deepEqual(parseCrashProtocolEvents(child.stdout), [
+          { phase: "ready", fixture: "lifecycle" },
+          {
+            phase: "crash",
+            fixture: "lifecycle",
+            boundary,
+            occurrence: 1,
+          },
+        ]);
         const effectExpected = [
           "post_start",
           "pre_result",

--- a/test/runtime/repository-local-crash.test.ts
+++ b/test/runtime/repository-local-crash.test.ts
@@ -16,6 +16,7 @@ import {
   protectedGenesisEvent,
   recoveryFact,
 } from "./repository-local-test-fixtures.js";
+import { parseCrashProtocolEvents } from "./fixtures/crash-protocol.js";
 
 const childPath = fileURLToPath(
   new URL("./fixtures/repository-local-crash-child.ts", import.meta.url),
@@ -89,7 +90,6 @@ function crashChild(
       cwd: process.cwd(),
       encoding: "utf8",
       env: process.env,
-      timeout: 30_000,
     },
   );
   assert.equal(
@@ -98,6 +98,15 @@ function crashChild(
     `child did not crash at ${boundary}: stdout=${result.stdout} stderr=${result.stderr}`,
   );
   assert.equal(result.signal, null);
+  assert.deepEqual(parseCrashProtocolEvents(result.stdout), [
+    { phase: "ready", fixture: "repository-local", mode },
+    {
+      phase: "crash",
+      fixture: "repository-local",
+      boundary,
+      occurrence,
+    },
+  ]);
 }
 
 async function assertPersistentLockThenRemove(root: string): Promise<void> {
@@ -301,7 +310,6 @@ test("a second real process cannot acquire the live create-exclusive lock", asyn
         cwd: process.cwd(),
         encoding: "utf8",
         env: process.env,
-        timeout: 30_000,
       },
     );
     assert.equal(result.status, 0, result.stderr);


### PR DESCRIPTION
## Summary

- remove scheduler-sensitive 30-second deadlines from deliberate crash subprocesses
- add synchronous `ready` and exact-boundary `crash` protocol evidence before exit 86
- assert protocol, crash exit, persistent lock, and restart convergence across every existing audit and lifecycle crash boundary

## Governing issue

Closes #106

## Security impact

- [x] No security-boundary impact
- [ ] Threat model updated
- [ ] Security review required

Explain: Test-fixture-only hardening. Real process termination, fail-closed persistent writer locks, durable audit/lifecycle evidence, and no-retry behavior are preserved.

## Context impact

- [ ] No context impact
- [x] Session/handoff updated
- [ ] ADR/RFC proposed or superseded

Explain: Author evidence for accepted RFC-0007 B-X maintenance: baseline `main@d5b0d0d37b1f6e032e7e8826c5cecff12177437c`; issue #106; commit `9b6a9c06fdef8da19f2b96e6b40b24f95e65650e`; 20/20 baseline targeted and 10/10 baseline full runs; deterministic delayed-start reproduction failed at 30.02s before the patch and passed at 31.93s after it; 10/10 patched targeted runs. This remains author-only and review-ready.

This PR is strictly local/inert and independent of RFC-0011 Effect B. It adds no capability, gateway registration, Projects adapter, credential, provider/network/live effect, workflow authority, release, or tag.

## Validation

- `npm run test:contracts` — 38/38
- `node --test test/supply-chain/*.test.mjs` — 41/41
- `npm run test:runtime` — 220/220
- `npm run typecheck`
- `npm run build`
- `npm run format:check`
- `npm test` — full authoritative command, 220/220 runtime after contracts and supply chain
- `npm audit --audit-level=moderate` — 0 vulnerabilities
- `mkdocs build --strict`
- `docker build --tag yukh-mcp:test .`

## Checklist

- [x] Change is narrowly scoped.
- [x] Public behavior and documentation agree.
- [x] Negative and failure paths are covered.
- [x] No secrets or sensitive infrastructure data are included.
- [x] Dependencies and workflow actions are intentionally pinned.
