### PR TITLE
Recover conversations from transient timeouts

### DIFF
--- a/apps/conversation-coordinator/src/main.ts
+++ b/apps/conversation-coordinator/src/main.ts
@@ -29,9 +29,27 @@ const coordinator = new ConversationCoordinator({
     process.stdout.write(`${JSON.stringify(event)}\n`);
   },
 });
+let unavailable = false;
+
+const availability = (event: "coordinator_unavailable" | "coordinator_recovered") => {
+  const record = { schema: 1, event };
+  lifecycle.record(record);
+  process.stdout.write(`${JSON.stringify(record)}\n`);
+};
 
 for (;;) {
-  const outcome = await coordinator.tick();
+  let outcome;
+  try {
+    outcome = await coordinator.tick();
+  } catch (error) {
+    if (!(error instanceof Error) || error.message !== "coordination_unavailable") throw error;
+    if (!unavailable) availability("coordinator_unavailable");
+    unavailable = true;
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+    continue;
+  }
+  if (unavailable) availability("coordinator_recovered");
+  unavailable = false;
   if (outcome === "complete") {
     const event = { schema: 1, event: "conversation_complete" };
     lifecycle.record(event);

--- a/apps/conversation-watch/src/main.ts
+++ b/apps/conversation-watch/src/main.ts
@@ -25,17 +25,36 @@ const lifecyclePath = workspace
   ? join(workspace, ".yukh", "conversation-lifecycle.jsonl")
   : undefined;
 const present = new Set<string>();
+let unavailable = false;
 
 process.stdout.write(
   "Yukh conversation — watching verified transcript\nPress Ctrl+C to stop. Use --full for complete message bodies.\n\n",
 );
 
 for (;;) {
-  let output = await launcher.invoke("events replay");
-  if (output.status === "error" && output.code === "YKC-AUTH-001") {
-    const bootstrap = await launcher.invoke("session bootstrap");
-    if (bootstrap.status !== "ok") throw new Error("coordination_unavailable");
+  let output;
+  try {
     output = await launcher.invoke("events replay");
+    if (output.status === "error" && output.code === "YKC-AUTH-001") {
+      const bootstrap = await launcher.invoke("session bootstrap");
+      if (bootstrap.status !== "ok") throw new Error("coordination_unavailable");
+      output = await launcher.invoke("events replay");
+    }
+    if (output.status === "error" && output.code === "YKC-UNAVAILABLE-001")
+      throw new Error("coordination_unavailable");
+  } catch (error) {
+    if (!(error instanceof Error) || error.message !== "coordination_unavailable") throw error;
+    if (!unavailable)
+      process.stdout.write("WATCHER  COORDINATION TEMPORARILY UNAVAILABLE — RETRYING\n\n");
+    unavailable = true;
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+    continue;
+  }
+  if (unavailable) process.stdout.write("WATCHER  COORDINATION RECOVERED\n\n");
+  unavailable = false;
+  if (!output) {
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+    continue;
   }
   for (const record of watchRecords(output, sequence)) {
     sequence = record.sequence;

--- a/packages/conversation-watch/src/watch.ts
+++ b/packages/conversation-watch/src/watch.ts
@@ -103,6 +103,8 @@ export function lifecycleRecords(raw: string, after: number): LifecycleRecord[] 
       "answer_verified",
       "agent_completed_without_answer",
       "agent_failed",
+      "coordinator_unavailable",
+      "coordinator_recovered",
       "conversation_complete",
     ];
     if (
@@ -123,6 +125,9 @@ export function lifecycleRecords(raw: string, after: number): LifecycleRecord[] 
 
 export function renderLifecycle(record: LifecycleRecord): string {
   if (record.event === "conversation_complete") return "COORDINATOR  CONVERSATION COMPLETE";
+  if (record.event === "coordinator_unavailable")
+    return "COORDINATOR  COORDINATION TEMPORARILY UNAVAILABLE — RETRYING";
+  if (record.event === "coordinator_recovered") return "COORDINATOR  COORDINATION RECOVERED";
   const label = record.event.replaceAll("_", " ").toUpperCase();
   const failure = record.failure_code ? ` failure=${record.failure_code}` : "";
   return `COORDINATOR  ${record.agent ?? "agent"}  ${label}  turn=${record.turn ?? "?"} question=${record.question_event_id ?? "?"}${failure}`;

--- a/test/runtime/conversation-watch.test.ts
+++ b/test/runtime/conversation-watch.test.ts
@@ -98,4 +98,12 @@ test("watch renders closed coordinator lifecycle without message content", () =>
     0,
   );
   assert.match(renderLifecycle(failure[0]!), /failure=agent_exit_nonzero$/u);
+  assert.equal(
+    renderLifecycle(lifecycleRecords('{"schema":1,"event":"coordinator_unavailable"}\n', 0)[0]!),
+    "COORDINATOR  COORDINATION TEMPORARILY UNAVAILABLE — RETRYING",
+  );
+  assert.equal(
+    renderLifecycle(lifecycleRecords('{"schema":1,"event":"coordinator_recovered"}\n', 0)[0]!),
+    "COORDINATOR  COORDINATION RECOVERED",
+  );
 });


### PR DESCRIPTION
Closes #123.

Keeps watcher and coordinator alive across bounded Coordination launcher timeouts. Each process reports only state transitions and resumes automatically; transcript verification failures remain fail-closed.

Validated with formatting, typecheck, focused runtime tests, and build.