### PR TITLE
Propose explicit local Coordination bootstrap

### DIFF
--- a/.context/rfcs/RFC-0013-explicit-local-coordination-bootstrap.md
+++ b/.context/rfcs/RFC-0013-explicit-local-coordination-bootstrap.md
@@ -1,0 +1,87 @@
+# RFC-0013 — Explicit local Coordination bootstrap
+
+- Status: Proposed
+- Authors: Codex
+- Created: 2026-08-14
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/111
+- Depends on: RFC-0012, https://github.com/nomed/yukh-coordination/issues/222
+- Amends: RFC-0012
+
+## Summary
+
+Add one preview-only MCP tool, `coordination.bootstrap`, so the fixed Codex or
+Copilot identity can explicitly obtain a fresh short-lived Coordination
+session after expiry. The action is never automatic and never retries another
+operation.
+
+## Motivation
+
+RFC-0012 exposes session operations but not the prerequisite bootstrap.
+Sessions expire after ten minutes by design. A host that receives
+`YKC-AUTH-001` cannot recover using only MCP and currently requires a person to
+run the native launcher. This prevents a sustained Codex–Copilot exercise.
+
+## Design
+
+The preview server exposes six tools, adding this fixed mapping:
+
+| MCP tool | Coordination command | Effect |
+| --- | --- | --- |
+| `coordination.bootstrap` | `session bootstrap` | replace an expired or create an absent short-lived session |
+
+The tool accepts no input. Agent identity, launcher, configuration, custody
+profile, descriptors and endpoints remain process-owned. The launcher keeps
+all tokens and keys outside MCP input, output and logs.
+
+The native client must:
+
+- reject bootstrap while the stored session is live;
+- replace an expired session using the exact stored revision;
+- obtain fresh external authority for every explicit attempt;
+- retain the existing 15-minute maximum lifetime;
+- return only the closed result or sanitized `YKC-*` error.
+
+The bridge must not invoke bootstrap after an auth failure, replay the failed
+operation, poll expiry or run in the background. The model or user chooses the
+bootstrap tool as a separate observable action.
+
+## Security impact
+
+The new model-selected action reaches credential custody but cannot select or
+observe credential material. Main threats are repeated issuance, live-session
+replacement, command substitution and presenting bootstrap as authorization.
+Controls are the no-input schema, fixed command registry, native live-session
+refusal, exact-revision CAS, bounded execution and unchanged separation between
+Coordination identity and capability authority.
+
+Residual risks are local denial of service through repeated refused calls and
+availability loss when the native authority is unavailable. The tool remains
+local-preview-only and grants no provider or protected-target authority.
+
+## Qualification
+
+- discovery lists exactly the six preview tools while the ordinary gateway
+  remains empty;
+- fake-launcher tests prove the exact no-input command mapping;
+- unknown command, caller-selected profile and credential-shaped input fail;
+- live-session refusal and expired-session replacement remain qualified by the
+  native client;
+- one Mac test expires or invalidates a session, explicitly bootstraps through
+  MCP, then completes join and replay for both agents.
+
+## Rollback
+
+Remove the bootstrap registration and command allowlist entry. Existing native
+sessions and transcript data require no migration.
+
+## Alternatives
+
+Automatic renewal was rejected because it hides a credential mutation and
+could replay an operation after an ambiguous result. Longer sessions were
+rejected because they weaken the accepted short-lived preview identity rather
+than fixing recovery.
+
+## Acceptance
+
+Implementation is forbidden until the project owner explicitly accepts this
+RFC and the threat-model impact.

--- a/.context/rfcs/RFC-0013-explicit-local-coordination-bootstrap.md
+++ b/.context/rfcs/RFC-0013-explicit-local-coordination-bootstrap.md
@@ -1,8 +1,10 @@
 # RFC-0013 — Explicit local Coordination bootstrap
 
-- Status: Proposed
+- Status: Accepted
 - Authors: Codex
 - Created: 2026-08-14
+- Accepted: 2026-08-14
+- Decider: project owner
 - Governing issue: https://github.com/nomed/yukh-mcp/issues/111
 - Depends on: RFC-0012, https://github.com/nomed/yukh-coordination/issues/222
 - Amends: RFC-0012
