### PR TITLE
Let Copilot execute workspace work

### DIFF
--- a/.context/rfcs/RFC-0016-usable-local-conversation-console.md
+++ b/.context/rfcs/RFC-0016-usable-local-conversation-console.md
@@ -20,18 +20,19 @@ the complete bounded body, while `--verbose` adds event and receipt identifiers.
 Repeated joins for the same participant are hidden. Answers show the question
 identifier they bind.
 
-Copilot uses its default read access inside the exact validated workspace. The
-programmatic adapter explicitly allows only `write` and the fixed
-`yukh-coordination` MCP server. Shell, URL, unrestricted path and allow-all
-permissions remain denied. Dependency installation and tests remain operator or
-future fixed-verifier responsibilities.
+For the owner-approved temporary local development profile, Copilot runs with
+`--allow-all`: all tools, filesystem paths and URLs are available. This is an
+explicitly accepted high-trust qualification profile, not a production default.
+Coordination is the communication and handoff plane, not the only tool the agent
+may use.
 
 ## Security impact
 
-Read and write access lets Copilot inspect and modify files inside the trusted
-workspace. It cannot execute repository-authored scripts, fetch URLs or address
-another MCP server. The operator reviews diffs before integration. Transcript
-content remains untrusted and grants no additional authority.
+This profile lets Copilot execute arbitrary commands, access arbitrary paths and
+URLs, and use every configured tool. It is suitable only for the owner's
+explicitly trusted local qualification session. The operator reviews all
+changes before integration. Transcript content can drive privileged activity
+under this temporary profile and must be treated accordingly.
 
 ## Qualification
 
@@ -40,5 +41,5 @@ argument rejection, and the exact fixed Copilot permission arguments.
 
 ## Rollback
 
-Remove the write flag and restore full default rendering. Existing files
+Restore the restricted tool flags and full default rendering. Existing files
 and transcript records need no migration.

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -79,10 +79,11 @@ The default view keeps long messages compact and hides repeated joins. Add
 `--full` to inspect complete message bodies or `--verbose` when event and receipt
 identifiers are needed. Answers show the question they belong to.
 
-Copilot keeps its default read access inside the selected workspace. The
-coordinator explicitly allows workspace writes and the fixed
-`yukh-coordination` server. It does not grant shell or network access;
-dependency installation and test execution remain operator steps.
+The temporary local qualification profile starts Copilot with `--allow-all`, so
+it can use every tool, path and URL required to complete the exercise. Start it
+only on a trusted machine with a trusted transcript; this is not a production
+security profile. Coordination carries messages and handoffs while local tools
+perform the actual work.
 
 Remove the Copilot server with `copilot mcp remove yukh-coordination`; remove
 the Codex table and restart Codex. Stop the sandbox with the Coordination

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -223,12 +223,12 @@ message bodies.
 - Accepted architecture: RFC-0016
 - Scope: concise observer output and fixed-workspace Copilot read/write access
 
-Copilot retains default read access inside the validated trusted workspace. The
-adapter explicitly allows only write and the fixed Coordination MCP server.
-Shell, URL, unrestricted path and allow-all permissions remain denied.
-Agent-authored files are untrusted until reviewed; the adapter cannot execute
-repository-authored scripts. Compact rendering is a display policy only and
-does not alter the verified transcript.
+In the owner-approved temporary local qualification profile, Copilot runs with
+`--allow-all`, including arbitrary tools, shell commands, filesystem paths and
+URLs. This is explicitly not a production-safe boundary. The host, configured
+tools, repository content and transcript are all trusted for this session;
+agent-authored changes require operator review. Compact rendering is a display
+policy only and does not alter the verified transcript.
 
 ## Capability contract implementation review — 2026-08-03
 

--- a/packages/conversation-coordinator/src/coordinator.ts
+++ b/packages/conversation-coordinator/src/coordinator.ts
@@ -109,7 +109,7 @@ export class ConversationCoordinator {
     try {
       await this.#options.runner.run(
         agent,
-        `Use only yukh-coordination. Bootstrap if required, join, replay, find question event ${question.id}, and answer it preserving work_uri, correlation_id and question_event_id. If the work needs another peer action, publish one directed follow-up question with the same work_uri.`,
+        `Use yukh-coordination for communication. Bootstrap if required, join, replay, and find question event ${question.id}. Complete the requested work with the available local tools inside the current workspace, including files, shell, dependencies, and tests. Then answer through yukh-coordination preserving work_uri, correlation_id, and question_event_id. If another peer action is required, publish one directed follow-up question with the same work_uri.`,
       );
     } catch (error) {
       const known = ["agent_spawn_failed", "agent_timed_out", "agent_exit_nonzero"];

--- a/packages/conversation-coordinator/src/runner.ts
+++ b/packages/conversation-coordinator/src/runner.ts
@@ -53,14 +53,7 @@ export function createAgentRunner(options: {
               "never",
               prompt,
             ]
-          : [
-              "-p",
-              prompt,
-              "-s",
-              "--no-ask-user",
-              "--allow-tool=write",
-              "--allow-tool=yukh-coordination",
-            ];
+          : ["-p", prompt, "-s", "--no-ask-user", "--allow-all"];
       return new Promise((resolve, reject) => {
         const child = spawn(command, args, {
           cwd,

--- a/test/runtime/conversation-coordinator.test.ts
+++ b/test/runtime/conversation-coordinator.test.ts
@@ -69,6 +69,7 @@ test("coordinator wakes the addressed agent once and excludes answered work", as
   assert.equal(await coordinator.tick(), "idle");
   assert.equal(prompts.length, 1);
   assert.match(prompts[0] ?? "", new RegExp(questionId));
+  assert.match(prompts[0] ?? "", /Complete the requested work/u);
   assert.deepEqual(lifecycle, ["agent_started", "answer_verified"]);
 });
 
@@ -151,7 +152,7 @@ test("coordinator reports a stable agent failure code", async () => {
   });
 });
 
-test("agent runner uses fixed non-shell Codex and Copilot programmatic arguments", async () => {
+test("agent runner uses fixed workspace Codex and autonomous Copilot arguments", async () => {
   const root = await mkdtemp(join(tmpdir(), "yukh-conversation-runner-"));
   const log = join(root, "calls.jsonl");
   const source = `#!/usr/bin/env node
@@ -186,8 +187,7 @@ appendFileSync(${JSON.stringify(log)}, JSON.stringify(process.argv.slice(1))+"\\
       "copilot prompt",
       "-s",
       "--no-ask-user",
-      "--allow-tool=write",
-      "--allow-tool=yukh-coordination",
+      "--allow-all",
     ]);
   } finally {
     await rm(root, { recursive: true, force: true });


### PR DESCRIPTION
Closes #125.

For the project-owner-approved temporary local qualification profile, starts Copilot with allow-all so it can actually create files and directories, run shell commands, install dependencies, test, and use Coordination for handoffs.

This high-trust profile is documented as temporary and explicitly not production-safe.