### PR TITLE
Launch persistent dynamic team workers

### DIFF
--- a/apps/team-control/src/main.ts
+++ b/apps/team-control/src/main.ts
@@ -11,19 +11,29 @@ const copilot = process.env.YUKH_COPILOT_EXECUTABLE;
 if (!workspace || !launcher || !codex || !copilot)
   throw new TypeError("invalid team control configuration");
 const store = new TeamStore(workspace);
+const callerTeamId = process.env.YUKH_CALLER_TEAM_ID;
+const callerAgentId = process.env.YUKH_CALLER_AGENT_ID;
+if ((callerTeamId && !callerAgentId) || (!callerTeamId && callerAgentId))
+  throw new TypeError("invalid team control caller");
 const supervisor = new TeamSupervisor({
   node: process.execPath,
   worker: fileURLToPath(new URL("../../team-worker/src/main.js", import.meta.url)),
   coordinationMcp: fileURLToPath(
     new URL("../../coordination-preview/src/main.js", import.meta.url),
   ),
+  teamControlMcp: fileURLToPath(new URL("./main.js", import.meta.url)),
   launcher,
   codex,
   copilot,
   workspace,
 });
 
-serveStdio(() => createTeamControlServer(store, supervisor), {
-  legacy: "serve",
-  onerror: () => undefined,
-});
+serveStdio(
+  () =>
+    createTeamControlServer(store, supervisor, {
+      ...(callerTeamId && callerAgentId
+        ? { caller: { team_id: callerTeamId, agent_id: callerAgentId } }
+        : {}),
+    }),
+  { legacy: "serve", onerror: () => undefined },
+);

--- a/apps/team-control/src/main.ts
+++ b/apps/team-control/src/main.ts
@@ -1,12 +1,29 @@
 import { serveStdio } from "@modelcontextprotocol/server/stdio";
+import { fileURLToPath } from "node:url";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
+import { TeamSupervisor } from "../../../packages/team-control/src/supervisor.js";
 import { createTeamControlServer } from "./server.js";
 
 const workspace = process.env.YUKH_TEAM_WORKSPACE;
-if (!workspace) throw new TypeError("invalid team control configuration");
+const launcher = process.env.YUKH_COORDINATION_LAUNCHER;
+const codex = process.env.YUKH_CODEX_EXECUTABLE;
+const copilot = process.env.YUKH_COPILOT_EXECUTABLE;
+if (!workspace || !launcher || !codex || !copilot)
+  throw new TypeError("invalid team control configuration");
 const store = new TeamStore(workspace);
+const supervisor = new TeamSupervisor({
+  node: process.execPath,
+  worker: fileURLToPath(new URL("../../team-worker/src/main.js", import.meta.url)),
+  coordinationMcp: fileURLToPath(
+    new URL("../../coordination-preview/src/main.js", import.meta.url),
+  ),
+  launcher,
+  codex,
+  copilot,
+  workspace,
+});
 
