### PR TITLE
Fix Copilot runner permissions and diagnostics

### DIFF
--- a/.context/rfcs/RFC-0016-usable-local-conversation-console.md
+++ b/.context/rfcs/RFC-0016-usable-local-conversation-console.md
@@ -20,11 +20,11 @@ the complete bounded body, while `--verbose` adds event and receipt identifiers.
 Repeated joins for the same participant are hidden. Answers show the question
 identifier they bind.
 
-The Copilot programmatic adapter receives only `read`, `write`, and the fixed
-`yukh-coordination` MCP server. Its current working directory remains the exact
-validated workspace. Shell, URL, unrestricted path and allow-all permissions
-remain denied. Dependency installation and tests remain operator or future
-fixed-verifier responsibilities.
+Copilot uses its default read access inside the exact validated workspace. The
+programmatic adapter explicitly allows only `write` and the fixed
+`yukh-coordination` MCP server. Shell, URL, unrestricted path and allow-all
+permissions remain denied. Dependency installation and tests remain operator or
+future fixed-verifier responsibilities.
 
 ## Security impact
 
@@ -40,5 +40,5 @@ argument rejection, and the exact fixed Copilot permission arguments.
 
 ## Rollback
 
-Remove the read/write flags and restore full default rendering. Existing files
+Remove the write flag and restore full default rendering. Existing files
 and transcript records need no migration.

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -79,10 +79,10 @@ The default view keeps long messages compact and hides repeated joins. Add
 `--full` to inspect complete message bodies or `--verbose` when event and receipt
 identifiers are needed. Answers show the question they belong to.
 
-The coordinator lets Copilot read and write files only inside the selected
-workspace and use the fixed `yukh-coordination` server. It does not grant shell
-or network access; dependency installation and test execution remain operator
-steps.
+Copilot keeps its default read access inside the selected workspace. The
+coordinator explicitly allows workspace writes and the fixed
+`yukh-coordination` server. It does not grant shell or network access;
+dependency installation and test execution remain operator steps.
 
 Remove the Copilot server with `copilot mcp remove yukh-coordination`; remove
 the Codex table and restart Codex. Stop the sandbox with the Coordination

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -223,11 +223,12 @@ message bodies.
 - Accepted architecture: RFC-0016
 - Scope: concise observer output and fixed-workspace Copilot read/write access
 
-Copilot receives only read, write and the fixed Coordination MCP server inside
-the validated trusted workspace. Shell, URL, unrestricted path and allow-all
-permissions remain denied. Agent-authored files are untrusted until reviewed;
-the adapter cannot execute repository-authored scripts. Compact rendering is a
-display policy only and does not alter the verified transcript.
+Copilot retains default read access inside the validated trusted workspace. The
+adapter explicitly allows only write and the fixed Coordination MCP server.
+Shell, URL, unrestricted path and allow-all permissions remain denied.
+Agent-authored files are untrusted until reviewed; the adapter cannot execute
+repository-authored scripts. Compact rendering is a display policy only and
+does not alter the verified transcript.
 
 ## Capability contract implementation review — 2026-08-03
 

--- a/packages/conversation-coordinator/src/coordinator.ts
+++ b/packages/conversation-coordinator/src/coordinator.ts
@@ -26,6 +26,8 @@ export interface CoordinatorEvent {
   readonly agent: PreviewAgent;
   readonly question_event_id: string;
   readonly turn: number;
+  readonly failure_code?:
+    "agent_spawn_failed" | "agent_timed_out" | "agent_exit_nonzero" | "agent_error";
 }
 
 type RecordValue = { readonly event?: unknown };
@@ -109,8 +111,13 @@ export class ConversationCoordinator {
         agent,
         `Use only yukh-coordination. Bootstrap if required, join, replay, find question event ${question.id}, and answer it preserving work_uri, correlation_id and question_event_id. If the work needs another peer action, publish one directed follow-up question with the same work_uri.`,
       );
-    } catch {
-      this.#observe("agent_failed", agent, question.id);
+    } catch (error) {
+      const known = ["agent_spawn_failed", "agent_timed_out", "agent_exit_nonzero"];
+      const failure =
+        error instanceof Error && known.includes(error.message)
+          ? (error.message as CoordinatorEvent["failure_code"])
+          : "agent_error";
+      this.#observe("agent_failed", agent, question.id, failure);
       return "handled";
     }
     const after = events(await this.#replay(agent));
@@ -125,13 +132,19 @@ export class ConversationCoordinator {
     return "handled";
   }
 
-  #observe(event: CoordinatorEvent["event"], agent: PreviewAgent, questionEventID: string) {
+  #observe(
+    event: CoordinatorEvent["event"],
+    agent: PreviewAgent,
+    questionEventID: string,
+    failureCode?: CoordinatorEvent["failure_code"],
+  ) {
     this.#options.observe?.({
       schema: 1,
       event,
       agent,
       question_event_id: questionEventID,
       turn: this.#turns,
+      ...(failureCode ? { failure_code: failureCode } : {}),
     });
   }
 

