### PR TITLE
Add private MCP over HTTP E2E demo

### DIFF
--- a/.context/sessions/SESSION-2026-08-10-01-local-mcp-e2e-demo.md
+++ b/.context/sessions/SESSION-2026-08-10-01-local-mcp-e2e-demo.md
@@ -27,8 +27,8 @@ without a code change, so no speculative fix was applied.
 ## Validation evidence
 
 - `npm run demo:e2e`: passed in 1.76 seconds;
-- targeted gateway, demo, and private Coordination tests: 7 passed;
-- `npm run test:runtime`: 220 passed;
+- targeted gateway, demo, and private Coordination tests: 8 passed;
+- `npm run test:runtime`: 221 passed;
 - `npm run typecheck -- --pretty false`: passed;
 - `npm run build`: passed, including the built demo E2E;
 - `npm run format:check`: passed.

--- a/.context/sessions/SESSION-2026-08-10-01-local-mcp-e2e-demo.md
+++ b/.context/sessions/SESSION-2026-08-10-01-local-mcp-e2e-demo.md
@@ -1,0 +1,43 @@
+# Session - Local MCP/HTTP E2E demo
+
+- Date: 2026-08-10
+- Governing issues: https://github.com/nomed/yukh-mcp/issues/11 and
+  https://github.com/nomed/yukh-mcp/issues/1
+- Status: implementation complete locally
+
+## Objective
+
+Qualify the existing synthetic read-only demo as a deterministic local E2E
+through the MCP Streamable HTTP boundary without adding live providers,
+credentials, mutation, durable state, or public exposure.
+
+## Outcome
+
+`npm run demo:e2e` now starts the existing fixture-only demo gateway in an
+isolated child process on `127.0.0.1` with an ephemeral port. The parent runner
+uses `@modelcontextprotocol/client` to discover and invoke `node.inspect`, prove
+one explicit allow and one policy deny with zero provider attempts, collect the
+closed protected in-memory evidence projection, stop the child, and remove the
+temporary fixture before returning success.
+
+The ordinary gateway remains inert. The private Coordination profile remains
+separate from gateway and provider paths; its targeted runtime test passed
+without a code change, so no speculative fix was applied.
+
+## Validation evidence
+
+- `npm run demo:e2e`: passed in 1.76 seconds;
+- targeted gateway, demo, and private Coordination tests: 7 passed;
+- `npm run test:runtime`: 220 passed;
+- `npm run typecheck -- --pretty false`: passed;
+- `npm run build`: passed, including the built demo E2E;
+- `npm run format:check`: passed.
+
+## Context impact
+
+This record preserves implementation and validation evidence only. The change
+uses the already reviewed issue #11 loopback demo boundary and existing
+`node.inspect` contract. It adds process isolation and explicit cleanup
+reporting but no new capability, authorization semantics, provider authority,
+credential, non-loopback listener, mutation, deployment profile, or production
+readiness claim.

--- a/.context/sessions/SESSION-2026-08-10-01-local-mcp-e2e-demo.md
+++ b/.context/sessions/SESSION-2026-08-10-01-local-mcp-e2e-demo.md
@@ -27,8 +27,8 @@ without a code change, so no speculative fix was applied.
 ## Validation evidence
 
 - `npm run demo:e2e`: passed in 1.76 seconds;
-- targeted gateway, demo, and private Coordination tests: 8 passed;
-- `npm run test:runtime`: 221 passed;
+- targeted gateway, demo, and private Coordination tests: 9 passed;
+- `npm run test:runtime`: 222 passed;
 - `npm run typecheck -- --pretty false`: passed;
 - `npm run build`: passed, including the built demo E2E;
 - `npm run format:check`: passed.

--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ Requires Node.js 22 or newer:
 
 ```sh
 npm ci --ignore-scripts
-npm run demo
+npm run demo:e2e
 ```
 
