### PR TITLE
Wake local Codex and Copilot agents from Coordination

### DIFF
--- a/.context/rfcs/RFC-0014-bounded-local-conversation-coordinator.md
+++ b/.context/rfcs/RFC-0014-bounded-local-conversation-coordinator.md
@@ -1,0 +1,56 @@
+# RFC-0014 — Bounded local conversation coordinator
+
+- Status: Accepted
+- Authors: Codex
+- Created: 2026-08-14
+- Accepted: 2026-08-14
+- Decider: project owner
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/113
+- Depends on: RFC-0012, RFC-0013
+
+## Summary
+
+Add a local-only process that watches the verified Coordination transcript and
+wakes the fixed Codex or Copilot CLI adapter for an unanswered directed
+question. The project owner authorized this increment after identifying manual
+polling as the remaining blocker to agent conversation.
+
+## Design
+
+One coordinator owns two fixed native launchers and two fixed CLI adapters. It
+replays the shared transcript, selects the oldest unanswered question directed
+to one agent, invokes that adapter once with the event identifier, then requires
+the agent to replay and answer through the existing MCP tools.
+
+The run has one in-flight adapter, exact event deduplication, a maximum turn
+count, an absolute lifetime, bounded polling and an adapter timeout. On
+`YKC-AUTH-001` it may perform one explicit bootstrap action for that fixed
+identity and repeat only replay; it never retries a publication.
+
+Codex uses `codex exec`. Copilot uses programmatic `copilot -p` and grants only
+the configured `yukh-coordination` MCP server. Executable paths and workspace
+are absolute process configuration. No shell is used.
+
+## Security impact
+
+Transcript content is untrusted and is never interpreted as executable
+configuration. The adapter prompt contains only a server-owned instruction and
+the validated event ID. Logs contain lifecycle codes and identifiers, never
+message bodies, model output, credentials or arbitrary errors.
+
+The coordinator grants no provider or protected-target authority. Local CLI
+file-writing authority remains bounded by each host's sandbox and trusted
+workspace configuration. Residual risks are model-authored workspace changes,
+local denial of service and a stalled conversation.
+
+## Qualification
+
+Tests cover directed selection, answered-event exclusion, duplicate prevention,
+turn/lifetime limits, auth recovery, no publication retry, malformed transcript
+rejection and fixed adapter arguments. The first live qualification is a Task
+Board exchange with Codex leading backend work and Copilot handling frontend.
+
+## Rollback
+
+Stop and remove the coordinator process. MCP tools, native sessions and
+transcript data require no migration.

