### PR TITLE
Accept dynamic team control contract and agent routing

### DIFF
--- a/.context/rfcs/RFC-0017-dynamic-team-control-plane.md
+++ b/.context/rfcs/RFC-0017-dynamic-team-control-plane.md
@@ -1,0 +1,65 @@
+# RFC-0017 — Dynamic MCP team control plane
+
+- Status: Accepted
+- Authors: Nomed with Codex implementation support
+- Created: 2026-08-15
+- Accepted: 2026-08-15
+- Decider: project owner
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/127
+- Depends on: RFC-0012 through RFC-0016; Coordination RFC-0030
+
+## Decision
+
+Add a persistent local team supervisor controlled through MCP and CLI clients.
+A human uses a normal Codex or Copilot session as manager, provides a goal, and
+the manager creates role-based Codex/Copilot workers without the human launching
+each process. CLI is a secondary interface over the same control API.
+
+The initial MCP contract contains `team.create`, `team.status`, `team.stop`,
+`agent.spawn`, `agent.status` and `task.assign`. Team and agent identifiers are
+server generated. Agent records include runtime, role, parent, task, workspace,
+state and Coordination identity.
+
+## Hierarchical delegation
+
+An agent may create children only when its record carries delegated spawn
+authority. Every child references one parent and inherits bounded workspace,
+runtime profile, maximum depth, remaining agent count and lifetime. Delegation
+cannot widen those bounds. The initial local profile defaults to depth three and
+16 workers per team.
+
+## Runtime
+
+The supervisor outlives the initiating MCP session. It persists only bounded
+public control state under `.yukh/`, starts fixed Codex/Copilot executables
+without a shell wrapper, supervises exit/timeout, and records lifecycle events
+through the worker's distinct Coordination identity. Closing the manager chat
+does not stop the team.
+
+Natural-language planning remains the manager model's responsibility. The
+control plane validates and executes explicit structured requests; it does not
+silently infer authority from transcript text.
+
+## Observability
+
+Watcher and status output show team, role, parent, task, runtime and lifecycle.
+Messages remain in the verified Coordination transcript. Process output is
+bounded and redacted; credentials and private reasoning are never persisted.
+
+## Security impact
+
+The project owner temporarily authorized an unrestricted local Copilot worker
+profile for qualification. That profile is high trust and not production safe.
+Dynamic spawning additionally introduces process and resource exhaustion risks,
+bounded by server-owned depth, count, lifetime and executable configuration.
+
+## Qualification
+
+The vertical test creates a manager, backend and frontend workers, allows one
+worker to create a test child, verifies distinct Coordination identities and
+parentage, then stops the team without orphan processes.
+
+## Rollback
+
+Stop the supervisor and remove its bounded public state after process shutdown.
+The existing two-agent conversation commands remain available during migration.

--- a/apps/coordination-preview/src/server.ts
+++ b/apps/coordination-preview/src/server.ts
@@ -10,6 +10,10 @@ const uri = z.string().url().max(2_048);
 const uuid = z
   .string()
   .regex(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u);