-The demo runs locally with synthetic data and no credentials. It discovers
-`node.inspect`, shows one allowed read, one denied read, and the resulting
-in-memory evidence.
+The demo starts an isolated child gateway on an ephemeral loopback port, then a
+real MCP client discovers `node.inspect`, shows one allowed read, one denied
+read, and the resulting in-memory evidence. It needs no credentials and cleans
+up its process and fixture before exit.
 
 [Follow the tutorial](https://nomed.github.io/yukh-mcp/guides/read-only-demo/)
 · [Read the documentation](https://nomed.github.io/yukh-mcp/)

--- a/apps/demo/src/demo.ts
+++ b/apps/demo/src/demo.ts
@@ -187,10 +187,7 @@ async function stopServer(child: ChildProcess): Promise<void> {
 }
 
 export async function runReadOnlyDemo(
-  options: {
-    readonly onFixtureCreated?: (root: string) => void;
-    readonly disconnectControlBeforeCleanup?: boolean;
-  } = {},
+  options: { readonly onFixtureCreated?: (root: string) => void } = {},
 ): Promise<DemoTranscript> {
   const root = await mkdtemp(join(tmpdir(), "yukh-demo-"));
   let child: ChildProcess | undefined;
@@ -267,7 +264,6 @@ export async function runReadOnlyDemo(
       denied,
       evidence_projection: evidence,
     };
-    if (options.disconnectControlBeforeCleanup) child.disconnect();
   } finally {
     let serverExited = child === undefined;
     try {

--- a/apps/demo/src/demo.ts
+++ b/apps/demo/src/demo.ts
@@ -92,35 +92,105 @@ function parseServerMessage(line: string): ReadyMessage | EvidenceMessage | { ty
   throw new Error("invalid demo server output");
 }
 
-function waitForExit(child: ChildProcess, timeoutMs: number): Promise<void> {
-  if (child.exitCode !== null)
-    return child.exitCode === 0
-      ? Promise.resolve()
-      : Promise.reject(new Error("demo server failed"));
+interface ExitResult {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+}
+
+function exited(child: ChildProcess): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+function waitForExit(child: ChildProcess, timeoutMs: number): Promise<ExitResult> {
+  if (exited(child))
+    return Promise.resolve({
+      code: child.exitCode,
+      signal: child.signalCode as NodeJS.Signals | null,
+    });
   return new Promise((resolve, reject) => {
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      clearTimeout(timeout);
+      resolve({ code, signal });
+    };
     const timeout = setTimeout(() => {
-      child.kill("SIGKILL");
+      child.off("exit", onExit);
       reject(new Error("demo server shutdown timed out"));
     }, timeoutMs);
-    child.once("exit", (code) => {
+    child.once("exit", onExit);
+  });
+}
+
+function requestStop(child: ChildProcess, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
       clearTimeout(timeout);
-      if (code === 0) resolve();
-      else reject(new Error("demo server failed"));
+      child.off("message", onMessage);
+      child.off("disconnect", onDisconnect);
+      if (error) reject(error);
+      else resolve();
+    };
+    const onMessage = (message: unknown) => {
+      if (
+        message &&
+        typeof message === "object" &&
+        Object.keys(message).length === 1 &&
+        (message as { type?: unknown }).type === "stopping"
+      )
+        finish();
+    };
+    const onDisconnect = () => finish(new Error("demo server control channel disconnected"));
+    const timeout = setTimeout(
+      () => finish(new Error("demo server stop acknowledgement timed out")),
+      timeoutMs,
+    );
+    child.on("message", onMessage);
+    child.once("disconnect", onDisconnect);
+    if (!child.connected) {
+      finish(new Error("demo server control channel unavailable"));
+      return;
+    }
+    child.send({ type: "stop" }, (error) => {
+      if (error) finish(error);
     });
   });
 }
 
-async function stopServer(child: ChildProcess): Promise<void> {
-  if (child.exitCode !== null) return waitForExit(child, 2_000);
-  if (!child.connected) throw new Error("demo server control channel unavailable");
-  await new Promise<void>((resolve, reject) => {
-    child.send({ type: "stop" }, (error) => (error ? reject(error) : resolve()));
-  });
+async function forceStopAndWait(child: ChildProcess): Promise<void> {
+  if (exited(child)) return;
+  child.kill();
+  try {
+    await waitForExit(child, 1_000);
+    return;
+  } catch {
+    if (!exited(child)) child.kill("SIGKILL");
+  }
   await waitForExit(child, 2_000);
 }
 
+async function stopServer(child: ChildProcess): Promise<void> {
+  if (exited(child)) {
+    const result = await waitForExit(child, 2_000);
+    if (result.code !== 0) throw new Error("demo server failed");
+    return;
+  }
+  try {
+    await requestStop(child, 1_000);
+    const result = await waitForExit(child, 2_000);
+    if (result.code !== 0) throw new Error("demo server failed");
+  } catch (error) {
+    await forceStopAndWait(child);
+    throw error;
+  }
+}
+
 export async function runReadOnlyDemo(
-  options: { readonly onFixtureCreated?: (root: string) => void } = {},
+  options: {
+    readonly onFixtureCreated?: (root: string) => void;
+    readonly disconnectControlBeforeCleanup?: boolean;
+  } = {},
 ): Promise<DemoTranscript> {
   const root = await mkdtemp(join(tmpdir(), "yukh-demo-"));
   let child: ChildProcess | undefined;
@@ -197,15 +267,22 @@ export async function runReadOnlyDemo(
       denied,
       evidence_projection: evidence,
     };
+    if (options.disconnectControlBeforeCleanup) child.disconnect();
   } finally {
+    let serverExited = child === undefined;
     try {
       try {
         await client?.close();
       } finally {
-        if (child) await stopServer(child);
+        if (child)
+          try {
+            await stopServer(child);
+          } finally {
+            serverExited = exited(child);
+          }
       }
     } finally {
-      await rm(root, { recursive: true, force: true });
+      if (serverExited) await rm(root, { recursive: true, force: true });
     }
   }
   if (!transcript) throw new Error("demo did not complete");

--- a/apps/demo/src/demo.ts
+++ b/apps/demo/src/demo.ts
@@ -1,130 +1,206 @@
+import { existsSync } from "node:fs";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn, type ChildProcess } from "node:child_process";
 import { Client, StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
-import { McpServer } from "@modelcontextprotocol/server";
-import { z } from "zod";
-import { createGatewayRuntime } from "../../gateway/src/server.js";
-import { createNodeInspectCapability } from "../../../packages/capabilities/src/node-inspect.js";
-import { createLocalReadNodeProvider } from "../../../packages/providers/local-read/src/node-inspect.js";
-import { createLogger } from "../../../packages/logging/src/logger.js";
 
-const inputSchema = z
-  .object({ node_ref: z.enum(["node-demo", "node-denied"]), path: z.literal("status.txt") })
-  .strict();
+export interface DemoEvidence {
+  readonly evidence_ref: string;
+  readonly event_type: "authorization.enforcement_recorded.v1";
+  readonly effect: "allow" | "deny";
+  readonly basis: "explicit";
+  readonly subject_ref: "subject_demo";
+  readonly policy_ref: "policy_demo_v1";
+  readonly classification: "protected";
+  readonly durability: "in_memory_demo_only";
+}
 
 export interface DemoTranscript {
-  readonly mode: "synthetic_local_demo";
+  readonly mode: "local_e2e";
+  readonly transport: {
+    readonly protocol: "mcp_streamable_http";
+    readonly binding: "127.0.0.1:ephemeral";
+    readonly client: "@modelcontextprotocol/client";
+    readonly server_process: "isolated_child";
+  };
   readonly discovery: { readonly tools: readonly string[] };
   readonly allowed: unknown;
   readonly denied: unknown;
-  readonly evidence_projection: readonly {
-    readonly evidence_ref: string;
-    readonly event_type: "authorization.enforcement_recorded.v1";
-    readonly effect: "allow" | "deny";
-    readonly basis: "explicit";
-    readonly subject_ref: "subject_demo";
-    readonly policy_ref: "policy_demo_v1";
-    readonly classification: "protected";
-    readonly durability: "in_memory_demo_only";
-  }[];
+  readonly evidence_projection: readonly DemoEvidence[];
+  readonly cleanup: {
+    readonly server_process: "stopped";
+    readonly fixture: "removed";
+  };
+}
+
+interface ReadyMessage {
+  readonly type: "ready";
+  readonly port: number;
+}
+
+interface EvidenceMessage {
+  readonly type: "evidence";
+  readonly evidence: DemoEvidence;
+}
+
+function serverEntrypoint(): string {
+  const javascript = fileURLToPath(new URL("./server-main.js", import.meta.url));
+  return existsSync(javascript)
+    ? javascript
+    : fileURLToPath(new URL("./server-main.ts", import.meta.url));
+}
+
+function validEvidence(value: unknown): value is DemoEvidence {
+  if (!value || typeof value !== "object") return false;
+  const evidence = value as Record<string, unknown>;
+  return (
+    Object.keys(evidence).length === 8 &&
+    typeof evidence.evidence_ref === "string" &&
+    /^evidence_demo_[1-9][0-9]*$/u.test(evidence.evidence_ref) &&
+    evidence.event_type === "authorization.enforcement_recorded.v1" &&
+    (evidence.effect === "allow" || evidence.effect === "deny") &&
+    evidence.basis === "explicit" &&
+    evidence.subject_ref === "subject_demo" &&
+    evidence.policy_ref === "policy_demo_v1" &&
+    evidence.classification === "protected" &&
+    evidence.durability === "in_memory_demo_only"
+  );
+}
+
+function parseServerMessage(line: string): ReadyMessage | EvidenceMessage | { type: "stopped" } {
+  if (Buffer.byteLength(line, "utf8") > 4_096) throw new Error("invalid demo server output");
+  const value: unknown = JSON.parse(line);
+  if (!value || typeof value !== "object") throw new Error("invalid demo server output");
+  const message = value as Record<string, unknown>;
+  if (
+    Object.keys(message).length === 2 &&
+    message.type === "ready" &&
+    Number.isInteger(message.port) &&
+    Number(message.port) >= 1 &&
+    Number(message.port) <= 65_535
+  )
+    return { type: "ready", port: Number(message.port) };
+  if (
+    Object.keys(message).length === 2 &&
+    message.type === "evidence" &&
+    validEvidence(message.evidence)
+  )
+    return { type: "evidence", evidence: message.evidence };
+  if (Object.keys(message).length === 1 && message.type === "stopped") return { type: "stopped" };
+  throw new Error("invalid demo server output");
+}
+
+function waitForExit(child: ChildProcess, timeoutMs: number): Promise<void> {
+  if (child.exitCode !== null)
+    return child.exitCode === 0
+      ? Promise.resolve()
+      : Promise.reject(new Error("demo server failed"));
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error("demo server shutdown timed out"));
+    }, timeoutMs);
+    child.once("exit", (code) => {
+      clearTimeout(timeout);
+      if (code === 0) resolve();
+      else reject(new Error("demo server failed"));
+    });
+  });
 }
 
 export async function runReadOnlyDemo(): Promise<DemoTranscript> {
   const root = await mkdtemp(join(tmpdir(), "yukh-demo-"));
+  let child: ChildProcess | undefined;
+  let client: Client | undefined;
+  const evidence: DemoEvidence[] = [];
+  let transcript: Omit<DemoTranscript, "cleanup"> | undefined;
   try {
     await writeFile(join(root, "status.txt"), "synthetic healthy fixture\n", "utf8");
-    const evidence: DemoTranscript["evidence_projection"][number][] = [];
-    const provider = await createLocalReadNodeProvider([{ ref: "node-demo", root }]);
-    let sequence = 0;
-    const capability = createNodeInspectCapability({
-      provider,
-      authorize: async (request) => {
-        const allowed = request.resource.ref === "node-demo";
-        const evidence_ref = `evidence_demo_${++sequence}`;
-        evidence.push({
-          evidence_ref,
-          event_type: "authorization.enforcement_recorded.v1",
-          effect: allowed ? "allow" : "deny",
-          basis: "explicit",
-          subject_ref: "subject_demo",
-          policy_ref: "policy_demo_v1",
-          classification: "protected",
-          durability: "in_memory_demo_only",
-        });
-        return { allowed, evidence_ref };
-      },
+    child = spawn(process.execPath, [...process.execArgv, serverEntrypoint(), root], {
+      stdio: ["ignore", "pipe", "pipe"],
     });
-
-    const createDemoServer = () => {
-      const server = new McpServer({ name: "yukh-mcp-demo", version: "0.0.0" });
-      server.registerTool(
-        "node.inspect",
-        {
-          title: "Inspect synthetic demo node",
-          description: "Read bounded metadata from the synthetic local demo fixture",
-          inputSchema,
-          annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
-        },
-        async ({ node_ref, path }) => {
-          const result = await capability.invoke({
-            request_version: 1,
-            request_id: `req_demo_${sequence + 1}`,
-            capability: { id: "node.inspect", version: "1.0.0" },
-            resource: { kind: "node", ref: node_ref },
-            environment: "demo",
-            input: { path },
-            idempotency_key: null,
-          });
-          return {
-            content: [{ type: "text", text: JSON.stringify(result) }],
-            structuredContent: { result },
-            isError: result.status !== "succeeded",
-          };
-        },
-      );
-      return server;
-    };
-
-    const runtime = createGatewayRuntime(
-      {
-        host: "127.0.0.1",
-        port: 0,
-        allowedHosts: ["127.0.0.1"],
-        allowedOrigins: [],
-        maxBodyBytes: 8_192,
-        shutdownTimeoutMs: 1_000,
-      },
-      createLogger({ sink: () => undefined }),
-      createDemoServer,
+    child.stderr?.resume();
+    const ready = new Promise<number>((resolve, reject) => {
+      let pending = "";
+      let resolved = false;
+      const timeout = setTimeout(() => reject(new Error("demo server startup timed out")), 5_000);
+      child?.once("error", reject);
+      child?.once("exit", (code) => {
+        if (!resolved) reject(new Error(`demo server exited before readiness (${String(code)})`));
+      });
+      child?.stdout?.setEncoding("utf8");
+      child?.stdout?.on("data", (chunk: string) => {
+        pending += chunk;
+        if (Buffer.byteLength(pending, "utf8") > 8_192) {
+          reject(new Error("invalid demo server output"));
+          return;
+        }
+        const lines = pending.split("\n");
+        pending = lines.pop() ?? "";
+        try {
+          for (const line of lines) {
+            if (line.length === 0) continue;
+            const message = parseServerMessage(line);
+            if (message.type === "ready") {
+              if (resolved) throw new Error("duplicate demo server readiness");
+              resolved = true;
+              clearTimeout(timeout);
+              resolve(message.port);
+            } else if (message.type === "evidence") {
+              evidence.push(message.evidence);
+            }
+          }
+        } catch (error) {
+          clearTimeout(timeout);
+          reject(error);
+        }
+      });
+    });
+    const port = await ready;
+    client = new Client({ name: "yukh-demo-client", version: "1.0.0" });
+    await client.connect(
+      new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`)),
     );
-    const { port } = await runtime.listen();
-    const client = new Client({ name: "yukh-demo-client", version: "1.0.0" });
-    try {
-      await client.connect(
-        new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`)),
-      );
-      const tools = (await client.listTools()).tools.map(({ name }) => name).sort();
-      const allowed = await client.callTool({
-        name: "node.inspect",
-        arguments: { node_ref: "node-demo", path: "status.txt" },
-      });
-      const denied = await client.callTool({
-        name: "node.inspect",
-        arguments: { node_ref: "node-denied", path: "status.txt" },
-      });
-      return {
-        mode: "synthetic_local_demo",
-        discovery: { tools },
-        allowed,
-        denied,
-        evidence_projection: evidence,
-      };
-    } finally {
-      await client.close();
-      await runtime.close();
-    }
+    const tools = (await client.listTools()).tools.map(({ name }) => name).sort();
+    const allowed = await client.callTool({
+      name: "node.inspect",
+      arguments: { node_ref: "node-demo", path: "status.txt" },
+    });
+    const denied = await client.callTool({
+      name: "node.inspect",
+      arguments: { node_ref: "node-denied", path: "status.txt" },
+    });
+    transcript = {
+      mode: "local_e2e",
+      transport: {
+        protocol: "mcp_streamable_http",
+        binding: "127.0.0.1:ephemeral",
+        client: "@modelcontextprotocol/client",
+        server_process: "isolated_child",
+      },
+      discovery: { tools },
+      allowed,
+      denied,
+      evidence_projection: evidence,
+    };
   } finally {
-    await rm(root, { recursive: true, force: true });
+    try {
+      try {
+        await client?.close();
+      } finally {
+        if (child && child.exitCode === null) child.kill("SIGTERM");
+        if (child) await waitForExit(child, 2_000);
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   }
+  if (!transcript) throw new Error("demo did not complete");
+  return {
+    ...transcript,
+    evidence_projection: [...evidence],
+    cleanup: { server_process: "stopped", fixture: "removed" },
+  };
 }

--- a/apps/demo/src/demo.ts
+++ b/apps/demo/src/demo.ts
@@ -110,16 +110,28 @@ function waitForExit(child: ChildProcess, timeoutMs: number): Promise<void> {
   });
 }
 
