### PR TITLE
Stop owned dynamic team workers

### DIFF
--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -154,7 +154,7 @@ export function createTeamControlServer(
     "team.stop",
     {
       title: "Stop a local team",
-      description: "Mark a team stopped; worker process termination is added with the supervisor",
+      description: "Stop the team and signal its worker wrappers to terminate their agent CLIs",
       inputSchema: z.object({ team_id: id }).strict(),
       annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true },
     },

--- a/apps/team-worker/src/main.ts
+++ b/apps/team-worker/src/main.ts
@@ -87,15 +87,34 @@ const args =
         })}`,
       ];
 
-const exitCode = await new Promise<number>((resolve) => {
-  const child = spawn(command, args, {
-    cwd: workspace,
-    shell: false,
-    stdio: ["ignore", "inherit", "inherit"],
-    env: { HOME: process.env.HOME ?? "", PATH: process.env.PATH ?? "/usr/bin:/bin" },
-  });
-  child.once("error", () => resolve(1));
-  child.once("close", (code) => resolve(code ?? 1));
-});
-store.transition(teamID, agentID, exitCode === 0 ? "completed" : "failed");
-process.exitCode = exitCode;
+const outcome = await new Promise<{ readonly exitCode: number; readonly stopped: boolean }>(
+  (resolve) => {
+    const child = spawn(command, args, {
+      cwd: workspace,
+      shell: false,
+      stdio: ["ignore", "inherit", "inherit"],
+      env: { HOME: process.env.HOME ?? "", PATH: process.env.PATH ?? "/usr/bin:/bin" },
+    });
+    let stopped = false;
+    let killTimer: NodeJS.Timeout | undefined;
+    const monitor = setInterval(() => {
+      if (stopped || store.status(teamID).team.state !== "stopped") return;
+      stopped = true;
+      child.kill("SIGTERM");
+      killTimer = setTimeout(() => child.kill("SIGKILL"), 5_000);
+    }, 500);
+    const finish = (exitCode: number): void => {
+      clearInterval(monitor);
+      if (killTimer) clearTimeout(killTimer);
+      resolve({ exitCode, stopped });
+    };
+    child.once("error", () => finish(1));
+    child.once("close", (code) => finish(code ?? 1));
+  },
+);
+store.transition(
+  teamID,
+  agentID,
+  outcome.stopped ? "stopped" : outcome.exitCode === 0 ? "completed" : "failed",
+);
+process.exitCode = outcome.stopped ? 0 : outcome.exitCode;

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -78,7 +78,8 @@ cross team boundaries or stop the team.
 
 Use `yukh conversation watch --full` to observe verified messages. Follow the
 returned agent log when command-level detail is needed. `team.status` shows the
-persistent team and worker states.
+persistent team and worker states. `team.stop` marks the team stopped; each
+worker wrapper observes that state and terminates its own agent CLI.
 
 ## Run bounded automatic wake-up
 

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -1,10 +1,15 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import { mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 import { TeamStore } from "../../packages/team-control/src/store.js";
 import { TeamSupervisor } from "../../packages/team-control/src/supervisor.js";
+
+const workerMain = fileURLToPath(new URL("../../apps/team-worker/src/main.ts", import.meta.url));
+const tsxLoader = fileURLToPath(import.meta.resolve("tsx"));
 
 test("team store creates dynamic workers and bounded delegated children", async () => {
   const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-team-control-")));
@@ -124,6 +129,52 @@ test("team supervisor starts a detached bounded worker wrapper", async () => {
       } catch {}
     }
     assert.equal(launched, `${team.team_id} ${agent.agent_id}`);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("stopping a team makes its wrapper terminate the owned agent CLI", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-team-stop-")));
+  try {
+    const executable = join(root, "agent-cli");
+    const support = join(root, "support.mjs");
+    await writeFile(executable, "#!/bin/sh\nsleep 30\n", { mode: 0o700 });
+    await writeFile(support, "", { mode: 0o600 });
+    const store = new TeamStore(root);
+    const team = store.create("Stop worker", "codex");
+    const agent = store.spawn(team.team_id, {
+      runtime: "codex",
+      role: "backend-developer",
+      task: "Wait",
+    });
+    const child = spawn(
+      process.execPath,
+      ["--import", tsxLoader, workerMain, team.team_id, agent.agent_id],
+      {
+        cwd: root,
+        stdio: "ignore",
+        env: {
+          HOME: process.env.HOME ?? "",
+          PATH: process.env.PATH ?? "/usr/bin:/bin",
+          YUKH_TEAM_WORKSPACE: root,
+          YUKH_COORDINATION_LAUNCHER: executable,
+          YUKH_COORDINATION_MCP_MAIN: support,
+          YUKH_TEAM_CONTROL_MCP_MAIN: support,
+          YUKH_CODEX_EXECUTABLE: executable,
+          YUKH_COPILOT_EXECUTABLE: executable,
+        },
+      },
+    );
+    for (let attempt = 0; attempt < 50; attempt++) {
+      if (store.agent(team.team_id, agent.agent_id).state === "running") break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    assert.equal(store.agent(team.team_id, agent.agent_id).state, "running");
+    store.stop(team.team_id);
+    const exitCode = await new Promise<number | null>((resolve) => child.once("close", resolve));
+    assert.equal(exitCode, 0);
+    assert.equal(store.agent(team.team_id, agent.agent_id).state, "stopped");
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Refs #127. Makes team.stop operational: each persistent wrapper observes the stopped team state, terminates only its own child CLI with SIGTERM and a bounded SIGKILL fallback, and records the worker as stopped. Avoids persisted-PID reuse hazards. Adds an integration test with a real wrapper and child process, and updates the operator guide.