@@ -83,5 +85,6 @@ than fixing recovery.
 
 ## Acceptance
 
-Implementation is forbidden until the project owner explicitly accepts this
-RFC and the threat-model impact.
+The project owner explicitly accepted this RFC and its threat-model impact on
+2026-08-14. Acceptance authorizes only the local-preview implementation and
+qualification described here.

--- a/apps/coordination-preview/src/server.ts
+++ b/apps/coordination-preview/src/server.ts
@@ -57,6 +57,17 @@ export function createCoordinationPreviewServer(options: {
   );
 
   server.registerTool(
+    "coordination.bootstrap",
+    {
+      title: "Bootstrap the local Coordination session",
+      description: `Explicitly create or replace an expired session for the fixed ${label} preview identity`,
+      inputSchema: z.object({}).strict(),
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+    },
+    () => invoke(options.launcher, "session bootstrap"),
+  );
+
+  server.registerTool(
     "coordination.join",
     {
       title: "Join the local Coordination preview",

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -1,12 +1,7 @@
 # Connect Codex and Copilot locally
 
 This preview uses the Yukh Coordination Compose sandbox already running on the
-Mac. Bootstrap both identities first:
-
-```sh
-.github/scripts/yukh-local-agent.py agent-a session bootstrap
-.github/scripts/yukh-local-agent.py agent-b session bootstrap
-```
+Mac. Each agent bootstraps its own short-lived session through MCP.
 
 Build Yukh MCP from its repository:
 
@@ -22,7 +17,7 @@ Use absolute paths below. Configure Codex as `agent-a`:
 command = "node"
 args = ["/path/to/yukh-mcp/dist/apps/coordination-preview/src/main.js"]
 env = { YUKH_COORDINATION_AGENT = "agent-a", YUKH_COORDINATION_LAUNCHER = "/path/to/yukh-coordination/.github/scripts/yukh-local-agent.py" }
-enabled_tools = ["coordination.join", "coordination.ask", "coordination.answer", "coordination.replay", "coordination.leave"]
+enabled_tools = ["coordination.bootstrap", "coordination.join", "coordination.ask", "coordination.answer", "coordination.replay", "coordination.leave"]
 default_tools_approval_mode = "writes"
 ```
 
@@ -38,7 +33,7 @@ copilot mcp add yukh-coordination \
 Ask Codex:
 
 ```text
-Use yukh_coordination. Join, then ask Copilot on
+Use yukh_coordination. Bootstrap, join, then ask Copilot on
 https://preview.local/work/codex-copilot-first-contact:
 "Reply with the Coordination event id you received and confirm this came through Yukh."
 ```
@@ -46,7 +41,7 @@ https://preview.local/work/codex-copilot-first-contact:
 Ask Copilot:
 
 ```text
-Use yukh-coordination. Join, replay the transcript, and answer the newest
+Use yukh-coordination. Bootstrap, join, replay the transcript, and answer the newest
 question addressed to you. Preserve its work URI, correlation id and question
 event id.
 ```

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -173,10 +173,10 @@ preview. Transcript content remains untrusted data. Implementation requires
 negative tests for command, profile, credential and output-boundary
 substitution.
 
-## Proposed explicit local Coordination bootstrap — 2026-08-14
+## Accepted explicit local Coordination bootstrap — 2026-08-14
 
 - Governing issue: #111
-- Proposed architecture: RFC-0013
+- Accepted architecture: RFC-0013
 - Scope: one no-input, preview-only MCP action for explicit session bootstrap
 - Changed trust boundary: model-selected call reaches native credential custody
 
@@ -185,9 +185,9 @@ profile or credential. The native client refuses replacement of a live session
 and uses exact-revision CAS for an expired session. Bootstrap is never invoked
 implicitly and never retries a failed Coordination operation. Credential and
 key material remain outside MCP input, output and logs. Residual risks are
-local issuance denial of service and availability loss. This proposal grants
-no provider or protected-target authority and authorizes no implementation
-until RFC-0013 is explicitly accepted.
+local issuance denial of service and availability loss. This accepted boundary
+grants no provider or protected-target authority and authorizes only the
+local-preview implementation and qualification in RFC-0013.
 
 ## Capability contract implementation review — 2026-08-03
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -173,6 +173,22 @@ preview. Transcript content remains untrusted data. Implementation requires
 negative tests for command, profile, credential and output-boundary
 substitution.
 
+## Proposed explicit local Coordination bootstrap — 2026-08-14
+
+- Governing issue: #111
+- Proposed architecture: RFC-0013
+- Scope: one no-input, preview-only MCP action for explicit session bootstrap
+- Changed trust boundary: model-selected call reaches native credential custody
+
+The tool cannot select an agent, command, launcher, endpoint, descriptor,
+profile or credential. The native client refuses replacement of a live session
+and uses exact-revision CAS for an expired session. Bootstrap is never invoked
+implicitly and never retries a failed Coordination operation. Credential and
+key material remain outside MCP input, output and logs. Residual risks are
+local issuance denial of service and availability loss. This proposal grants
+no provider or protected-target authority and authorizes no implementation
+until RFC-0013 is explicitly accepted.
+
 ## Capability contract implementation review — 2026-08-03
 
 - Governing issue: #5

--- a/packages/coordination-preview/src/launcher.ts
+++ b/packages/coordination-preview/src/launcher.ts
@@ -4,6 +4,7 @@ import { spawn } from "node:child_process";
 
 const maximumOutputBytes = 1 << 20;
 const commandNames = new Set([
+  "session bootstrap",
   "session join",
   "question ask",
   "question answer",

--- a/test/runtime/coordination-preview.test.ts
+++ b/test/runtime/coordination-preview.test.ts
@@ -50,10 +50,15 @@ process.stdout.write(JSON.stringify({schema:1,status:"ok",command,result})+"\\n"
     assert.deepEqual((await client.listTools()).tools.map(({ name }) => name).sort(), [
       "coordination.answer",
       "coordination.ask",
+      "coordination.bootstrap",
       "coordination.join",
       "coordination.leave",
       "coordination.replay",
     ]);
+    assert.equal(
+      (await client.callTool({ name: "coordination.bootstrap", arguments: {} })).isError,
+      false,
+    );
     assert.equal(
       (await client.callTool({ name: "coordination.join", arguments: {} })).isError,
       false,
@@ -84,6 +89,15 @@ process.stdout.write(JSON.stringify({schema:1,status:"ok",command,result})+"\\n"
       ).isError,
       true,
     );
+    assert.equal(
+      (
+        await client.callTool({
+          name: "coordination.bootstrap",
+          arguments: { profile: "agent-b", credential: "substituted" },
+        })
+      ).isError,
+      true,
+    );
     const calls = (await readFile(log, "utf8"))
       .trim()
       .split("\n")
@@ -91,12 +105,14 @@ process.stdout.write(JSON.stringify({schema:1,status:"ok",command,result})+"\\n"
     assert.deepEqual(
       calls.map(({ args }) => args),
       [
+        ["agent-a", "session", "bootstrap"],
         ["agent-a", "session", "join"],
         ["agent-a", "question", "ask"],
         ["agent-a", "events", "replay"],
       ],
     );
-    assert.deepEqual(calls[1]?.input?.requested_from, ["agent:b"]);
+    assert.equal(calls[0]?.input, null);
+    assert.deepEqual(calls[2]?.input?.requested_from, ["agent:b"]);
   } finally {
     await client.close();
     await rm(root, { recursive: true, force: true });


### PR DESCRIPTION
Closes #111.

RFC-0013 and its threat-model impact were explicitly accepted by the project owner on 2026-08-14.

## Outcome
- adds one no-input local-preview tool: `coordination.bootstrap`;
- maps only to the fixed profile session bootstrap command;
- exposes no path, descriptor, profile, token or credential input;
- performs no implicit renewal or retry;
- updates the runnable Codex–Copilot guide.

## Validation
- exact discovery and command mapping covered;
- credential/profile-shaped input rejected before launcher invocation;
- formatting and typecheck pass locally;
- full Node 24 suite and build run in required CI.

## Context impact
RFC-0013 accepted; threat model updated. The ordinary gateway remains inert and no provider or protected-target authority is added.