+const participant = z
+  .string()
+  .regex(/^agent:[a-z](?:[a-z0-9-]{0,40}[a-z0-9])?$/u)
+  .max(48);
 
 function toolResult(output: CoordinationOutput) {
   return {
@@ -45,8 +49,9 @@ export function createCoordinationPreviewServer(options: {
   readonly agent: PreviewAgent;
   readonly launcher: CoordinationLauncher;
 }): McpServer {
-  const label = options.agent === "agent-a" ? "codex" : "copilot";
-  const peer = options.agent === "agent-a" ? "agent:b" : "agent:a";
+  const label = options.agent.slice("agent-".length);
+  const defaultPeer =
+    options.agent === "agent-a" ? "agent:b" : options.agent === "agent-b" ? "agent:a" : undefined;
   const server = new McpServer(
     { name: `yukh-coordination-${label}-preview`, version: "0.1.0-preview" },
     {
@@ -87,17 +92,26 @@ export function createCoordinationPreviewServer(options: {
     "coordination.ask",
     {
       title: "Ask the peer agent",
-      description: `Publish a question addressed to ${peer}`,
-      inputSchema: z.object({ work_uri: uri, body: z.string().min(1).max(4_096) }).strict(),
+      description: "Publish a question addressed to one or more explicit agent identities",
+      inputSchema: z
+        .object({
+          work_uri: uri,
+          body: z.string().min(1).max(4_096),
+          requested_from: z.array(participant).min(1).max(8).optional(),
+        })
+        .strict(),
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
     },
-    ({ work_uri, body }) =>
-      invoke(options.launcher, "question ask", {
+    ({ work_uri, body, requested_from }) => {
+      const recipients = requested_from ?? (defaultPeer ? [defaultPeer] : undefined);
+      if (!recipients) return unavailable();
+      return invoke(options.launcher, "question ask", {
         work_uri,
         body,
-        requested_from: [peer],
+        requested_from: recipients,
         response_required: true,
-      }),
+      });
+    },
   );
 
   server.registerTool(

--- a/apps/team-control/src/main.ts
+++ b/apps/team-control/src/main.ts
@@ -1,0 +1,12 @@
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
+import { TeamStore } from "../../../packages/team-control/src/store.js";
+import { createTeamControlServer } from "./server.js";
+
+const workspace = process.env.YUKH_TEAM_WORKSPACE;
+if (!workspace) throw new TypeError("invalid team control configuration");
+const store = new TeamStore(workspace);
+
+serveStdio(() => createTeamControlServer(store), {
+  legacy: "serve",
+  onerror: () => undefined,
+});

--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -1,0 +1,65 @@
+import { McpServer } from "@modelcontextprotocol/server";
+import { z } from "zod";
+import { TeamStore } from "../../../packages/team-control/src/store.js";
+
+const id = z.string().regex(/^team-[0-9a-f-]{36}$/u);
+
+function result(value: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(value) }],
+    structuredContent: { result: value },
+  };
+}
+
+export function createTeamControlServer(store: TeamStore): McpServer {
+  const server = new McpServer(
+    { name: "yukh-team-control", version: "0.1.0-preview" },
+    {
+      capabilities: { tools: { listChanged: false } },
+      instructions:
+        "Create and inspect bounded local agent teams from explicit user goals. Team state is persistent; creating a team does not yet start workers.",
+    },
+  );
+
+  server.registerTool(
+    "team.create",
+    {
+      title: "Create a persistent local team",
+      description: "Create bounded persistent team state for an explicit goal",
+      inputSchema: z
+        .object({
+          goal: z.string().min(1).max(4_096),
+          manager_runtime: z.enum(["codex", "copilot"]),
+          max_agents: z.number().int().min(1).max(32).default(16),
+          max_depth: z.number().int().min(1).max(5).default(3),
+        })
+        .strict(),
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+    },
+    ({ goal, manager_runtime, max_agents, max_depth }) =>
+      result(store.create(goal, manager_runtime, max_agents, max_depth)),
+  );
+
+  server.registerTool(
+    "team.status",
+    {
+      title: "Inspect a local team",
+      description: "Read persistent team and worker state",
+      inputSchema: z.object({ team_id: id }).strict(),
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    },
+    ({ team_id }) => result(store.status(team_id)),
+  );
+
+  server.registerTool(
+    "team.stop",
+    {
+      title: "Stop a local team",
+      description: "Mark a team stopped; worker process termination is added with the supervisor",
+      inputSchema: z.object({ team_id: id }).strict(),
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true },
+    },
+    ({ team_id }) => result(store.stop(team_id)),
+  );
+  return server;
+}

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -741,3 +741,14 @@ OIDC, assertion authorities, bridge trust, materializer, Coordination, audit,
 verifier, workflow, target, credentials, endpoints, network, gateway
 activation, live synthetic apply, teardown, deployment, and operational
 readiness each require later explicit review.
+# Accepted dynamic local team control plane — 2026-08-15
+
+- Governing issue: #127
+- Accepted architecture: RFC-0017
+
+The persistent local supervisor accepts only structured MCP/CLI control
+requests. Server-generated identities, fixed executable paths, bounded team
+size/depth/lifetime and inherited workspace constraints prevent transcript text
+from directly spawning unbounded processes. Parent-child relationships are
+auditable but do not grant authority. The temporarily unrestricted Copilot
+profile remains explicitly local, high trust and non-production.

--- a/packages/conversation-coordinator/src/coordinator.ts
+++ b/packages/conversation-coordinator/src/coordinator.ts
@@ -149,11 +149,13 @@ export class ConversationCoordinator {
   }
 
   async #replay(agent: PreviewAgent): Promise<CoordinationOutput> {
-    let output = await this.#options.launchers[agent].invoke("events replay");
+    const launcher = this.#options.launchers[agent];
+    if (!launcher) throw new Error("coordination_protocol_error");
+    let output = await launcher.invoke("events replay");
     if (output.status === "error" && output.code === "YKC-AUTH-001") {
-      const bootstrap = await this.#options.launchers[agent].invoke("session bootstrap");
+      const bootstrap = await launcher.invoke("session bootstrap");
       if (bootstrap.status !== "ok") return bootstrap;
-      output = await this.#options.launchers[agent].invoke("events replay");
+      output = await launcher.invoke("events replay");
     }
     return output;
   }

--- a/packages/coordination-preview/src/launcher.ts
+++ b/packages/coordination-preview/src/launcher.ts
@@ -12,7 +12,7 @@ const commandNames = new Set([
   "session leave",
 ]);
 
-export type PreviewAgent = "agent-a" | "agent-b";
+export type PreviewAgent = `agent-${string}`;
 
 export interface CoordinationOutput {
   readonly schema: 1;
@@ -33,8 +33,9 @@ export function validateLauncher(path: string): string {
 }
 
 export function validateAgent(value: string): PreviewAgent {
-  if (value !== "agent-a" && value !== "agent-b") throw new TypeError("invalid Coordination agent");
-  return value;
+  if (value.length > 48 || !/^agent-[a-z](?:[a-z0-9-]{0,40}[a-z0-9])?$/u.test(value))
+    throw new TypeError("invalid Coordination agent");
+  return value as PreviewAgent;
 }
 
 function closedOutput(raw: Buffer, command: string): CoordinationOutput {

--- a/packages/team-control/src/store.ts
+++ b/packages/team-control/src/store.ts
@@ -1,0 +1,200 @@
+import {
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { randomUUID } from "node:crypto";
+import { isAbsolute, join } from "node:path";
+
+export type AgentRuntime = "codex" | "copilot";
+export type TeamState = "active" | "stopped";
+export type AgentState = "defined" | "running" | "completed" | "failed" | "stopped";
+
+export interface TeamRecord {
+  readonly schema: 1;
+  readonly team_id: string;
+  readonly goal: string;
+  readonly workspace: string;
+  readonly manager_runtime: AgentRuntime;
+  readonly max_agents: number;
+  readonly max_depth: number;
+  readonly state: TeamState;
+}
+
+export interface AgentRecord {
+  readonly schema: 1;
+  readonly agent_id: string;
+  readonly coordination_agent: `agent-${string}`;
+  readonly team_id: string;
+  readonly parent_agent_id?: string;
+  readonly runtime: AgentRuntime;
+  readonly role: string;
+  readonly task: string;
+  readonly depth: number;
+  readonly can_spawn: boolean;
+  readonly state: AgentState;
+}
+
+const teamID = /^team-[0-9a-f-]{36}$/u;
+const agentID = /^worker-[0-9a-f-]{36}$/u;
+const roleName = /^[a-z][a-z0-9-]{0,31}$/u;
+
+export class TeamStore {
+  readonly #workspace: string;
+  readonly #root: string;
+
+  constructor(workspace: string) {
+    if (!isAbsolute(workspace)) throw new TypeError("invalid team workspace");
+    const info = lstatSync(workspace);
+    if (!info.isDirectory() || info.isSymbolicLink() || realpathSync(workspace) !== workspace)
+      throw new TypeError("invalid team workspace");
+    this.#workspace = workspace;
+    const state = join(workspace, ".yukh");
+    mkdirSync(state, { recursive: true, mode: 0o700 });
+    if (lstatSync(state).isSymbolicLink()) throw new TypeError("invalid team state path");
+    this.#root = join(state, "teams");
+    mkdirSync(this.#root, { recursive: true, mode: 0o700 });
+    if (lstatSync(this.#root).isSymbolicLink()) throw new TypeError("invalid team state path");
+  }
+
+  create(goal: string, managerRuntime: AgentRuntime, maxAgents = 16, maxDepth = 3): TeamRecord {
+    if (
+      goal.trim() !== goal ||
+      goal.length < 1 ||
+      goal.length > 4_096 ||
+      !["codex", "copilot"].includes(managerRuntime) ||
+      !Number.isInteger(maxAgents) ||
+      maxAgents < 1 ||
+      maxAgents > 32 ||
+      !Number.isInteger(maxDepth) ||
+      maxDepth < 1 ||
+      maxDepth > 5
+    )
+      throw new TypeError("invalid team definition");
+    const record: TeamRecord = {
+      schema: 1,
+      team_id: `team-${randomUUID()}`,
+      goal,
+      workspace: this.#workspace,
+      manager_runtime: managerRuntime,
+      max_agents: maxAgents,
+      max_depth: maxDepth,
+      state: "active",
+    };
+    const directory = this.#teamDirectory(record.team_id);
+    mkdirSync(join(directory, "agents"), { recursive: true, mode: 0o700 });
+    this.#write(join(directory, "team.json"), record, true);
+    return record;
+  }
+
+  spawn(
+    id: string,
+    input: {
+      readonly parent_agent_id?: string;
+      readonly runtime: AgentRuntime;
+      readonly role: string;
+      readonly task: string;
+      readonly can_spawn?: boolean;
+    },
+  ): AgentRecord {
+    const team = this.#readTeam(id);
+    if (team.state !== "active") throw new Error("team_not_active");
+    if (
+      !["codex", "copilot"].includes(input.runtime) ||
+      !roleName.test(input.role) ||
+      input.task.trim() !== input.task ||
+      input.task.length < 1 ||
+      input.task.length > 4_096
+    )
+      throw new TypeError("invalid agent definition");
+    const agents = this.#readAgents(id);
+    if (agents.length >= team.max_agents) throw new Error("team_agent_limit");
+    const parent = input.parent_agent_id
+      ? agents.find((agent) => agent.agent_id === input.parent_agent_id)
+      : undefined;
+    if (input.parent_agent_id && (!parent || !parent.can_spawn))
+      throw new Error("agent_delegation_denied");
+    const depth = parent ? parent.depth + 1 : 1;
+    if (depth > team.max_depth) throw new Error("team_depth_limit");
+    const suffix = randomUUID().replaceAll("-", "").slice(0, 8);
+    const coordination = `agent-${input.role.slice(0, 32)}-${suffix}` as const;
+    const record: AgentRecord = {
+      schema: 1,
+      agent_id: `worker-${randomUUID()}`,
+      coordination_agent: coordination,
+      team_id: id,
+      ...(parent ? { parent_agent_id: parent.agent_id } : {}),
+      runtime: input.runtime,
+      role: input.role,
+      task: input.task,
+      depth,
+      can_spawn: input.can_spawn ?? false,
+      state: "defined",
+    };
+    this.#write(join(this.#teamDirectory(id), "agents", `${record.agent_id}.json`), record, true);
+    return record;
+  }
+
+  status(id: string): { readonly team: TeamRecord; readonly agents: readonly AgentRecord[] } {
+    return { team: this.#readTeam(id), agents: this.#readAgents(id) };
+  }
+
+  assign(id: string, worker: string, task: string): AgentRecord {
+    if (task.length < 1 || task.length > 4_096) throw new TypeError("invalid task");
+    const current = this.#readAgent(id, worker);
+    if (["completed", "stopped"].includes(current.state)) throw new Error("agent_not_assignable");
+    const updated = { ...current, task };
+    this.#write(join(this.#teamDirectory(id), "agents", `${worker}.json`), updated, false);
+    return updated;
+  }
+
+  stop(id: string): TeamRecord {
+    const team = this.#readTeam(id);
+    const updated: TeamRecord = { ...team, state: "stopped" };
+    this.#write(join(this.#teamDirectory(id), "team.json"), updated, false);
+    return updated;
+  }
+
+  #teamDirectory(id: string): string {
+    if (!teamID.test(id)) throw new TypeError("invalid team id");
+    return join(this.#root, id);
+  }
+
+  #readTeam(id: string): TeamRecord {
+    return this.#read(join(this.#teamDirectory(id), "team.json")) as TeamRecord;
+  }
+
+  #readAgent(id: string, worker: string): AgentRecord {
+    if (!agentID.test(worker)) throw new TypeError("invalid agent id");
+    return this.#read(join(this.#teamDirectory(id), "agents", `${worker}.json`)) as AgentRecord;
+  }
+
+  #readAgents(id: string): AgentRecord[] {
+    const directory = join(this.#teamDirectory(id), "agents");
+    return readdirSync(directory)
+      .filter((name) => /^worker-[0-9a-f-]{36}\.json$/u.test(name))
+      .sort()
+      .map((name) => this.#read(join(directory, name)) as AgentRecord);
+  }
+
+  #read(path: string): unknown {
+    const raw = readFileSync(path, "utf8");
+    if (raw.length < 2 || raw.length > 16_384) throw new Error("invalid team state");
+    return JSON.parse(raw) as unknown;
+  }
+
+  #write(path: string, value: object, exclusive: boolean): void {
+    const raw = `${JSON.stringify(value)}\n`;
+    if (exclusive) {
+      writeFileSync(path, raw, { encoding: "utf8", mode: 0o600, flag: "wx" });
+      return;
+    }
+    const temporary = `${path}.${randomUUID()}.tmp`;
+    writeFileSync(temporary, raw, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    renameSync(temporary, path);
+  }
+}

--- a/test/runtime/coordination-preview.test.ts
+++ b/test/runtime/coordination-preview.test.ts
@@ -15,7 +15,7 @@ const server = fileURLToPath(
   new URL("../../apps/coordination-preview/src/main.ts", import.meta.url),
 );
 
-test("local Coordination preview exposes only fixed bounded tools", async () => {
+test("local Coordination preview exposes bounded tools with explicit dynamic peers", async () => {
   const root = await mkdtemp(join(tmpdir(), "yukh-coordination-mcp-"));
   const launcher = join(root, "launcher");
   const log = join(root, "invocations.jsonl");
@@ -67,7 +67,11 @@ process.stdout.write(JSON.stringify({schema:1,status:"ok",command,result})+"\\n"
       (
         await client.callTool({
           name: "coordination.ask",
-          arguments: { work_uri: "https://preview.local/work/first-contact", body: "hello" },
+          arguments: {
+            work_uri: "https://preview.local/work/first-contact",
+            body: "hello",
+            requested_from: ["agent:frontend-developer"],
+          },
         })
       ).isError,
       false,
@@ -112,14 +116,16 @@ process.stdout.write(JSON.stringify({schema:1,status:"ok",command,result})+"\\n"
       ],
     );
     assert.equal(calls[0]?.input, null);
-    assert.deepEqual(calls[2]?.input?.requested_from, ["agent:b"]);
+    assert.deepEqual(calls[2]?.input?.requested_from, ["agent:frontend-developer"]);
   } finally {
     await client.close();
     await rm(root, { recursive: true, force: true });
   }
 });
 
-test("preview configuration rejects substituted identities and launchers", async () => {
-  assert.throws(() => validateAgent("agent-c"));
+test("preview configuration accepts bounded dynamic identities and rejects substitutions", async () => {
+  assert.equal(validateAgent("agent-frontend-developer"), "agent-frontend-developer");
+  assert.throws(() => validateAgent("agent-C"));
+  assert.throws(() => validateAgent("agent-a/../b"));
   assert.throws(() => validateLauncher("relative-launcher"));
 });

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { TeamStore } from "../../packages/team-control/src/store.js";
+
+test("team store creates dynamic workers and bounded delegated children", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-team-control-")));
+  try {
+    const store = new TeamStore(root);
+    const team = store.create("Build a task board", "codex", 3, 2);
+    const backend = store.spawn(team.team_id, {
+      runtime: "codex",
+      role: "backend-developer",
+      task: "Implement the API",
+      can_spawn: true,
+    });
+    const testWorker = store.spawn(team.team_id, {
+      parent_agent_id: backend.agent_id,
+      runtime: "copilot",
+      role: "api-tester",
+      task: "Test the API",
+    });
+    assert.equal(testWorker.parent_agent_id, backend.agent_id);
+    assert.equal(testWorker.depth, 2);
+    assert.notEqual(testWorker.coordination_agent, backend.coordination_agent);
+    assert.equal(store.status(team.team_id).agents.length, 2);
+    assert.equal(
+      store.assign(team.team_id, backend.agent_id, "Implement and document API").task,
+      "Implement and document API",
+    );
+    assert.equal(store.stop(team.team_id).state, "stopped");
+    assert.throws(
+      () =>
+        store.spawn(team.team_id, {
+          runtime: "copilot",
+          role: "frontend-developer",
+          task: "Implement UI",
+        }),
+      /team_not_active/u,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("team store denies undelegated and over-depth children", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-team-bounds-")));
+  try {
+    const store = new TeamStore(root);
+    const team = store.create("Bound delegation", "copilot", 4, 2);
+    const parent = store.spawn(team.team_id, {
+      runtime: "copilot",
+      role: "frontend-lead",
+      task: "Lead frontend",
+      can_spawn: false,
+    });
+    assert.throws(
+      () =>
+        store.spawn(team.team_id, {
+          parent_agent_id: parent.agent_id,
+          runtime: "copilot",
+          role: "ui-worker",
+          task: "Build UI",
+        }),
+      /agent_delegation_denied/u,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Refs #127 and depends on nomed/yukh-coordination#225.

Adds accepted RFC-0017, opens the local launcher to the same bounded dynamic-agent grammar, and lets Coordination questions target explicit dynamic peers while preserving agent-a/agent-b defaults.

This is the contract and routing foundation; persistent supervisor tools and worker process lifecycle remain in #127.

Validated with formatting, typecheck, focused tests, build, and diff checks.