### PR TITLE
Make local agent conversations observable

### DIFF
--- a/.context/rfcs/RFC-0015-local-conversation-observer.md
+++ b/.context/rfcs/RFC-0015-local-conversation-observer.md
@@ -1,0 +1,44 @@
+# RFC-0015 — Local conversation observer
+
+- Status: Accepted
+- Authors: Codex
+- Created: 2026-08-14
+- Accepted: 2026-08-14
+- Decider: project owner
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/115
+- Depends on: RFC-0014
+
+## Summary
+
+Add a read-only terminal observer for local Coordination conversations and make
+coordinator lifecycle output operator-readable. This is the minimum interface
+needed for the project owner to understand who is working and what agents say.
+
+## Design
+
+`yukh conversation watch` follows the verified transcript, prints new records
+once, groups them by actor and event type, and shows message bodies on the local
+operator terminal. Receipt identifiers are hidden unless `--verbose` is used.
+
+Coordinator output changes from repeated idle ticks to closed lifecycle events:
+`agent_started`, `answer_verified`, `agent_completed_without_answer`,
+`agent_failed`, and `conversation_complete`. An adapter exit is not success
+until replay proves an answer bound to the selected question.
+
+## Security impact
+
+The observer is local and read-only. Transcript bodies are intentionally shown
+to the operator but are not copied into coordinator lifecycle logs. Credentials,
+reasoning, raw stderr and unknown fields are never printed. Malformed transcript
+records fail closed. Matrix, IRC, remote listeners and control commands remain
+out of scope.
+
+## Qualification
+
+Tests cover rendering, incremental sequence handling, verbose receipt display,
+malformed records, lifecycle transitions and answer verification.
+
+## Rollback
+
+Remove the observer entrypoint and restore the previous coordinator output. No
+transcript or credential migration is required.