-serveStdio(() => createTeamControlServer(store), {
+serveStdio(() => createTeamControlServer(store, supervisor), {
   legacy: "serve",
   onerror: () => undefined,
 });

--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
+import { TeamSupervisor } from "../../../packages/team-control/src/supervisor.js";
 
 const id = z.string().regex(/^team-[0-9a-f-]{36}$/u);
 
@@ -11,7 +12,7 @@ function result(value: unknown) {
   };
 }
 
-export function createTeamControlServer(store: TeamStore): McpServer {
+export function createTeamControlServer(store: TeamStore, supervisor: TeamSupervisor): McpServer {
   const server = new McpServer(
     { name: "yukh-team-control", version: "0.1.0-preview" },
     {
@@ -49,6 +50,70 @@ export function createTeamControlServer(store: TeamStore): McpServer {
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     },
     ({ team_id }) => result(store.status(team_id)),
+  );
+
+  server.registerTool(
+    "agent.spawn",
+    {
+      title: "Spawn a local team worker",
+      description:
+        "Create a bounded worker identity and start its detached Codex or Copilot process",
+      inputSchema: z
+        .object({
+          team_id: id,
+          parent_agent_id: z
+            .string()
+            .regex(/^worker-[0-9a-f-]{36}$/u)
+            .optional(),
+          runtime: z.enum(["codex", "copilot"]),
+          role: z.string().regex(/^[a-z][a-z0-9-]{0,31}$/u),
+          task: z.string().min(1).max(4_096),
+          can_spawn: z.boolean().default(false),
+        })
+        .strict(),
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+    },
+    (input) => {
+      const agent = store.spawn(input.team_id, {
+        ...(input.parent_agent_id ? { parent_agent_id: input.parent_agent_id } : {}),
+        runtime: input.runtime,
+        role: input.role,
+        task: input.task,
+        can_spawn: input.can_spawn,
+      });
+      const pid = supervisor.launch(agent);
+      return result({ agent, pid });
+    },
+  );
+
+  server.registerTool(
+    "agent.status",
+    {
+      title: "Inspect a local team worker",
+      description: "Read one persistent worker record",
+      inputSchema: z
+        .object({ team_id: id, agent_id: z.string().regex(/^worker-[0-9a-f-]{36}$/u) })
+        .strict(),
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    },
+    ({ team_id, agent_id }) => result(store.agent(team_id, agent_id)),
+  );
+
+  server.registerTool(
+    "task.assign",
+    {
+      title: "Assign a worker task",
+      description: "Replace the bounded task of a worker that has not completed",
+      inputSchema: z
+        .object({
+          team_id: id,
+          agent_id: z.string().regex(/^worker-[0-9a-f-]{36}$/u),
+          task: z.string().min(1).max(4_096),
+        })
+        .strict(),
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+    },
+    ({ team_id, agent_id, task }) => result(store.assign(team_id, agent_id, task)),
   );
 
   server.registerTool(

--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -12,7 +12,19 @@ function result(value: unknown) {
   };
 }
 
-export function createTeamControlServer(store: TeamStore, supervisor: TeamSupervisor): McpServer {
+export interface TeamControlOptions {
+  readonly caller?: { readonly team_id: string; readonly agent_id: string };
+}
+
+export function createTeamControlServer(
+  store: TeamStore,
+  supervisor: TeamSupervisor,
+  options: TeamControlOptions = {},
+): McpServer {
+  const authorizeTeam = (teamId: string): void => {
+    if (options.caller && teamId !== options.caller.team_id)
+      throw new Error("agent_delegation_denied");
+  };
   const server = new McpServer(
     { name: "yukh-team-control", version: "0.1.0-preview" },
     {
@@ -37,8 +49,10 @@ export function createTeamControlServer(store: TeamStore, supervisor: TeamSuperv
         .strict(),
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
     },
-    ({ goal, manager_runtime, max_agents, max_depth }) =>
-      result(store.create(goal, manager_runtime, max_agents, max_depth)),
+    ({ goal, manager_runtime, max_agents, max_depth }) => {
+      if (options.caller) throw new Error("agent_delegation_denied");
+      return result(store.create(goal, manager_runtime, max_agents, max_depth));
+    },
   );
 
   server.registerTool(
@@ -49,7 +63,10 @@ export function createTeamControlServer(store: TeamStore, supervisor: TeamSuperv
       inputSchema: z.object({ team_id: id }).strict(),
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     },
-    ({ team_id }) => result(store.status(team_id)),
+    ({ team_id }) => {
+      authorizeTeam(team_id);
+      return result(store.status(team_id));
+    },
   );
 
   server.registerTool(
@@ -74,15 +91,26 @@ export function createTeamControlServer(store: TeamStore, supervisor: TeamSuperv
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
     },
     (input) => {
+      if (
+        options.caller &&
+        (input.team_id !== options.caller.team_id ||
+          (input.parent_agent_id !== undefined &&
+            input.parent_agent_id !== options.caller.agent_id))
+      )
+        throw new Error("agent_delegation_denied");
       const agent = store.spawn(input.team_id, {
-        ...(input.parent_agent_id ? { parent_agent_id: input.parent_agent_id } : {}),
+        ...(options.caller
+          ? { parent_agent_id: options.caller.agent_id }
+          : input.parent_agent_id
+            ? { parent_agent_id: input.parent_agent_id }
+            : {}),
         runtime: input.runtime,
         role: input.role,
         task: input.task,
         can_spawn: input.can_spawn,
       });
-      const pid = supervisor.launch(agent);
-      return result({ agent, pid });
+      const runtime = supervisor.launch(agent);
+      return result({ agent, ...runtime });
     },
   );
 
@@ -96,7 +124,10 @@ export function createTeamControlServer(store: TeamStore, supervisor: TeamSuperv
         .strict(),
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     },
-    ({ team_id, agent_id }) => result(store.agent(team_id, agent_id)),
+    ({ team_id, agent_id }) => {
+      authorizeTeam(team_id);
+      return result(store.agent(team_id, agent_id));
+    },
   );
 
   server.registerTool(
@@ -113,7 +144,10 @@ export function createTeamControlServer(store: TeamStore, supervisor: TeamSuperv
         .strict(),
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
     },
-    ({ team_id, agent_id, task }) => result(store.assign(team_id, agent_id, task)),
+    ({ team_id, agent_id, task }) => {
+      authorizeTeam(team_id);
+      return result(store.assign(team_id, agent_id, task));
+    },
   );
 
   server.registerTool(
@@ -124,7 +158,10 @@ export function createTeamControlServer(store: TeamStore, supervisor: TeamSuperv
       inputSchema: z.object({ team_id: id }).strict(),
       annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true },
     },
-    ({ team_id }) => result(store.stop(team_id)),
+    ({ team_id }) => {
+      if (options.caller) throw new Error("agent_delegation_denied");
+      return result(store.stop(team_id));
+    },
   );
   return server;
 }

--- a/apps/team-worker/src/main.ts
+++ b/apps/team-worker/src/main.ts
@@ -1,0 +1,77 @@
+import { spawn } from "node:child_process";
+import { TeamStore } from "../../../packages/team-control/src/store.js";
+
+const required = (name: string): string => {
+  const value = process.env[name];
+  if (!value) throw new TypeError("invalid team worker configuration");
+  return value;
+};
+
+const teamID = process.argv[2];
+const agentID = process.argv[3];
+if (!teamID || !agentID) throw new TypeError("invalid team worker arguments");
+const workspace = required("YUKH_TEAM_WORKSPACE");
+const store = new TeamStore(workspace);
+const agent = store.agent(teamID, agentID);
+store.transition(teamID, agentID, "running");
+
+const node = process.execPath;
+const launcher = required("YUKH_COORDINATION_LAUNCHER");
+const mcpMain = required("YUKH_COORDINATION_MCP_MAIN");
+const mcpEnv = {
+  YUKH_COORDINATION_AGENT: agent.coordination_agent,
+  YUKH_COORDINATION_LAUNCHER: launcher,
+};
+const prompt = `You are ${agent.role}, worker ${agent.agent_id} in team ${agent.team_id}. Complete this task: ${agent.task}\nUse yukh-coordination to bootstrap if required, join with your role, replay messages, and communicate blockers or completion. You may create a bounded child team only when explicitly delegated.`;
+
+const command =
+  agent.runtime === "codex"
+    ? required("YUKH_CODEX_EXECUTABLE")
+    : required("YUKH_COPILOT_EXECUTABLE");
+const args =
+  agent.runtime === "codex"
+    ? [
+        "exec",
+        "--ephemeral",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "-c",
+        `mcp_servers.yukh-coordination.command=${JSON.stringify(node)}`,
+        "-c",
+        `mcp_servers.yukh-coordination.args=${JSON.stringify([mcpMain])}`,
+        "-c",
+        `mcp_servers.yukh-coordination.env.YUKH_COORDINATION_AGENT=${JSON.stringify(agent.coordination_agent)}`,
+        "-c",
+        `mcp_servers.yukh-coordination.env.YUKH_COORDINATION_LAUNCHER=${JSON.stringify(launcher)}`,
+        prompt,
+      ]
+    : [
+        "-p",
+        prompt,
+        "-s",
+        "--no-ask-user",
+        "--allow-all",
+        `--additional-mcp-config=${JSON.stringify({
+          mcpServers: {
+            "yukh-coordination": {
+              type: "stdio",
+              command: node,
+              args: [mcpMain],
+              env: mcpEnv,
+              tools: ["*"],
+            },
+          },
+        })}`,
+      ];
+
+const exitCode = await new Promise<number>((resolve) => {
+  const child = spawn(command, args, {
+    cwd: workspace,
+    shell: false,
+    stdio: "ignore",
+    env: { HOME: process.env.HOME ?? "", PATH: process.env.PATH ?? "/usr/bin:/bin" },
+  });
+  child.once("error", () => resolve(1));
+  child.once("close", (code) => resolve(code ?? 1));
+});
+store.transition(teamID, agentID, exitCode === 0 ? "completed" : "failed");
+process.exitCode = exitCode;

--- a/apps/team-worker/src/main.ts
+++ b/apps/team-worker/src/main.ts
@@ -13,16 +13,25 @@ if (!teamID || !agentID) throw new TypeError("invalid team worker arguments");
 const workspace = required("YUKH_TEAM_WORKSPACE");
 const store = new TeamStore(workspace);
 const agent = store.agent(teamID, agentID);
-store.transition(teamID, agentID, "running");
+if (agent.state === "defined") store.transition(teamID, agentID, "running");
 
 const node = process.execPath;
 const launcher = required("YUKH_COORDINATION_LAUNCHER");
 const mcpMain = required("YUKH_COORDINATION_MCP_MAIN");
+const teamControlMain = required("YUKH_TEAM_CONTROL_MCP_MAIN");
 const mcpEnv = {
   YUKH_COORDINATION_AGENT: agent.coordination_agent,
   YUKH_COORDINATION_LAUNCHER: launcher,
 };
 const prompt = `You are ${agent.role}, worker ${agent.agent_id} in team ${agent.team_id}. Complete this task: ${agent.task}\nUse yukh-coordination to bootstrap if required, join with your role, replay messages, and communicate blockers or completion. You may create a bounded child team only when explicitly delegated.`;
+const teamControlEnv = {
+  YUKH_TEAM_WORKSPACE: workspace,
+  YUKH_COORDINATION_LAUNCHER: launcher,
+  YUKH_CODEX_EXECUTABLE: required("YUKH_CODEX_EXECUTABLE"),
+  YUKH_COPILOT_EXECUTABLE: required("YUKH_COPILOT_EXECUTABLE"),
+  YUKH_CALLER_TEAM_ID: agent.team_id,
+  YUKH_CALLER_AGENT_ID: agent.agent_id,
+};
 
 const command =
   agent.runtime === "codex"
@@ -42,6 +51,14 @@ const args =
         `mcp_servers.yukh-coordination.env.YUKH_COORDINATION_AGENT=${JSON.stringify(agent.coordination_agent)}`,
         "-c",
         `mcp_servers.yukh-coordination.env.YUKH_COORDINATION_LAUNCHER=${JSON.stringify(launcher)}`,
+        "-c",
+        `mcp_servers.yukh-team-control.command=${JSON.stringify(node)}`,
+        "-c",
+        `mcp_servers.yukh-team-control.args=${JSON.stringify([teamControlMain])}`,
+        ...Object.entries(teamControlEnv).flatMap(([name, value]) => [
+          "-c",
+          `mcp_servers.yukh-team-control.env.${name}=${JSON.stringify(value)}`,
+        ]),
         prompt,
       ]
     : [
@@ -59,6 +76,13 @@ const args =
               env: mcpEnv,
               tools: ["*"],
             },
+            "yukh-team-control": {
+              type: "stdio",
+              command: node,
+              args: [teamControlMain],
+              env: teamControlEnv,
+              tools: ["*"],
+            },
           },
         })}`,
       ];
@@ -67,7 +91,7 @@ const exitCode = await new Promise<number>((resolve) => {
   const child = spawn(command, args, {
     cwd: workspace,
     shell: false,
-    stdio: "ignore",
+    stdio: ["ignore", "inherit", "inherit"],
     env: { HOME: process.env.HOME ?? "", PATH: process.env.PATH ?? "/usr/bin:/bin" },
   });
   child.once("error", () => resolve(1));

--- a/bin/yukh.mjs
+++ b/bin/yukh.mjs
@@ -1,8 +1,14 @@
 #!/usr/bin/env node
 
-if (process.argv[2] !== "conversation" || process.argv[3] !== "watch") {
-  process.stderr.write("usage: yukh conversation watch [--full] [--verbose]\n");
-  process.exit(2);
+if (process.argv[2] === "conversation" && process.argv[3] === "watch") {
+  process.argv.splice(2, 2);
+  await import("../dist/apps/conversation-watch/src/main.js");
+} else if (process.argv[2] === "team" && process.argv[3] === "serve") {
+  process.argv.splice(2, 2);
+  await import("../dist/apps/team-control/src/main.js");
+} else {
+  process.stderr.write(
+    "usage: yukh conversation watch [--full] [--verbose]\n       yukh team serve\n",
+  );
+  process.exitCode = 2;
 }
-process.argv.splice(2, 2);
-await import("../dist/apps/conversation-watch/src/main.js");

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -48,6 +48,38 @@ event id.
 
 Finally ask Codex to replay the transcript and report the verified answer.
 
+## Create a team from Codex or Copilot
+
+Add `yukh-team-control` to the manager session. Its environment uses absolute
+paths to the project workspace, Coordination launcher and both agent CLIs:
+
+```toml
+[mcp_servers.yukh_team_control]
+command = "node"
+args = ["/path/to/yukh-mcp/dist/apps/team-control/src/main.js"]
+env = { YUKH_TEAM_WORKSPACE = "/path/to/project", YUKH_COORDINATION_LAUNCHER = "/path/to/yukh-local-agent.py", YUKH_CODEX_EXECUTABLE = "/absolute/path/to/codex", YUKH_COPILOT_EXECUTABLE = "/absolute/path/to/copilot" }
+enabled_tools = ["team.create", "team.status", "agent.spawn", "agent.status", "task.assign", "team.stop"]
+default_tools_approval_mode = "writes"
+```
+
+For Copilot, use the equivalent MCP server values in `copilot mcp add`. Then ask
+the manager:
+
+```text
+Use yukh-team-control. Create a team for this workspace with one Codex backend
+developer and one Copilot frontend developer. Start both, let them coordinate
+through Yukh, and report their states and log paths.
+```
+
+`agent.spawn` starts a real detached CLI and returns its PID and log path. A
+worker with `can_spawn=true` receives the same team-control MCP but can create
+only bounded children inside its team. It cannot create another root team,
+cross team boundaries or stop the team.
+
+Use `yukh conversation watch --full` to observe verified messages. Follow the
+returned agent log when command-level detail is needed. `team.status` shows the
+persistent team and worker states.
+
 ## Run bounded automatic wake-up
 
 After building this repository, start the local coordinator from the trusted

--- a/packages/conversation-watch/src/watch.ts
+++ b/packages/conversation-watch/src/watch.ts
@@ -22,6 +22,8 @@ export interface LifecycleRecord {
 }
 
 const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const participant = /^agent:[a-z][a-z0-9-]{0,47}$/u;
+const lifecycleAgent = /^agent-[a-z][a-z0-9-]{0,47}$/u;
 
 export function watchRecords(output: CoordinationOutput, after: number): WatchRecord[] {
   if (output.status !== "ok" || !output.result || typeof output.result !== "object")
@@ -46,7 +48,7 @@ function validate(item: unknown): WatchRecord {
     !["join", "leave", "question", "answer"].includes(event.type) ||
     typeof event.time !== "string" ||
     !event.participant ||
-    !["agent:a", "agent:b"].includes(event.participant.id) ||
+    !participant.test(event.participant.id) ||
     !event.data ||
     typeof event.data !== "object" ||
     !record.receipt ||
@@ -110,7 +112,7 @@ export function lifecycleRecords(raw: string, after: number): LifecycleRecord[] 
     if (
       record.schema !== 1 ||
       !allowed.includes(record.event) ||
-      (record.agent !== undefined && !["agent-a", "agent-b"].includes(record.agent)) ||
+      (record.agent !== undefined && !lifecycleAgent.test(record.agent)) ||
       (record.question_event_id !== undefined && !uuid.test(record.question_event_id)) ||
       (record.turn !== undefined && (!Number.isSafeInteger(record.turn) || record.turn < 1)) ||
       (record.failure_code !== undefined &&

--- a/packages/team-control/src/store.ts
+++ b/packages/team-control/src/store.ts
@@ -143,6 +143,25 @@ export class TeamStore {
     return { team: this.#readTeam(id), agents: this.#readAgents(id) };
   }
 
+  agent(id: string, worker: string): AgentRecord {
+    return this.#readAgent(id, worker);
+  }
+
+  transition(id: string, worker: string, state: AgentState): AgentRecord {
+    const current = this.#readAgent(id, worker);
+    const allowed: Readonly<Record<AgentState, readonly AgentState[]>> = {
+      defined: ["running", "stopped"],
+      running: ["completed", "failed", "stopped"],
+      completed: [],
+      failed: [],
+      stopped: [],
+    };
+    if (!allowed[current.state].includes(state)) throw new Error("invalid_agent_transition");
+    const updated: AgentRecord = { ...current, state };
+    this.#write(join(this.#teamDirectory(id), "agents", `${worker}.json`), updated, false);
+    return updated;
+  }
+
   assign(id: string, worker: string, task: string): AgentRecord {
     if (task.length < 1 || task.length > 4_096) throw new TypeError("invalid task");
     const current = this.#readAgent(id, worker);

--- a/packages/team-control/src/supervisor.ts
+++ b/packages/team-control/src/supervisor.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
-import { lstatSync, realpathSync } from "node:fs";
-import { isAbsolute } from "node:path";
+import { closeSync, lstatSync, openSync, realpathSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
 import type { AgentRecord } from "./store.js";
 
 function executable(path: string): string {
@@ -29,6 +29,7 @@ export class TeamSupervisor {
   readonly #worker: string;
   readonly #launcher: string;
   readonly #coordinationMcp: string;
+  readonly #teamControlMcp: string;
   readonly #codex: string;
   readonly #copilot: string;
   readonly #workspace: string;
@@ -38,6 +39,7 @@ export class TeamSupervisor {
     readonly worker: string;
     readonly launcher: string;
     readonly coordinationMcp: string;
+    readonly teamControlMcp: string;
     readonly codex: string;
     readonly copilot: string;
     readonly workspace: string;
@@ -46,30 +48,42 @@ export class TeamSupervisor {
     this.#worker = file(options.worker);
     this.#launcher = executable(options.launcher);
     this.#coordinationMcp = file(options.coordinationMcp);
+    this.#teamControlMcp = file(options.teamControlMcp);
     this.#codex = executable(options.codex);
     this.#copilot = executable(options.copilot);
     this.#workspace = realpathSync(options.workspace);
     if (!lstatSync(this.#workspace).isDirectory()) throw new TypeError("invalid team workspace");
   }
 
-  launch(agent: AgentRecord): number {
+  launch(agent: AgentRecord): { readonly pid: number; readonly log: string } {
+    const log = join(
+      this.#workspace,
+      ".yukh",
+      "teams",
+      agent.team_id,
+      "agents",
+      `${agent.agent_id}.log`,
+    );
+    const output = openSync(log, "a", 0o600);
     const child = spawn(this.#node, [this.#worker, agent.team_id, agent.agent_id], {
       cwd: this.#workspace,
       detached: true,
       shell: false,
-      stdio: "ignore",
+      stdio: ["ignore", output, output],
       env: {
         HOME: process.env.HOME ?? "",
         PATH: process.env.PATH ?? "/usr/bin:/bin",
         YUKH_TEAM_WORKSPACE: this.#workspace,
         YUKH_COORDINATION_LAUNCHER: this.#launcher,
         YUKH_COORDINATION_MCP_MAIN: this.#coordinationMcp,
+        YUKH_TEAM_CONTROL_MCP_MAIN: this.#teamControlMcp,
         YUKH_CODEX_EXECUTABLE: this.#codex,
         YUKH_COPILOT_EXECUTABLE: this.#copilot,
       },
     });
+    closeSync(output);
     if (!child.pid) throw new Error("agent_spawn_failed");
     child.unref();
-    return child.pid;
+    return { pid: child.pid, log };
   }
 }

--- a/packages/team-control/src/supervisor.ts
+++ b/packages/team-control/src/supervisor.ts
@@ -1,0 +1,75 @@
+import { spawn } from "node:child_process";
+import { lstatSync, realpathSync } from "node:fs";
+import { isAbsolute } from "node:path";
+import type { AgentRecord } from "./store.js";
+
+function executable(path: string): string {
+  if (!isAbsolute(path)) throw new TypeError("invalid team executable");
+  const info = lstatSync(path);
+  if (
+    !info.isFile() ||
+    info.isSymbolicLink() ||
+    (info.mode & 0o111) === 0 ||
+    realpathSync(path) !== path
+  )
+    throw new TypeError("invalid team executable");
+  return path;
+}
+
+function file(path: string): string {
+  if (!isAbsolute(path)) throw new TypeError("invalid team runtime file");
+  const info = lstatSync(path);
+  if (!info.isFile() || info.isSymbolicLink() || realpathSync(path) !== path)
+    throw new TypeError("invalid team runtime file");
+  return path;
+}
+
+export class TeamSupervisor {
+  readonly #node: string;
+  readonly #worker: string;
+  readonly #launcher: string;
+  readonly #coordinationMcp: string;
+  readonly #codex: string;
+  readonly #copilot: string;
+  readonly #workspace: string;
+
+  constructor(options: {
+    readonly node: string;
+    readonly worker: string;
+    readonly launcher: string;
+    readonly coordinationMcp: string;
+    readonly codex: string;
+    readonly copilot: string;
+    readonly workspace: string;
+  }) {
+    this.#node = executable(options.node);
+    this.#worker = file(options.worker);
+    this.#launcher = executable(options.launcher);
+    this.#coordinationMcp = file(options.coordinationMcp);
+    this.#codex = executable(options.codex);
+    this.#copilot = executable(options.copilot);
+    this.#workspace = realpathSync(options.workspace);
+    if (!lstatSync(this.#workspace).isDirectory()) throw new TypeError("invalid team workspace");
+  }
+
+  launch(agent: AgentRecord): number {
+    const child = spawn(this.#node, [this.#worker, agent.team_id, agent.agent_id], {
+      cwd: this.#workspace,
+      detached: true,
+      shell: false,
+      stdio: "ignore",
+      env: {
+        HOME: process.env.HOME ?? "",
+        PATH: process.env.PATH ?? "/usr/bin:/bin",
+        YUKH_TEAM_WORKSPACE: this.#workspace,
+        YUKH_COORDINATION_LAUNCHER: this.#launcher,
+        YUKH_COORDINATION_MCP_MAIN: this.#coordinationMcp,
+        YUKH_CODEX_EXECUTABLE: this.#codex,
+        YUKH_COPILOT_EXECUTABLE: this.#copilot,
+      },
+    });
+    if (!child.pid) throw new Error("agent_spawn_failed");
+    child.unref();
+    return child.pid;
+  }
+}

--- a/test/runtime/conversation-watch.test.ts
+++ b/test/runtime/conversation-watch.test.ts
@@ -45,6 +45,20 @@ test("watch renders verified conversation once with optional evidence", () => {
   );
 });
 
+test("watch accepts bounded dynamic team identities", () => {
+  const dynamic = structuredClone(output);
+  dynamic.result.records[0]!.event.participant.id = "agent:frontend-developer-a1b2c3d4";
+  assert.equal(
+    watchRecords(dynamic, 0)[0]?.event.participant.id,
+    "agent:frontend-developer-a1b2c3d4",
+  );
+  const lifecycle = lifecycleRecords(
+    `${JSON.stringify({ schema: 1, event: "agent_started", agent: "agent-frontend-developer-a1b2c3d4", question_event_id: eventID, turn: 1 })}\n`,
+    0,
+  );
+  assert.equal(lifecycle[0]?.agent, "agent-frontend-developer-a1b2c3d4");
+});
+
 test("watch compacts long messages and can render their full body", () => {
   const record = structuredClone(watchRecords(output, 0)[0]!);
   const body = `Frontend implementation request:\n${"Create accessible components. ".repeat(12)}`;

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -85,12 +85,14 @@ test("team supervisor starts a detached bounded worker wrapper", async () => {
     const worker = join(root, "worker.mjs");
     const executable = join(root, "agent-cli");
     const mcp = join(root, "coordination.mjs");
+    const teamControlMcp = join(root, "team-control.mjs");
     await writeFile(
       worker,
       `import {writeFileSync} from "node:fs"; writeFileSync(${JSON.stringify(marker)}, process.argv.slice(2).join(" "));`,
     );
     await writeFile(executable, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
     await writeFile(mcp, "", { mode: 0o600 });
+    await writeFile(teamControlMcp, "", { mode: 0o600 });
     const store = new TeamStore(root);
     const team = store.create("Launch worker", "codex");
     const agent = store.spawn(team.team_id, {
@@ -103,11 +105,17 @@ test("team supervisor starts a detached bounded worker wrapper", async () => {
       worker,
       launcher: executable,
       coordinationMcp: mcp,
+      teamControlMcp,
       codex: executable,
       copilot: executable,
       workspace: root,
     });
-    assert.ok(supervisor.launch(agent) > 0);
+    const launchedRuntime = supervisor.launch(agent);
+    assert.ok(launchedRuntime.pid > 0);
+    assert.equal(
+      launchedRuntime.log,
+      join(root, ".yukh", "teams", team.team_id, "agents", `${agent.agent_id}.log`),
+    );
     let launched = "";
     for (let attempt = 0; attempt < 50 && !launched; attempt++) {
       await new Promise((resolve) => setTimeout(resolve, 20));

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
-import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { TeamStore } from "../../packages/team-control/src/store.js";
+import { TeamSupervisor } from "../../packages/team-control/src/supervisor.js";
 
 test("team store creates dynamic workers and bounded delegated children", async () => {
   const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-team-control-")));
@@ -26,9 +27,15 @@ test("team store creates dynamic workers and bounded delegated children", async 
     assert.equal(testWorker.depth, 2);
     assert.notEqual(testWorker.coordination_agent, backend.coordination_agent);
     assert.equal(store.status(team.team_id).agents.length, 2);
+    assert.equal(store.transition(team.team_id, backend.agent_id, "running").state, "running");
+    assert.equal(store.transition(team.team_id, backend.agent_id, "completed").state, "completed");
+    assert.throws(
+      () => store.transition(team.team_id, backend.agent_id, "running"),
+      /invalid_agent_transition/u,
+    );
     assert.equal(
-      store.assign(team.team_id, backend.agent_id, "Implement and document API").task,
-      "Implement and document API",
+      store.assign(team.team_id, testWorker.agent_id, "Test and document API").task,
+      "Test and document API",
     );
     assert.equal(store.stop(team.team_id).state, "stopped");
     assert.throws(
@@ -66,6 +73,49 @@ test("team store denies undelegated and over-depth children", async () => {
         }),
       /agent_delegation_denied/u,
     );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("team supervisor starts a detached bounded worker wrapper", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-team-supervisor-")));
+  try {
+    const marker = join(root, "worker-launched");
+    const worker = join(root, "worker.mjs");
+    const executable = join(root, "agent-cli");
+    const mcp = join(root, "coordination.mjs");
+    await writeFile(
+      worker,
+      `import {writeFileSync} from "node:fs"; writeFileSync(${JSON.stringify(marker)}, process.argv.slice(2).join(" "));`,
+    );
+    await writeFile(executable, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+    await writeFile(mcp, "", { mode: 0o600 });
+    const store = new TeamStore(root);
+    const team = store.create("Launch worker", "codex");
+    const agent = store.spawn(team.team_id, {
+      runtime: "copilot",
+      role: "frontend-developer",
+      task: "Build UI",
+    });
+    const supervisor = new TeamSupervisor({
+      node: process.execPath,
+      worker,
+      launcher: executable,
+      coordinationMcp: mcp,
+      codex: executable,
+      copilot: executable,
+      workspace: root,
+    });
+    assert.ok(supervisor.launch(agent) > 0);
+    let launched = "";
+    for (let attempt = 0; attempt < 50 && !launched; attempt++) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      try {
+        launched = await readFile(marker, "utf8");
+      } catch {}
+    }
+    assert.equal(launched, `${team.team_id} ${agent.agent_id}`);
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Refs #127 and builds on Coordination RFC-0030.

Adds agent.spawn, agent.status and task.assign to the team-control MCP server. agent.spawn allocates a distinct Coordination identity, launches a detached Codex or Copilot worker, injects Coordination plus caller-bound team-control MCP configuration, records persistent state, and returns PID and log path. Delegated workers can create bounded children only inside their own team; cross-team, root-team and stop authority are denied. The conversation watcher accepts dynamic identities, and `yukh team serve` provides CLI parity for serving the same MCP control plane.

Process termination for team.stop and a native team-aware watch/status presentation remain follow-up increments in #127.

Validated with formatting, typecheck, full test suite, build and diff checks.