### PR TITLE
Allow coordinator restart with existing state

### DIFF
--- a/apps/conversation-coordinator/src/main.ts
+++ b/apps/conversation-coordinator/src/main.ts
@@ -1,7 +1,6 @@
-import { appendFileSync, lstatSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
 import { createCoordinationLauncher } from "../../../packages/coordination-preview/src/launcher.js";
 import { ConversationCoordinator } from "../../../packages/conversation-coordinator/src/coordinator.js";
+import { createLifecycleRecorder } from "../../../packages/conversation-coordinator/src/lifecycle.js";
 import { createAgentRunner } from "../../../packages/conversation-coordinator/src/runner.js";
 
 const required = (name: string): string => {
@@ -12,15 +11,7 @@ const required = (name: string): string => {
 
 const launcher = required("YUKH_COORDINATION_LAUNCHER");
 const workspace = required("YUKH_CONVERSATION_WORKSPACE");
-const lifecycleDirectory = join(workspace, ".yukh");
-const lifecyclePath = join(lifecycleDirectory, "conversation-lifecycle.jsonl");
-mkdirSync(lifecycleDirectory, { mode: 0o700 });
-if (lstatSync(lifecycleDirectory).isSymbolicLink())
-  throw new Error("invalid coordinator lifecycle path");
-writeFileSync(lifecyclePath, "", { encoding: "utf8", mode: 0o600 });
-const record = (event: object) => {
-  appendFileSync(lifecyclePath, `${JSON.stringify(event)}\n`, { encoding: "utf8", mode: 0o600 });
-};
+const lifecycle = createLifecycleRecorder(workspace);
 const coordinator = new ConversationCoordinator({
   launchers: {
     "agent-a": createCoordinationLauncher({ path: launcher, agent: "agent-a" }),
@@ -34,7 +25,7 @@ const coordinator = new ConversationCoordinator({
   maxTurns: 20,
   lifetimeMs: 4 * 60 * 60 * 1_000,
   observe: (event) => {
-    record(event);
+    lifecycle.record(event);
     process.stdout.write(`${JSON.stringify(event)}\n`);
   },
 });
@@ -43,7 +34,7 @@ for (;;) {
   const outcome = await coordinator.tick();
   if (outcome === "complete") {
     const event = { schema: 1, event: "conversation_complete" };
-    record(event);
+    lifecycle.record(event);
     process.stdout.write(`${JSON.stringify(event)}\n`);
     break;
   }

--- a/packages/conversation-coordinator/src/lifecycle.ts
+++ b/packages/conversation-coordinator/src/lifecycle.ts
@@ -1,0 +1,25 @@
+import { constants, closeSync, lstatSync, mkdirSync, openSync, writeSync } from "node:fs";
+import { join } from "node:path";
+
+export interface LifecycleRecorder {
+  readonly path: string;
+  readonly record: (event: object) => void;
+  readonly close: () => void;
+}
+
+export function createLifecycleRecorder(workspace: string): LifecycleRecorder {
+  const directory = join(workspace, ".yukh");
+  const path = join(directory, "conversation-lifecycle.jsonl");
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  if (lstatSync(directory).isSymbolicLink()) throw new Error("invalid coordinator lifecycle path");
+  const descriptor = openSync(
+    path,
+    constants.O_APPEND | constants.O_CREAT | constants.O_WRONLY | constants.O_NOFOLLOW,
+    0o600,
+  );
+  return {
+    path,
+    record: (event) => writeSync(descriptor, `${JSON.stringify(event)}\n`, undefined, "utf8"),
+    close: () => closeSync(descriptor),
+  };
+}

--- a/test/runtime/conversation-coordinator.test.ts
+++ b/test/runtime/conversation-coordinator.test.ts
@@ -1,14 +1,34 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { ConversationCoordinator } from "../../packages/conversation-coordinator/src/coordinator.js";
+import { createLifecycleRecorder } from "../../packages/conversation-coordinator/src/lifecycle.js";
 import { createAgentRunner } from "../../packages/conversation-coordinator/src/runner.js";
 import type { CoordinationLauncher } from "../../packages/coordination-preview/src/launcher.js";
 
 const questionId = "019fffc0-06d7-7bbf-8f28-a60641591e1f";
 const answerId = "019fffc0-ffef-7e44-b392-bf7a62f9b665";
+
+test("coordinator reuses lifecycle state without truncating it", async () => {
+  const root = await mkdtemp(join(tmpdir(), "yukh-conversation-lifecycle-"));
+  const directory = join(root, ".yukh");
+  const path = join(directory, "conversation-lifecycle.jsonl");
+  await mkdir(directory);
+  await writeFile(path, '{"schema":1,"event":"existing"}\n');
+  try {
+    const lifecycle = createLifecycleRecorder(root);
+    lifecycle.record({ schema: 1, event: "new" });
+    lifecycle.close();
+    assert.equal(
+      await readFile(path, "utf8"),
+      '{"schema":1,"event":"existing"}\n{"schema":1,"event":"new"}\n',
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
 
 function replay(answered = false) {
   return {


### PR DESCRIPTION
Closes #119.

Makes lifecycle initialization idempotent, preserves prior observer records across restarts, and opens the log through a no-follow file descriptor.

Adds a regression test for an existing .yukh directory and lifecycle file.