--- a/apps/conversation-coordinator/src/main.ts
+++ b/apps/conversation-coordinator/src/main.ts
@@ -1,0 +1,31 @@
+import { createCoordinationLauncher } from "../../../packages/coordination-preview/src/launcher.js";
+import { ConversationCoordinator } from "../../../packages/conversation-coordinator/src/coordinator.js";
+import { createAgentRunner } from "../../../packages/conversation-coordinator/src/runner.js";
+
+const required = (name: string): string => {
+  const value = process.env[name];
+  if (!value) throw new TypeError("invalid coordinator configuration");
+  return value;
+};
+
+const launcher = required("YUKH_COORDINATION_LAUNCHER");
+const coordinator = new ConversationCoordinator({
+  launchers: {
+    "agent-a": createCoordinationLauncher({ path: launcher, agent: "agent-a" }),
+    "agent-b": createCoordinationLauncher({ path: launcher, agent: "agent-b" }),
+  },
+  runner: createAgentRunner({
+    codex: required("YUKH_CODEX_EXECUTABLE"),
+    copilot: required("YUKH_COPILOT_EXECUTABLE"),
+    workspace: required("YUKH_CONVERSATION_WORKSPACE"),
+  }),
+  maxTurns: 20,
+  lifetimeMs: 4 * 60 * 60 * 1_000,
+});
+
+for (;;) {
+  const outcome = await coordinator.tick();
+  process.stdout.write(`${JSON.stringify({ schema: 1, event: "coordinator_tick", outcome })}\n`);
+  if (outcome === "complete") break;
+  await new Promise((resolve) => setTimeout(resolve, outcome === "idle" ? 2_000 : 250));
+}

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -47,6 +47,24 @@ event id.
 ```
 
 Finally ask Codex to replay the transcript and report the verified answer.
+
+## Run bounded automatic wake-up
+
+After building this repository, start the local coordinator from the trusted
+application workspace:
+
+```sh
+YUKH_COORDINATION_LAUNCHER=/absolute/path/to/yukh-local-agent.py \
+YUKH_CODEX_EXECUTABLE=/absolute/path/to/codex \
+YUKH_COPILOT_EXECUTABLE=/absolute/path/to/copilot \
+YUKH_CONVERSATION_WORKSPACE=/absolute/path/to/task-board \
+node /absolute/path/to/yukh-mcp/dist/apps/conversation-coordinator/src/main.js
+```
+
+Seed one directed question through `coordination.ask`. The coordinator wakes
+the addressed CLI, which answers and may publish one directed follow-up. It
+stops after 20 turns or four hours. Stop it earlier with `Ctrl+C`.
+
 Remove the Copilot server with `copilot mcp remove yukh-coordination`; remove
 the Codex table and restart Codex. Stop the sandbox with the Coordination
 `yukh-local-preview-macos.sh down` command.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -189,6 +189,21 @@ local issuance denial of service and availability loss. This accepted boundary
 grants no provider or protected-target authority and authorizes only the
 local-preview implementation and qualification in RFC-0013.
 
+## Accepted bounded local conversation coordinator — 2026-08-14
+
+- Governing issue: #113
+- Accepted architecture: RFC-0014
+- Scope: local wake-up of fixed Codex and Copilot CLI adapters
+
+The coordinator treats transcript bodies as untrusted data and passes adapters
+only a server-owned instruction plus a validated event ID. Fixed absolute
+executables, no shell, a trusted workspace, one in-flight turn, deduplication,
+timeouts, run lifetime and turn ceilings constrain execution. Authentication
+recovery may repeat replay only; publications are never retried. Closed logs
+exclude prompts, model output, credentials and arbitrary errors. Residual risk
+is bounded local workspace mutation or availability loss; no provider or
+protected-target authority is granted.
+
 ## Capability contract implementation review — 2026-08-03
 
 - Governing issue: #5

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "demo": "tsx apps/demo/src/main.ts",
     "demo:e2e": "tsx apps/demo/src/main.ts",
     "preview:coordination": "tsx apps/coordination-preview/src/main.ts",
+    "preview:conversation": "tsx apps/conversation-coordinator/src/main.ts",
     "format:check": "prettier --check apps packages test/contracts/authorization-v1.test.mjs 'test/contracts/*.test.ts' test/runtime package.json tsconfig.json tsconfig.build.json compose.yaml '.github/**/*.yml'",
     "test": "bash -c 'rm -rf .audit-test-scratch && mkdir .audit-test-scratch && trap \"rm -rf .audit-test-scratch\" EXIT; TMPDIR=\"$PWD/.audit-test-scratch\" npm run test:contracts && TMPDIR=\"$PWD/.audit-test-scratch\" node --test test/supply-chain/*.test.mjs && TMPDIR=\"$PWD/.audit-test-scratch\" npm run test:runtime'",
     "test:contracts": "bash -c 'mkdir -p .audit-test-scratch && TMPDIR=\"$PWD/.audit-test-scratch\" node --import tsx --test test/contracts/*.test.mjs test/contracts/*.test.ts'",

--- a/packages/conversation-coordinator/src/coordinator.ts
+++ b/packages/conversation-coordinator/src/coordinator.ts
@@ -1,0 +1,112 @@
+import type {
+  CoordinationLauncher,
+  CoordinationOutput,
+  PreviewAgent,
+} from "../../coordination-preview/src/launcher.js";
+
+const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+
+export interface AgentRunner {
+  run(agent: PreviewAgent, prompt: string): Promise<void>;
+}
+
+export interface CoordinatorOptions {
+  readonly launchers: Readonly<Record<PreviewAgent, CoordinationLauncher>>;
+  readonly runner: AgentRunner;
+  readonly maxTurns: number;
+  readonly lifetimeMs: number;
+  readonly now?: () => number;
+}
+
+type RecordValue = { readonly event?: unknown };
+type EventValue = {
+  readonly id: string;
+  readonly type: string;
+  readonly data: Record<string, unknown>;
+};
+
+function events(output: CoordinationOutput): EventValue[] {
+  if (output.status !== "ok" || !output.result || typeof output.result !== "object")
+    throw new Error("coordination_protocol_error");
+  const records = (output.result as { records?: unknown }).records;
+  if (!Array.isArray(records)) throw new Error("coordination_protocol_error");
+  return records.map((record: RecordValue) => {
+    const event = record?.event;
+    if (!event || typeof event !== "object") throw new Error("coordination_protocol_error");
+    const value = event as EventValue;
+    if (
+      !uuid.test(value.id) ||
+      typeof value.type !== "string" ||
+      !value.data ||
+      typeof value.data !== "object"
+    )
+      throw new Error("coordination_protocol_error");
+    return value;
+  });
+}
+
+function target(event: EventValue): PreviewAgent | undefined {
+  if (event.type !== "question" || !Array.isArray(event.data.requested_from)) return undefined;
+  if (event.data.requested_from.includes("agent:a")) return "agent-a";
+  if (event.data.requested_from.includes("agent:b")) return "agent-b";
+  return undefined;
+}
+
+export class ConversationCoordinator {
+  readonly #options: CoordinatorOptions;
+  readonly #started: number;
+  readonly #attempted = new Set<string>();
+  #turns = 0;
+
+  constructor(options: CoordinatorOptions) {
+    if (
+      !Number.isInteger(options.maxTurns) ||
+      options.maxTurns < 1 ||
+      options.maxTurns > 100 ||
+      !Number.isInteger(options.lifetimeMs) ||
+      options.lifetimeMs < 1_000 ||
+      options.lifetimeMs > 86_400_000
+    )
+      throw new TypeError("invalid coordinator bounds");
+    this.#options = options;
+    this.#started = (options.now ?? Date.now)();
+  }
+
+  async tick(): Promise<"idle" | "invoked" | "complete"> {
+    const now = (this.#options.now ?? Date.now)();
+    if (this.#turns >= this.#options.maxTurns || now - this.#started >= this.#options.lifetimeMs)
+      return "complete";
+    const transcript = events(await this.#replay("agent-a"));
+    const answered = new Set(
+      transcript
+        .filter(
+          (event) => event.type === "answer" && uuid.test(String(event.data.question_event_id)),
+        )
+        .map((event) => String(event.data.question_event_id)),
+    );
+    const question = transcript.find((event) => {
+      const addressed = target(event);
+      return addressed && !answered.has(event.id) && !this.#attempted.has(event.id);
+    });
+    if (!question) return "idle";
+    const agent = target(question);
+    if (!agent) return "idle";
+    this.#attempted.add(question.id);
+    this.#turns++;
+    await this.#options.runner.run(
+      agent,
+      `Use only yukh-coordination. Bootstrap if required, join, replay, find question event ${question.id}, and answer it preserving work_uri, correlation_id and question_event_id. If the work needs another peer action, publish one directed follow-up question with the same work_uri.`,
+    );
+    return "invoked";
+  }
+
+  async #replay(agent: PreviewAgent): Promise<CoordinationOutput> {
+    let output = await this.#options.launchers[agent].invoke("events replay");
+    if (output.status === "error" && output.code === "YKC-AUTH-001") {
+      const bootstrap = await this.#options.launchers[agent].invoke("session bootstrap");
+      if (bootstrap.status !== "ok") return bootstrap;
+      output = await this.#options.launchers[agent].invoke("events replay");
+    }
+    return output;
+  }
+}

--- a/packages/conversation-coordinator/src/runner.ts
+++ b/packages/conversation-coordinator/src/runner.ts
@@ -1,0 +1,83 @@
+import { lstatSync, realpathSync } from "node:fs";
+import { isAbsolute } from "node:path";
+import { spawn } from "node:child_process";
+import type { PreviewAgent } from "../../coordination-preview/src/launcher.js";
+import type { AgentRunner } from "./coordinator.js";
+
+function executable(path: string): string {
+  if (!isAbsolute(path)) throw new TypeError("invalid agent executable");
+  const info = lstatSync(path);
+  if (
+    !info.isFile() ||
+    info.isSymbolicLink() ||
+    (info.mode & 0o111) === 0 ||
+    realpathSync(path) !== path
+  )
+    throw new TypeError("invalid agent executable");
+  return path;
+}
+
+function workspace(path: string): string {
+  if (!isAbsolute(path)) throw new TypeError("invalid agent workspace");
+  const info = lstatSync(path);
+  if (!info.isDirectory() || info.isSymbolicLink() || realpathSync(path) !== path)
+    throw new TypeError("invalid agent workspace");
+  return path;
+}
+
+export function createAgentRunner(options: {
+  readonly codex: string;
+  readonly copilot: string;
+  readonly workspace: string;
+  readonly timeoutMs?: number;
+}): AgentRunner {
+  const codex = executable(options.codex);
+  const copilot = executable(options.copilot);
+  const cwd = workspace(options.workspace);
+  const timeoutMs = options.timeoutMs ?? 300_000;
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 1_000 || timeoutMs > 900_000)
+    throw new TypeError("invalid agent timeout");
+  return {
+    run(agent: PreviewAgent, prompt: string): Promise<void> {
+      if (prompt.length === 0 || prompt.length > 1_024)
+        return Promise.reject(new TypeError("invalid prompt"));
+      const command = agent === "agent-a" ? codex : copilot;
+      const args =
+        agent === "agent-a"
+          ? [
+              "exec",
+              "--ephemeral",
+              "--sandbox",
+              "workspace-write",
+              "--ask-for-approval",
+              "never",
+              prompt,
+            ]
+          : ["-p", prompt, "-s", "--no-ask-user", "--allow-tool=yukh-coordination"];
+      return new Promise((resolve, reject) => {
+        const child = spawn(command, args, {
+          cwd,
+          shell: false,
+          stdio: "ignore",
+          env: { HOME: process.env.HOME ?? "", PATH: process.env.PATH ?? "/usr/bin:/bin" },
+        });
+        let settled = false;
+        const fail = () => {
+          if (settled) return;
+          settled = true;
+          child.kill("SIGKILL");
+          reject(new Error("agent_unavailable"));
+        };
+        const timer = setTimeout(fail, timeoutMs);
+        child.once("error", fail);
+        child.once("close", (code) => {
+          clearTimeout(timer);
+          if (settled) return;
+          settled = true;
+          if (code === 0) resolve();
+          else reject(new Error("agent_unavailable"));
+        });
+      });
+    },
+  };
+}

--- a/test/runtime/conversation-coordinator.test.ts
+++ b/test/runtime/conversation-coordinator.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { ConversationCoordinator } from "../../packages/conversation-coordinator/src/coordinator.js";
+import { createAgentRunner } from "../../packages/conversation-coordinator/src/runner.js";
+import type { CoordinationLauncher } from "../../packages/coordination-preview/src/launcher.js";
+
+const questionId = "019fffc0-06d7-7bbf-8f28-a60641591e1f";
+const answerId = "019fffc0-ffef-7e44-b392-bf7a62f9b665";
+
+function replay(answered = false) {
+  return {
+    schema: 1 as const,
+    status: "ok" as const,
+    command: "events replay",
+    result: {
+      records: [
+        { event: { id: questionId, type: "question", data: { requested_from: ["agent:b"] } } },
+        ...(answered
+          ? [{ event: { id: answerId, type: "answer", data: { question_event_id: questionId } } }]
+          : []),
+      ],
+    },
+  };
+}
+
+test("coordinator wakes the addressed agent once and excludes answered work", async () => {
+  const prompts: string[] = [];
+  let output = replay();
+  const launcher: CoordinationLauncher = { invoke: async () => output };
+  const coordinator = new ConversationCoordinator({
+    launchers: { "agent-a": launcher, "agent-b": launcher },
+    runner: {
+      run: async (agent, prompt) => {
+        assert.equal(agent, "agent-b");
+        prompts.push(prompt);
+      },
+    },
+    maxTurns: 2,
+    lifetimeMs: 10_000,
+    now: () => 1_000,
+  });
+  assert.equal(await coordinator.tick(), "invoked");
+  assert.equal(await coordinator.tick(), "idle");
+  assert.equal(prompts.length, 1);
+  assert.match(prompts[0] ?? "", new RegExp(questionId));
+  output = replay(true);
+  assert.equal(await coordinator.tick(), "idle");
+});
+
+test("coordinator explicitly recovers replay authentication without retrying publications", async () => {
+  const commands: string[] = [];
+  const launcher: CoordinationLauncher = {
+    invoke: async (command) => {
+      commands.push(command);
+      if (commands.length === 1)
+        return { schema: 1, status: "error", command, code: "YKC-AUTH-001" };
+      if (command === "session bootstrap")
+        return { schema: 1, status: "ok", command, result: { outcome: "bootstrapped" } };
+      return replay(true);
+    },
+  };
+  const coordinator = new ConversationCoordinator({
+    launchers: { "agent-a": launcher, "agent-b": launcher },
+    runner: { run: async () => assert.fail("answered question must not wake an agent") },
+    maxTurns: 1,
+    lifetimeMs: 10_000,
+  });
+  assert.equal(await coordinator.tick(), "idle");
+  assert.deepEqual(commands, ["events replay", "session bootstrap", "events replay"]);
+});
+
+test("coordinator fails closed on malformed transcript and enforces lifetime", async () => {
+  const launcher: CoordinationLauncher = {
+    invoke: async () => ({
+      schema: 1,
+      status: "ok",
+      command: "events replay",
+      result: { records: [{}] },
+    }),
+  };
+  let now = 0;
+  const coordinator = new ConversationCoordinator({
+    launchers: { "agent-a": launcher, "agent-b": launcher },
+    runner: { run: async () => assert.fail() },
+    maxTurns: 1,
+    lifetimeMs: 1_000,
+    now: () => now,
+  });
+  await assert.rejects(coordinator.tick(), /coordination_protocol_error/u);
+  now = 1_000;
+  assert.equal(await coordinator.tick(), "complete");
+});
+
+test("agent runner uses fixed non-shell Codex and Copilot programmatic arguments", async () => {
+  const root = await mkdtemp(join(tmpdir(), "yukh-conversation-runner-"));
+  const log = join(root, "calls.jsonl");
+  const source = `#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+appendFileSync(${JSON.stringify(log)}, JSON.stringify(process.argv.slice(1))+"\\n");
+`;
+  const codex = join(root, "codex-test");
+  const copilot = join(root, "copilot-test");
+  await writeFile(codex, source, { mode: 0o700 });
+  await writeFile(copilot, source, { mode: 0o700 });
+  try {
+    const runner = createAgentRunner({ codex, copilot, workspace: root, timeoutMs: 5_000 });
+    await runner.run("agent-a", "codex prompt");
+    await runner.run("agent-b", "copilot prompt");
+    const calls = (await readFile(log, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    assert.deepEqual(calls[0], [
+      codex,
+      "exec",
+      "--ephemeral",
+      "--sandbox",
+      "workspace-write",
+      "--ask-for-approval",
+      "never",
+      "codex prompt",
+    ]);
+    assert.deepEqual(calls[1], [
+      copilot,
+      "-p",
+      "copilot prompt",
+      "-s",
+      "--no-ask-user",
+      "--allow-tool=yukh-coordination",
+    ]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #113.

RFC-0014 was explicitly authorized by the project owner on 2026-08-14.

## Outcome
- watches verified questions and wakes the addressed fixed CLI once;
- uses Codex exec and Copilot programmatic mode without a shell;
- grants Copilot only the yukh-coordination MCP server;
- bounds one in-flight turn, deduplication, timeout, 20 turns and four hours;
- recovers auth only for replay and never retries publication;
- logs no transcript or model content.

## Validation
- focused coordinator and fixed-argument tests pass;
- formatting, typecheck and build pass locally;
- full Node 24 suite and security analysis run in required CI.

## Context impact
RFC-0014 accepted and threat model updated. Local preview only; no provider or protected-target authority.