--- a/packages/conversation-coordinator/src/runner.ts
+++ b/packages/conversation-coordinator/src/runner.ts
@@ -58,7 +58,6 @@ export function createAgentRunner(options: {
               prompt,
               "-s",
               "--no-ask-user",
-              "--allow-tool=read",
               "--allow-tool=write",
               "--allow-tool=yukh-coordination",
             ];
@@ -70,20 +69,20 @@ export function createAgentRunner(options: {
           env: { HOME: process.env.HOME ?? "", PATH: process.env.PATH ?? "/usr/bin:/bin" },
         });
         let settled = false;
-        const fail = () => {
+        const fail = (reason: "agent_spawn_failed" | "agent_timed_out") => {
           if (settled) return;
           settled = true;
           child.kill("SIGKILL");
-          reject(new Error("agent_unavailable"));
+          reject(new Error(reason));
         };
-        const timer = setTimeout(fail, timeoutMs);
-        child.once("error", fail);
+        const timer = setTimeout(() => fail("agent_timed_out"), timeoutMs);
+        child.once("error", () => fail("agent_spawn_failed"));
         child.once("close", (code) => {
           clearTimeout(timer);
           if (settled) return;
           settled = true;
           if (code === 0) resolve();
-          else reject(new Error("agent_unavailable"));
+          else reject(new Error("agent_exit_nonzero"));
         });
       });
     },

--- a/packages/conversation-watch/src/watch.ts
+++ b/packages/conversation-watch/src/watch.ts
@@ -18,6 +18,7 @@ export interface LifecycleRecord {
   readonly agent?: string;
   readonly question_event_id?: string;
   readonly turn?: number;
+  readonly failure_code?: string;
 }
 
 const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
@@ -109,7 +110,11 @@ export function lifecycleRecords(raw: string, after: number): LifecycleRecord[] 
       !allowed.includes(record.event) ||
       (record.agent !== undefined && !["agent-a", "agent-b"].includes(record.agent)) ||
       (record.question_event_id !== undefined && !uuid.test(record.question_event_id)) ||
-      (record.turn !== undefined && (!Number.isSafeInteger(record.turn) || record.turn < 1))
+      (record.turn !== undefined && (!Number.isSafeInteger(record.turn) || record.turn < 1)) ||
+      (record.failure_code !== undefined &&
+        !["agent_spawn_failed", "agent_timed_out", "agent_exit_nonzero", "agent_error"].includes(
+          record.failure_code,
+        ))
     )
       throw new Error("coordination_protocol_error");
     return record;
@@ -119,5 +124,6 @@ export function lifecycleRecords(raw: string, after: number): LifecycleRecord[] 
 export function renderLifecycle(record: LifecycleRecord): string {
   if (record.event === "conversation_complete") return "COORDINATOR  CONVERSATION COMPLETE";
   const label = record.event.replaceAll("_", " ").toUpperCase();
-  return `COORDINATOR  ${record.agent ?? "agent"}  ${label}  turn=${record.turn ?? "?"} question=${record.question_event_id ?? "?"}`;
+  const failure = record.failure_code ? ` failure=${record.failure_code}` : "";
+  return `COORDINATOR  ${record.agent ?? "agent"}  ${label}  turn=${record.turn ?? "?"} question=${record.question_event_id ?? "?"}${failure}`;
 }

--- a/test/runtime/conversation-coordinator.test.ts
+++ b/test/runtime/conversation-coordinator.test.ts
@@ -130,6 +130,27 @@ test("coordinator reports adapter success without a verified answer", async () =
   assert.deepEqual(lifecycle, ["agent_started", "agent_completed_without_answer"]);
 });
 
+test("coordinator reports a stable agent failure code", async () => {
+  const lifecycle: Array<{ event: string; failure_code?: string }> = [];
+  const launcher: CoordinationLauncher = { invoke: async () => replay(false) };
+  const coordinator = new ConversationCoordinator({
+    launchers: { "agent-a": launcher, "agent-b": launcher },
+    runner: { run: async () => Promise.reject(new Error("agent_exit_nonzero")) },
+    maxTurns: 1,
+    lifetimeMs: 10_000,
+    observe: (event) => lifecycle.push(event),
+  });
+  assert.equal(await coordinator.tick(), "handled");
+  assert.deepEqual(lifecycle.at(-1), {
+    schema: 1,
+    event: "agent_failed",
+    agent: "agent-b",
+    question_event_id: questionId,
+    turn: 1,
+    failure_code: "agent_exit_nonzero",
+  });
+});
+
 test("agent runner uses fixed non-shell Codex and Copilot programmatic arguments", async () => {
   const root = await mkdtemp(join(tmpdir(), "yukh-conversation-runner-"));
   const log = join(root, "calls.jsonl");
@@ -165,7 +186,6 @@ appendFileSync(${JSON.stringify(log)}, JSON.stringify(process.argv.slice(1))+"\\
       "copilot prompt",
       "-s",
       "--no-ask-user",
-      "--allow-tool=read",
       "--allow-tool=write",
       "--allow-tool=yukh-coordination",
     ]);

--- a/test/runtime/conversation-watch.test.ts
+++ b/test/runtime/conversation-watch.test.ts
@@ -93,4 +93,9 @@ test("watch renders closed coordinator lifecycle without message content", () =>
     `COORDINATOR  agent-b  AGENT STARTED  turn=1 question=${eventID}`,
   );
   assert.throws(() => lifecycleRecords('{"schema":1,"event":"unknown"}\n', 0));
+  const failure = lifecycleRecords(
+    `${JSON.stringify({ schema: 1, event: "agent_failed", agent: "agent-b", question_event_id: eventID, turn: 2, failure_code: "agent_exit_nonzero" })}\n`,
+    0,
+  );
+  assert.match(renderLifecycle(failure[0]!), /failure=agent_exit_nonzero$/u);
 });


### PR DESCRIPTION
Closes #121.

Removes the unsupported Copilot permission kind read. Workspace reads remain provided by the CLI path boundary, while write and yukh-coordination stay explicitly allowed.

Adds stable bounded failure codes to coordinator lifecycle output and regression coverage.