-export async function runReadOnlyDemo(): Promise<DemoTranscript> {
+async function stopServer(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null) return waitForExit(child, 2_000);
+  if (!child.connected) throw new Error("demo server control channel unavailable");
+  await new Promise<void>((resolve, reject) => {
+    child.send({ type: "stop" }, (error) => (error ? reject(error) : resolve()));
+  });
+  await waitForExit(child, 2_000);
+}
+
+export async function runReadOnlyDemo(
+  options: { readonly onFixtureCreated?: (root: string) => void } = {},
+): Promise<DemoTranscript> {
   const root = await mkdtemp(join(tmpdir(), "yukh-demo-"));
   let child: ChildProcess | undefined;
   let client: Client | undefined;
   const evidence: DemoEvidence[] = [];
   let transcript: Omit<DemoTranscript, "cleanup"> | undefined;
   try {
+    options.onFixtureCreated?.(root);
     await writeFile(join(root, "status.txt"), "synthetic healthy fixture\n", "utf8");
     child = spawn(process.execPath, [...process.execArgv, serverEntrypoint(), root], {
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: ["ignore", "pipe", "pipe", "ipc"],
     });
     child.stderr?.resume();
     const ready = new Promise<number>((resolve, reject) => {
@@ -190,8 +202,7 @@ export async function runReadOnlyDemo(): Promise<DemoTranscript> {
       try {
         await client?.close();
       } finally {
-        if (child && child.exitCode === null) child.kill("SIGTERM");
-        if (child) await waitForExit(child, 2_000);
+        if (child) await stopServer(child);
       }
     } finally {
       await rm(root, { recursive: true, force: true });

--- a/apps/demo/src/server-main.ts
+++ b/apps/demo/src/server-main.ts
@@ -1,0 +1,94 @@
+import { createNodeInspectCapability } from "../../../packages/capabilities/src/node-inspect.js";
+import { createLogger } from "../../../packages/logging/src/logger.js";
+import { createLocalReadNodeProvider } from "../../../packages/providers/local-read/src/node-inspect.js";
+import { McpServer } from "@modelcontextprotocol/server";
+import { z } from "zod";
+import { createGatewayRuntime } from "../../gateway/src/server.js";
+import type { DemoEvidence } from "./demo.js";
+
+const root = process.argv[2];
+if (!root || process.argv.length !== 3) throw new Error("invalid demo server configuration");
+
+const inputSchema = z
+  .object({ node_ref: z.enum(["node-demo", "node-denied"]), path: z.literal("status.txt") })
+  .strict();
+const provider = await createLocalReadNodeProvider([{ ref: "node-demo", root }]);
+let sequence = 0;
+const capability = createNodeInspectCapability({
+  provider,
+  authorize: async (request) => {
+    const allowed = request.resource.ref === "node-demo";
+    const evidence_ref = `evidence_demo_${++sequence}`;
+    const evidence: DemoEvidence = {
+      evidence_ref,
+      event_type: "authorization.enforcement_recorded.v1",
+      effect: allowed ? "allow" : "deny",
+      basis: "explicit",
+      subject_ref: "subject_demo",
+      policy_ref: "policy_demo_v1",
+      classification: "protected",
+      durability: "in_memory_demo_only",
+    };
+    process.stdout.write(`${JSON.stringify({ type: "evidence", evidence })}\n`);
+    return { allowed, evidence_ref };
+  },
+});
+
+const runtime = createGatewayRuntime(
+  {
+    host: "127.0.0.1",
+    port: 0,
+    allowedHosts: ["127.0.0.1"],
+    allowedOrigins: [],
+    maxBodyBytes: 8_192,
+    shutdownTimeoutMs: 1_000,
+  },
+  createLogger({ sink: () => undefined }),
+  () => {
+    const server = new McpServer({ name: "yukh-mcp-demo", version: "0.0.0" });
+    server.registerTool(
+      "node.inspect",
+      {
+        title: "Inspect synthetic demo node",
+        description: "Read bounded metadata from the synthetic local demo fixture",
+        inputSchema,
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+      },
+      async ({ node_ref, path }) => {
+        const result = await capability.invoke({
+          request_version: 1,
+          request_id: `req_demo_${sequence + 1}`,
+          capability: { id: "node.inspect", version: "1.0.0" },
+          resource: { kind: "node", ref: node_ref },
+          environment: "demo",
+          input: { path },
+          idempotency_key: null,
+        });
+        return {
+          content: [{ type: "text", text: JSON.stringify(result) }],
+          structuredContent: { result },
+          isError: result.status !== "succeeded",
+        };
+      },
+    );
+    return server;
+  },
+);
+
+const { port } = await runtime.listen();
+process.stdout.write(`${JSON.stringify({ type: "ready", port })}\n`);
+
+let stopping = false;
+const stop = async () => {
+  if (stopping) return;
+  stopping = true;
+  try {
+    await runtime.close();
+    process.stdout.write('{"type":"stopped"}\n');
+    process.exitCode = 0;
+  } catch {
+    process.exitCode = 1;
+  }
+};
+process.once("SIGINT", stop);
+process.once("SIGTERM", stop);

--- a/apps/demo/src/server-main.ts
+++ b/apps/demo/src/server-main.ts
@@ -88,7 +88,16 @@ const stop = async () => {
     process.exitCode = 0;
   } catch {
     process.exitCode = 1;
+  } finally {
+    process.disconnect();
   }
 };
-process.once("SIGINT", stop);
-process.once("SIGTERM", stop);
+process.on("message", (message: unknown) => {
+  if (
+    message &&
+    typeof message === "object" &&
+    Object.keys(message).length === 1 &&
+    (message as { type?: unknown }).type === "stop"
+  )
+    void stop();
+});

--- a/apps/demo/src/server-main.ts
+++ b/apps/demo/src/server-main.ts
@@ -89,7 +89,7 @@ const stop = async () => {
   } catch {
     process.exitCode = 1;
   } finally {
-    process.disconnect();
+    if (process.connected) process.disconnect();
   }
 };
 process.on("message", (message: unknown) => {
@@ -98,6 +98,11 @@ process.on("message", (message: unknown) => {
     typeof message === "object" &&
     Object.keys(message).length === 1 &&
     (message as { type?: unknown }).type === "stop"
-  )
-    void stop();
+  ) {
+    if (process.connected) {
+      process.send?.({ type: "stopping" });
+      setImmediate(() => void stop());
+    } else void stop();
+  }
 });
+process.once("disconnect", () => void stop());

--- a/docs/guides/read-only-demo.md
+++ b/docs/guides/read-only-demo.md
@@ -1,7 +1,8 @@
-# Run the read-only demo
+# Run the local read-only E2E demo
 
-Use this tutorial to see capability discovery, allow, deny, verification, and
-evidence in one local run.
+Use this tutorial to cross the real MCP Streamable HTTP boundary with the
+official MCP client and see capability discovery, allow, deny, verification,
+evidence, and cleanup in one local run.
 
 ## Prerequisites
 
@@ -14,33 +15,44 @@ No token, service, container, or configuration is required.
 
 ```sh
 npm ci --ignore-scripts
-npm run demo
+npm run demo:e2e
 ```
 
 The process exits by itself. In the JSON output, check these fields:
 
 ```text
-mode: synthetic_local_demo
+mode: local_e2e
+transport.protocol: mcp_streamable_http
+transport.binding: 127.0.0.1:ephemeral
+transport.server_process: isolated_child
 discovery.tools: [node.inspect]
 allowed.structuredContent.result.status: succeeded
 allowed.structuredContent.result.verification.status: verified
 denied.structuredContent.result.status: denied
 denied.structuredContent.result.attempts: 0
 evidence_projection[*].durability: in_memory_demo_only
+cleanup.server_process: stopped
+cleanup.fixture: removed
 ```
 
-The allowed request reads metadata from a temporary fixture. The denied request
-never invokes the provider (`attempts: 0`). Cleanup runs before exit.
+The runner starts the demo gateway in an isolated child process on an ephemeral
+loopback port. A real `@modelcontextprotocol/client` discovers and invokes
+`node.inspect` over HTTP. The allowed request reads metadata from a temporary
+fixture; the denied request never invokes the provider (`attempts: 0`). The
+runner stops the server and removes the fixture before reporting success.
 
 ## What this proves
 
-- MCP discovery can expose one reviewed capability;
+- a real MCP client can discover one reviewed capability across the HTTP gateway;
 - authorization is enforced before provider invocation;
 - results and denials use closed structured records;
-- verification and evidence are separate from execution.
+- verification and protected evidence projections are observable separately from
+  execution;
+- the child process and temporary fixture are cleaned up deterministically.
 
 ## What it does not prove
 
-The demo is not an installation profile. It uses no production identity,
-policy service, credential, target, or durable audit store. The ordinary
-gateway remains inert.
+The demo is not an installation profile. It binds only to `127.0.0.1` on an
+ephemeral port and uses no production identity, policy service, credential,
+target, provider, mutation, container, or durable audit store. Evidence is
+explicitly labeled `in_memory_demo_only`. The ordinary gateway remains inert.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,11 +17,12 @@ Requires Node.js 22 or newer:
 
 ```sh
 npm ci --ignore-scripts
-npm run demo
+npm run demo:e2e
 ```
 
-The command needs no credentials or configuration. It runs one allowed
-`node.inspect` request and one denial, then exits.
+The command needs no credentials or configuration. It uses a real MCP client
+over an ephemeral loopback HTTP port, runs one allowed `node.inspect` request
+and one denial, cleans up, then exits.
 
 [Run the demo](guides/read-only-demo.md){ .md-button .md-button--primary }
 [Understand the architecture](architecture/overview.md){ .md-button }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start": "node dist/apps/gateway/src/main.js",
     "dev": "tsx apps/gateway/src/main.ts",
     "demo": "tsx apps/demo/src/main.ts",
+    "demo:e2e": "tsx apps/demo/src/main.ts",
     "format:check": "prettier --check apps packages test/contracts/authorization-v1.test.mjs 'test/contracts/*.test.ts' test/runtime package.json tsconfig.json tsconfig.build.json compose.yaml '.github/**/*.yml'",
     "test": "bash -c 'rm -rf .audit-test-scratch && mkdir .audit-test-scratch && trap \"rm -rf .audit-test-scratch\" EXIT; TMPDIR=\"$PWD/.audit-test-scratch\" npm run test:contracts && TMPDIR=\"$PWD/.audit-test-scratch\" node --test test/supply-chain/*.test.mjs && TMPDIR=\"$PWD/.audit-test-scratch\" npm run test:runtime'",
     "test:contracts": "bash -c 'mkdir -p .audit-test-scratch && TMPDIR=\"$PWD/.audit-test-scratch\" node --import tsx --test test/contracts/*.test.mjs test/contracts/*.test.ts'",

--- a/test/runtime/demo.test.ts
+++ b/test/runtime/demo.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
-import { access, mkdtemp, rm } from "node:fs/promises";
+import { spawn, type ChildProcess } from "node:child_process";
+import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import { runReadOnlyDemo } from "../../apps/demo/src/demo.js";
 
 interface ToolResult {
@@ -21,6 +23,66 @@ function toolResult(response: unknown): ToolResult {
   const result = (structuredContent as { result?: unknown }).result;
   assert.ok(result && typeof result === "object");
   return result as ToolResult;
+}
+
+function waitForReady(child: ChildProcess, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let pending = "";
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      child.stdout?.off("data", onData);
+      child.off("exit", onExit);
+      if (error) reject(error);
+      else resolve();
+    };
+    const onData = (chunk: string) => {
+      pending += chunk;
+      const lines = pending.split("\n");
+      pending = lines.pop() ?? "";
+      try {
+        for (const line of lines) {
+          if (line.length === 0) continue;
+          const message: unknown = JSON.parse(line);
+          if (
+            message &&
+            typeof message === "object" &&
+            (message as { type?: unknown }).type === "ready"
+          ) {
+            finish();
+            return;
+          }
+        }
+      } catch {
+        finish(new Error("invalid isolated demo server output"));
+      }
+    };
+    const onExit = () => finish(new Error("isolated demo server exited before readiness"));
+    const timeout = setTimeout(
+      () => finish(new Error("isolated demo server readiness timed out")),
+      timeoutMs,
+    );
+    child.stdout?.setEncoding("utf8");
+    child.stdout?.on("data", onData);
+    child.once("exit", onExit);
+  });
+}
+
+function waitForExit(child: ChildProcess, timeoutMs: number): Promise<number | null> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve(child.exitCode);
+  return new Promise((resolve, reject) => {
+    const onExit = (code: number | null) => {
+      clearTimeout(timeout);
+      resolve(code);
+    };
+    const timeout = setTimeout(() => {
+      child.off("exit", onExit);
+      reject(new Error("isolated demo server exit timed out"));
+    }, timeoutMs);
+    child.once("exit", onExit);
+  });
 }
 
 test("local E2E correlates allow and deny results with policy evidence", async () => {
@@ -82,17 +144,26 @@ test("cleanup removes only the invocation fixture", async () => {
   }
 });
 
-test("IPC disconnect fails closed after stopping the child and removing its fixture", async () => {
-  let invocationFixture: string | undefined;
-  await assert.rejects(
-    runReadOnlyDemo({
-      onFixtureCreated: (root) => {
-        invocationFixture = root;
-      },
-      disconnectControlBeforeCleanup: true,
-    }),
-    /control channel/u,
+test("isolated child shuts itself down when its parent IPC channel disconnects", async () => {
+  const fixture = await mkdtemp(join(tmpdir(), "yukh-demo-"));
+  const serverEntrypoint = fileURLToPath(
+    new URL("../../apps/demo/src/server-main.ts", import.meta.url),
   );
-  assert.ok(invocationFixture);
-  await assert.rejects(access(invocationFixture), { code: "ENOENT" });
+  const child = spawn(process.execPath, [...process.execArgv, serverEntrypoint, fixture], {
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+  });
+  child.stderr?.resume();
+  try {
+    await writeFile(join(fixture, "status.txt"), "synthetic healthy fixture\n", "utf8");
+    await waitForReady(child, 5_000);
+    child.disconnect();
+    assert.equal(await waitForExit(child, 2_000), 0);
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGKILL");
+      await waitForExit(child, 2_000);
+    }
+    await rm(fixture, { recursive: true, force: true });
+  }
+  await assert.rejects(access(fixture), { code: "ENOENT" });
 });

--- a/test/runtime/demo.test.ts
+++ b/test/runtime/demo.test.ts
@@ -1,11 +1,29 @@
 import assert from "node:assert/strict";
-import { readdir } from "node:fs/promises";
+import { access, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import { runReadOnlyDemo } from "../../apps/demo/src/demo.js";
 
-test("local E2E crosses MCP/HTTP and proves allow, deny, evidence, and cleanup", async () => {
-  const before = new Set((await readdir(tmpdir())).filter((name) => name.startsWith("yukh-demo-")));
+interface ToolResult {
+  readonly status: "succeeded" | "denied" | "failed";
+  readonly attempts: number;
+  readonly verification: {
+    readonly status: "verified" | "not_applicable";
+    readonly evidence_refs: readonly string[];
+  };
+}
+
+function toolResult(response: unknown): ToolResult {
+  assert.ok(response && typeof response === "object");
+  const structuredContent = (response as { structuredContent?: unknown }).structuredContent;
+  assert.ok(structuredContent && typeof structuredContent === "object");
+  const result = (structuredContent as { result?: unknown }).result;
+  assert.ok(result && typeof result === "object");
+  return result as ToolResult;
+}
+
+test("local E2E correlates allow and deny results with policy evidence", async () => {
   const transcript = await runReadOnlyDemo();
   assert.equal(transcript.mode, "local_e2e");
   assert.deepEqual(transcript.transport, {
@@ -17,10 +35,23 @@ test("local E2E crosses MCP/HTTP and proves allow, deny, evidence, and cleanup",
   assert.deepEqual(transcript.discovery.tools, ["node.inspect"]);
   assert.equal((transcript.allowed as { isError?: boolean }).isError, false);
   assert.equal((transcript.denied as { isError?: boolean }).isError, true);
+  const allowed = toolResult(transcript.allowed);
+  const denied = toolResult(transcript.denied);
+  assert.equal(allowed.status, "succeeded");
+  assert.equal(allowed.attempts, 1);
+  assert.equal(allowed.verification.status, "verified");
+  assert.equal(denied.status, "denied");
+  assert.equal(denied.attempts, 0);
+  assert.equal(denied.verification.status, "not_applicable");
   assert.deepEqual(
     transcript.evidence_projection.map(({ effect }) => effect),
     ["allow", "deny"],
   );
+  const [allowEvidence, denyEvidence] = transcript.evidence_projection;
+  assert.ok(allowEvidence);
+  assert.ok(denyEvidence);
+  assert.deepEqual(allowed.verification.evidence_refs, [allowEvidence.evidence_ref]);
+  assert.deepEqual(denied.verification.evidence_refs, [denyEvidence.evidence_ref]);
   assert.ok(
     transcript.evidence_projection.every(
       ({ durability, classification }) =>
@@ -32,9 +63,21 @@ test("local E2E crosses MCP/HTTP and proves allow, deny, evidence, and cleanup",
     server_process: "stopped",
     fixture: "removed",
   });
-  const after = (await readdir(tmpdir())).filter((name) => name.startsWith("yukh-demo-"));
-  assert.deepEqual(
-    after.filter((name) => !before.has(name)),
-    [],
-  );
+});
+
+test("cleanup removes only the invocation fixture", async () => {
+  const concurrentFixture = await mkdtemp(join(tmpdir(), "yukh-demo-"));
+  let invocationFixture: string | undefined;
+  try {
+    await runReadOnlyDemo({
+      onFixtureCreated: (root) => {
+        invocationFixture = root;
+      },
+    });
+    assert.ok(invocationFixture);
+    await assert.rejects(access(invocationFixture), { code: "ENOENT" });
+    await access(concurrentFixture);
+  } finally {
+    await rm(concurrentFixture, { recursive: true, force: true });
+  }
 });

--- a/test/runtime/demo.test.ts
+++ b/test/runtime/demo.test.ts
@@ -4,9 +4,16 @@ import { tmpdir } from "node:os";
 import test from "node:test";
 import { runReadOnlyDemo } from "../../apps/demo/src/demo.js";
 
-test("five-minute demo discovers one read tool and proves allow plus deny", async () => {
+test("local E2E crosses MCP/HTTP and proves allow, deny, evidence, and cleanup", async () => {
   const before = new Set((await readdir(tmpdir())).filter((name) => name.startsWith("yukh-demo-")));
   const transcript = await runReadOnlyDemo();
+  assert.equal(transcript.mode, "local_e2e");
+  assert.deepEqual(transcript.transport, {
+    protocol: "mcp_streamable_http",
+    binding: "127.0.0.1:ephemeral",
+    client: "@modelcontextprotocol/client",
+    server_process: "isolated_child",
+  });
   assert.deepEqual(transcript.discovery.tools, ["node.inspect"]);
   assert.equal((transcript.allowed as { isError?: boolean }).isError, false);
   assert.equal((transcript.denied as { isError?: boolean }).isError, true);
@@ -21,6 +28,10 @@ test("five-minute demo discovers one read tool and proves allow plus deny", asyn
     ),
   );
   assert.equal(JSON.stringify(transcript).includes("synthetic healthy fixture"), false);
+  assert.deepEqual(transcript.cleanup, {
+    server_process: "stopped",
+    fixture: "removed",
+  });
   const after = (await readdir(tmpdir())).filter((name) => name.startsWith("yukh-demo-"));
   assert.deepEqual(
     after.filter((name) => !before.has(name)),

--- a/test/runtime/demo.test.ts
+++ b/test/runtime/demo.test.ts
@@ -81,3 +81,18 @@ test("cleanup removes only the invocation fixture", async () => {
     await rm(concurrentFixture, { recursive: true, force: true });
   }
 });
+
+test("IPC disconnect fails closed after stopping the child and removing its fixture", async () => {
+  let invocationFixture: string | undefined;
+  await assert.rejects(
+    runReadOnlyDemo({
+      onFixtureCreated: (root) => {
+        invocationFixture = root;
+      },
+      disconnectControlBeforeCleanup: true,
+    }),
+    /control channel/u,
+  );
+  assert.ok(invocationFixture);
+  await assert.rejects(access(invocationFixture), { code: "ENOENT" });
+});


### PR DESCRIPTION
## Summary

- run a real MCP client against the demo gateway over loopback HTTP on an ephemeral port
- use acknowledged IPC shutdown, child fail-safe shutdown on disconnect, and forced parent termination with exit waiting on control failures
- prove child-initiated disconnect handling by spawning the server directly, closing IPC without runner teardown, and requiring spontaneous clean exit before fixture cleanup
- verify invocation-scoped fixture cleanup and no residual process or fixture
- prove `node.inspect` allow/verified, policy deny before provider invocation (`attempts: 0`), and correlated protected in-memory evidence
- keep the ordinary gateway inert with no live provider, secret, mutation, or public exposure

## Validation

- runtime suite: 222 tests passed
- targeted gateway/demo/private-coordination tests: 9 passed
- typecheck passed
- build and built E2E passed
- format checks passed