--- a/apps/conversation-coordinator/src/main.ts
+++ b/apps/conversation-coordinator/src/main.ts
@@ -1,3 +1,5 @@
+import { appendFileSync, lstatSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { createCoordinationLauncher } from "../../../packages/coordination-preview/src/launcher.js";
 import { ConversationCoordinator } from "../../../packages/conversation-coordinator/src/coordinator.js";
 import { createAgentRunner } from "../../../packages/conversation-coordinator/src/runner.js";
@@ -9,6 +11,16 @@ const required = (name: string): string => {
 };
 
 const launcher = required("YUKH_COORDINATION_LAUNCHER");
+const workspace = required("YUKH_CONVERSATION_WORKSPACE");
+const lifecycleDirectory = join(workspace, ".yukh");
+const lifecyclePath = join(lifecycleDirectory, "conversation-lifecycle.jsonl");
+mkdirSync(lifecycleDirectory, { mode: 0o700 });
+if (lstatSync(lifecycleDirectory).isSymbolicLink())
+  throw new Error("invalid coordinator lifecycle path");
+writeFileSync(lifecyclePath, "", { encoding: "utf8", mode: 0o600 });
+const record = (event: object) => {
+  appendFileSync(lifecyclePath, `${JSON.stringify(event)}\n`, { encoding: "utf8", mode: 0o600 });
+};
 const coordinator = new ConversationCoordinator({
   launchers: {
     "agent-a": createCoordinationLauncher({ path: launcher, agent: "agent-a" }),
@@ -17,15 +29,23 @@ const coordinator = new ConversationCoordinator({
   runner: createAgentRunner({
     codex: required("YUKH_CODEX_EXECUTABLE"),
     copilot: required("YUKH_COPILOT_EXECUTABLE"),
-    workspace: required("YUKH_CONVERSATION_WORKSPACE"),
+    workspace,
   }),
   maxTurns: 20,
   lifetimeMs: 4 * 60 * 60 * 1_000,
+  observe: (event) => {
+    record(event);
+    process.stdout.write(`${JSON.stringify(event)}\n`);
+  },
 });
 
 for (;;) {
   const outcome = await coordinator.tick();
-  process.stdout.write(`${JSON.stringify({ schema: 1, event: "coordinator_tick", outcome })}\n`);
-  if (outcome === "complete") break;
+  if (outcome === "complete") {
+    const event = { schema: 1, event: "conversation_complete" };
+    record(event);
+    process.stdout.write(`${JSON.stringify(event)}\n`);
+    break;
+  }
   await new Promise((resolve) => setTimeout(resolve, outcome === "idle" ? 2_000 : 250));
 }

--- a/apps/conversation-watch/src/main.ts
+++ b/apps/conversation-watch/src/main.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { createCoordinationLauncher } from "../../../packages/coordination-preview/src/launcher.js";
+import {
+  lifecycleRecords,
+  renderLifecycle,
+  renderRecord,
+  watchRecords,
+} from "../../../packages/conversation-watch/src/watch.js";
+
+const launcherPath = process.env.YUKH_COORDINATION_LAUNCHER;
+if (!launcherPath) throw new TypeError("invalid watcher configuration");
+const unknown = process.argv.slice(2).filter((value) => value !== "--verbose");
+if (unknown.length > 0) throw new TypeError("invalid watcher arguments");
+const verbose = process.argv.includes("--verbose");
+const launcher = createCoordinationLauncher({ path: launcherPath, agent: "agent-a" });
+let sequence = 0;
+let lifecycleOffset = 0;
+const workspace = process.env.YUKH_CONVERSATION_WORKSPACE;
+const lifecyclePath = workspace
+  ? join(workspace, ".yukh", "conversation-lifecycle.jsonl")
+  : undefined;
+
+for (;;) {
+  let output = await launcher.invoke("events replay");
+  if (output.status === "error" && output.code === "YKC-AUTH-001") {
+    const bootstrap = await launcher.invoke("session bootstrap");
+    if (bootstrap.status !== "ok") throw new Error("coordination_unavailable");
+    output = await launcher.invoke("events replay");
+  }
+  for (const record of watchRecords(output, sequence)) {
+    process.stdout.write(`${renderRecord(record, verbose)}\n\n`);
+    sequence = record.sequence;
+  }
+  if (lifecyclePath) {
+    let raw = "";
+    try {
+      raw = readFileSync(lifecyclePath, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    const records = lifecycleRecords(raw, lifecycleOffset);
+    for (const record of records) process.stdout.write(`${renderLifecycle(record)}\n\n`);
+    lifecycleOffset += records.length;
+  }
+  await new Promise((resolve) => setTimeout(resolve, 1_000));
+}

--- a/bin/yukh.mjs
+++ b/bin/yukh.mjs
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+if (process.argv[2] !== "conversation" || process.argv[3] !== "watch") {
+  process.stderr.write("usage: yukh conversation watch [--verbose]\n");
+  process.exit(2);
+}
+process.argv.splice(2, 2);
+await import("../dist/apps/conversation-watch/src/main.js");

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -65,6 +65,20 @@ Seed one directed question through `coordination.ask`. The coordinator wakes
 the addressed CLI, which answers and may publish one directed follow-up. It
 stops after 20 turns or four hours. Stop it earlier with `Ctrl+C`.
 
+In a second terminal, follow the conversation and coordinator state:
+
+```sh
+cd /absolute/path/to/yukh-mcp
+npm link
+YUKH_COORDINATION_LAUNCHER=/absolute/path/to/yukh-local-agent.py \
+YUKH_CONVERSATION_WORKSPACE=/absolute/path/to/task-board \
+yukh conversation watch
+```
+
+Add `--verbose` only when event and receipt identifiers are needed. The default
+view shows participants, directed questions, answers and lifecycle state without
+receipt noise.
+
 Remove the Copilot server with `copilot mcp remove yukh-coordination`; remove
 the Codex table and restart Codex. Stop the sandbox with the Coordination
 `yukh-local-preview-macos.sh down` command.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -204,6 +204,19 @@ exclude prompts, model output, credentials and arbitrary errors. Residual risk
 is bounded local workspace mutation or availability loss; no provider or
 protected-target authority is granted.
 
+## Accepted local conversation observer — 2026-08-14
+
+- Governing issue: #115
+- Accepted architecture: RFC-0015
+- Scope: read-only local transcript display and closed coordinator lifecycle
+
+The observer intentionally displays verified conversation bodies to the local
+operator terminal. It has no remote listener or mutation command. Credentials,
+private reasoning, raw stderr and unknown fields remain excluded. Receipt
+identifiers require an explicit verbose flag. Malformed transcript data fails
+closed. Coordinator lifecycle logs contain identifiers and states only, not
+message bodies.
+
 ## Capability contract implementation review — 2026-08-03
 
 - Governing issue: #5

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "private": true,
   "license": "Apache-2.0",
   "type": "module",
+  "bin": {
+    "yukh": "bin/yukh.mjs"
+  },
   "engines": {
     "node": ">=22"
   },

--- a/packages/conversation-coordinator/src/coordinator.ts
+++ b/packages/conversation-coordinator/src/coordinator.ts
@@ -16,6 +16,16 @@ export interface CoordinatorOptions {
   readonly maxTurns: number;
   readonly lifetimeMs: number;
   readonly now?: () => number;
+  readonly observe?: (event: CoordinatorEvent) => void;
+}
+
+export interface CoordinatorEvent {
+  readonly schema: 1;
+  readonly event:
+    "agent_started" | "answer_verified" | "agent_completed_without_answer" | "agent_failed";
+  readonly agent: PreviewAgent;
+  readonly question_event_id: string;
+  readonly turn: number;
 }
 
 type RecordValue = { readonly event?: unknown };
@@ -72,7 +82,7 @@ export class ConversationCoordinator {
     this.#started = (options.now ?? Date.now)();
   }
 
-  async tick(): Promise<"idle" | "invoked" | "complete"> {
+  async tick(): Promise<"idle" | "handled" | "complete"> {
     const now = (this.#options.now ?? Date.now)();
     if (this.#turns >= this.#options.maxTurns || now - this.#started >= this.#options.lifetimeMs)
       return "complete";
@@ -93,11 +103,36 @@ export class ConversationCoordinator {
     if (!agent) return "idle";
     this.#attempted.add(question.id);
     this.#turns++;
-    await this.#options.runner.run(
-      agent,
-      `Use only yukh-coordination. Bootstrap if required, join, replay, find question event ${question.id}, and answer it preserving work_uri, correlation_id and question_event_id. If the work needs another peer action, publish one directed follow-up question with the same work_uri.`,
+    this.#observe("agent_started", agent, question.id);
+    try {
+      await this.#options.runner.run(
+        agent,
+        `Use only yukh-coordination. Bootstrap if required, join, replay, find question event ${question.id}, and answer it preserving work_uri, correlation_id and question_event_id. If the work needs another peer action, publish one directed follow-up question with the same work_uri.`,
+      );
+    } catch {
+      this.#observe("agent_failed", agent, question.id);
+      return "handled";
+    }
+    const after = events(await this.#replay(agent));
+    const verified = after.some(
+      (event) => event.type === "answer" && event.data.question_event_id === question.id,
     );
-    return "invoked";
+    this.#observe(
+      verified ? "answer_verified" : "agent_completed_without_answer",
+      agent,
+      question.id,
+    );
+    return "handled";
+  }
+
+  #observe(event: CoordinatorEvent["event"], agent: PreviewAgent, questionEventID: string) {
+    this.#options.observe?.({
+      schema: 1,
+      event,
+      agent,
+      question_event_id: questionEventID,
+      turn: this.#turns,
+    });
   }
 
   async #replay(agent: PreviewAgent): Promise<CoordinationOutput> {

--- a/packages/conversation-watch/src/watch.ts
+++ b/packages/conversation-watch/src/watch.ts
@@ -1,0 +1,104 @@
+import type { CoordinationOutput } from "../../coordination-preview/src/launcher.js";
+
+export interface WatchRecord {
+  readonly sequence: number;
+  readonly event: {
+    readonly id: string;
+    readonly type: string;
+    readonly time: string;
+    readonly participant: { readonly id: string };
+    readonly data: Record<string, unknown>;
+  };
+  readonly receipt: { readonly receipt_id: string };
+}
+
+export interface LifecycleRecord {
+  readonly schema: 1;
+  readonly event: string;
+  readonly agent?: string;
+  readonly question_event_id?: string;
+  readonly turn?: number;
+}
+
+const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+
+export function watchRecords(output: CoordinationOutput, after: number): WatchRecord[] {
+  if (output.status !== "ok" || !output.result || typeof output.result !== "object")
+    throw new Error("coordination_protocol_error");
+  const records = (output.result as { records?: unknown }).records;
+  if (!Array.isArray(records)) throw new Error("coordination_protocol_error");
+  return records
+    .map((item: unknown) => validate(item))
+    .filter((record) => record.sequence > after)
+    .sort((left, right) => left.sequence - right.sequence);
+}
+
+function validate(item: unknown): WatchRecord {
+  if (!item || typeof item !== "object") throw new Error("coordination_protocol_error");
+  const record = item as WatchRecord;
+  const event = record.event;
+  if (
+    !Number.isSafeInteger(record.sequence) ||
+    record.sequence < 1 ||
+    !event ||
+    !uuid.test(event.id) ||
+    !["join", "leave", "question", "answer"].includes(event.type) ||
+    typeof event.time !== "string" ||
+    !event.participant ||
+    !["agent:a", "agent:b"].includes(event.participant.id) ||
+    !event.data ||
+    typeof event.data !== "object" ||
+    !record.receipt ||
+    !uuid.test(record.receipt.receipt_id)
+  )
+    throw new Error("coordination_protocol_error");
+  return record;
+}
+
+export function renderRecord(record: WatchRecord, verbose: boolean): string {
+  const time = new Date(record.event.time);
+  if (Number.isNaN(time.valueOf())) throw new Error("coordination_protocol_error");
+  const actor = record.event.participant.id;
+  let peer = "";
+  if (record.event.type === "question" && Array.isArray(record.event.data.requested_from))
+    peer = ` → ${record.event.data.requested_from.join(", ")}`;
+  const heading = `${time.toISOString().slice(11, 19)}  ${actor}${peer}  ${record.event.type.toUpperCase()}`;
+  const body = record.event.data.body;
+  const lines = [heading];
+  if (typeof body === "string" && body.length > 0 && body.length <= 4_096)
+    lines.push(...body.split("\n").map((line) => `         ${line}`));
+  if (verbose) lines.push(`         event=${record.event.id} receipt=${record.receipt.receipt_id}`);
+  return lines.join("\n");
+}
+
+export function lifecycleRecords(raw: string, after: number): LifecycleRecord[] {
+  if (raw.length > 65_536) throw new Error("coordination_protocol_error");
+  const lines = raw.split("\n").filter(Boolean);
+  return lines.slice(after).map((line) => {
+    const value: unknown = JSON.parse(line);
+    if (!value || typeof value !== "object") throw new Error("coordination_protocol_error");
+    const record = value as LifecycleRecord;
+    const allowed = [
+      "agent_started",
+      "answer_verified",
+      "agent_completed_without_answer",
+      "agent_failed",
+      "conversation_complete",
+    ];
+    if (
+      record.schema !== 1 ||
+      !allowed.includes(record.event) ||
+      (record.agent !== undefined && !["agent-a", "agent-b"].includes(record.agent)) ||
+      (record.question_event_id !== undefined && !uuid.test(record.question_event_id)) ||
+      (record.turn !== undefined && (!Number.isSafeInteger(record.turn) || record.turn < 1))
+    )
+      throw new Error("coordination_protocol_error");
+    return record;
+  });
+}
+
+export function renderLifecycle(record: LifecycleRecord): string {
+  if (record.event === "conversation_complete") return "COORDINATOR  CONVERSATION COMPLETE";
+  const label = record.event.replaceAll("_", " ").toUpperCase();
+  return `COORDINATOR  ${record.agent ?? "agent"}  ${label}  turn=${record.turn ?? "?"} question=${record.question_event_id ?? "?"}`;
+}

--- a/test/runtime/conversation-coordinator.test.ts
+++ b/test/runtime/conversation-coordinator.test.ts
@@ -28,6 +28,7 @@ function replay(answered = false) {
 
 test("coordinator wakes the addressed agent once and excludes answered work", async () => {
   const prompts: string[] = [];
+  const lifecycle: string[] = [];
   let output = replay();
   const launcher: CoordinationLauncher = { invoke: async () => output };
   const coordinator = new ConversationCoordinator({
@@ -36,18 +37,19 @@ test("coordinator wakes the addressed agent once and excludes answered work", as
       run: async (agent, prompt) => {
         assert.equal(agent, "agent-b");
         prompts.push(prompt);
+        output = replay(true);
       },
     },
     maxTurns: 2,
     lifetimeMs: 10_000,
     now: () => 1_000,
+    observe: (event) => lifecycle.push(event.event),
   });
-  assert.equal(await coordinator.tick(), "invoked");
+  assert.equal(await coordinator.tick(), "handled");
   assert.equal(await coordinator.tick(), "idle");
   assert.equal(prompts.length, 1);
   assert.match(prompts[0] ?? "", new RegExp(questionId));
-  output = replay(true);
-  assert.equal(await coordinator.tick(), "idle");
+  assert.deepEqual(lifecycle, ["agent_started", "answer_verified"]);
 });
 
 test("coordinator explicitly recovers replay authentication without retrying publications", async () => {
@@ -92,6 +94,20 @@ test("coordinator fails closed on malformed transcript and enforces lifetime", a
   await assert.rejects(coordinator.tick(), /coordination_protocol_error/u);
   now = 1_000;
   assert.equal(await coordinator.tick(), "complete");
+});
+
+test("coordinator reports adapter success without a verified answer", async () => {
+  const lifecycle: string[] = [];
+  const launcher: CoordinationLauncher = { invoke: async () => replay(false) };
+  const coordinator = new ConversationCoordinator({
+    launchers: { "agent-a": launcher, "agent-b": launcher },
+    runner: { run: async () => undefined },
+    maxTurns: 1,
+    lifetimeMs: 10_000,
+    observe: (event) => lifecycle.push(event.event),
+  });
+  assert.equal(await coordinator.tick(), "handled");
+  assert.deepEqual(lifecycle, ["agent_started", "agent_completed_without_answer"]);
 });
 
 test("agent runner uses fixed non-shell Codex and Copilot programmatic arguments", async () => {

--- a/test/runtime/conversation-watch.test.ts
+++ b/test/runtime/conversation-watch.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  lifecycleRecords,
+  renderLifecycle,
+  renderRecord,
+  watchRecords,
+} from "../../packages/conversation-watch/src/watch.js";
+
+const eventID = "019fffc0-06d7-7bbf-8f28-a60641591e1f";
+const receiptID = "019fffc0-ffef-7e44-b392-bf7a62f9b665";
+const output = {
+  schema: 1 as const,
+  status: "ok" as const,
+  command: "events replay",
+  result: {
+    records: [
+      {
+        sequence: 2,
+        event: {
+          id: eventID,
+          type: "question",
+          time: "2026-08-14T12:01:05.929Z",
+          participant: { id: "agent:a" },
+          data: { body: "Build the frontend", requested_from: ["agent:b"] },
+        },
+        receipt: { receipt_id: receiptID },
+      },
+    ],
+  },
+};
+
+test("watch renders verified conversation once with optional evidence", () => {
+  const records = watchRecords(output, 0);
+  assert.equal(records.length, 1);
+  assert.equal(watchRecords(output, 2).length, 0);
+  assert.equal(
+    renderRecord(records[0]!, false),
+    "12:01:05  agent:a → agent:b  QUESTION\n         Build the frontend",
+  );
+  assert.match(
+    renderRecord(records[0]!, true),
+    new RegExp(`event=${eventID} receipt=${receiptID}`),
+  );
+});
+
+test("watch rejects malformed or unverified transcript records", () => {
+  assert.throws(
+    () =>
+      watchRecords(
+        { schema: 1, status: "ok", command: "events replay", result: { records: [{}] } },
+        0,
+      ),
+    /coordination_protocol_error/u,
+  );
+});
+
+test("watch renders closed coordinator lifecycle without message content", () => {
+  const raw = `${JSON.stringify({ schema: 1, event: "agent_started", agent: "agent-b", question_event_id: eventID, turn: 1 })}\n`;
+  const records = lifecycleRecords(raw, 0);
+  assert.equal(records.length, 1);
+  assert.equal(lifecycleRecords(raw, 1).length, 0);
+  assert.equal(
+    renderLifecycle(records[0]!),
+    `COORDINATOR  agent-b  AGENT STARTED  turn=1 question=${eventID}`,
+  );
+  assert.throws(() => lifecycleRecords('{"schema":1,"event":"unknown"}\n', 0));
+});


### PR DESCRIPTION
Closes #115.

RFC-0015 was explicitly authorized by the project owner on 2026-08-14.

## Outcome
- adds yukh conversation watch for a readable verified transcript;
- merges closed coordinator lifecycle from the trusted workspace;
- removes repeated idle output;
- reports agent start, verified answer, missing answer, failure and completion;
- treats adapter exit as success only after replay proves the bound answer;
- keeps receipts behind the verbose option and excludes credentials, reasoning and raw stderr.

## Validation
- focused rendering, incremental sequence, malformed record and lifecycle tests pass;
- coordinator answer-verification tests pass;
- formatting, typecheck and build pass locally;
- full Node 24 and security gates run in CI.

## Context impact
RFC-0015 accepted and threat model updated. Local read-only observer only; no Matrix, IRC, remote listener or control authority.