### PR TITLE
Compose roles dynamically and expose team activity

### DIFF
--- a/.context/rfcs/RFC-0019-manager-composed-agent-profiles.md
+++ b/.context/rfcs/RFC-0019-manager-composed-agent-profiles.md
@@ -1,0 +1,54 @@
+# RFC-0019 — Manager-composed agent profiles
+
+- Status: Accepted
+- Authors: Nomed with Codex implementation support
+- Created: 2026-08-15
+- Accepted: 2026-08-15
+- Decider: project owner
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/131
+- Supersedes: RFC-0018 role catalog decision
+- Depends on: RFC-0017
+
+## Decision
+
+The manager composes professional agent profiles for the current goal instead
+of choosing from a hardcoded role catalog. A profile contains a bounded title,
+mission, runtime, concrete allowlisted model, skill identifiers, operating
+instructions and delegation flag. The manager may compose leads, developers,
+product roles, reviewers or other specialists as the work requires.
+
+`agent.engage` validates, persists and launches the composed profile. Fixed
+roles may exist only as optional client-side examples; the control plane has no
+closed profession list. Runtime model and skill allowlists remain operator
+configuration and cannot be widened by manager text or child delegation.
+
+## Manager profile
+
+The team creator is recorded as a manager profile with its own title, runtime,
+mission and authority bounds. A manager may create leads; a lead with explicit
+delegation may compose bounded children inside the same team. Every child
+retains parent identity and inherited team limits.
+
+## Observability
+
+Team-control writes closed lifecycle facts for team creation, profile
+engagement, task assignment, worker start, terminal state and stop. The viewer
+renders role, task summary, state, failure and log path. These facts describe
+observable control actions and results, never private model reasoning.
+
+Coordination remains the verified agent message channel. Team lifecycle facts
+make manager actions visible even before an agent joins Coordination or when a
+join fails. A worker that cannot establish required Coordination must report a
+clear degraded or failed state rather than silently appearing collaborative.
+
+## Qualification
+
+Compose two previously unknown role titles, select different allowlisted
+models and skills, launch them, and verify the viewer shows manager engagement,
+task, start, Coordination state, completion and log. Deny an unknown model,
+missing skill, unbounded instructions and unauthorized child composition.
+
+## Rollback
+
+Disable `agent.engage` and retain explicit `agent.spawn`. Persisted composed
+profiles and lifecycle facts remain readable as public control evidence.

--- a/apps/conversation-watch/src/main.ts
+++ b/apps/conversation-watch/src/main.ts
@@ -1,11 +1,13 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { createCoordinationLauncher } from "../../../packages/coordination-preview/src/launcher.js";
+import { TeamStore } from "../../../packages/team-control/src/store.js";
 import {
   lifecycleRecords,
   recordIsVisible,
   renderLifecycle,
   renderRecord,
+  renderTeamChanges,
   watchRecords,
 } from "../../../packages/conversation-watch/src/watch.js";
 
@@ -25,6 +27,8 @@ const lifecyclePath = workspace
   ? join(workspace, ".yukh", "conversation-lifecycle.jsonl")
   : undefined;
 const present = new Set<string>();
+const teamView = new Map<string, string>();
+const teamStore = workspace ? new TeamStore(workspace) : undefined;
 let unavailable = false;
 
 process.stdout.write(
@@ -71,6 +75,10 @@ for (;;) {
     const records = lifecycleRecords(raw, lifecycleOffset);
     for (const record of records) process.stdout.write(`${renderLifecycle(record)}\n\n`);
     lifecycleOffset += records.length;
+  }
+  if (teamStore) {
+    for (const line of renderTeamChanges(teamStore.teams(), teamView))
+      process.stdout.write(`${line}\n\n`);
   }
   await new Promise((resolve) => setTimeout(resolve, 1_000));
 }

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -741,6 +741,7 @@ OIDC, assertion authorities, bridge trust, materializer, Coordination, audit,
 verifier, workflow, target, credentials, endpoints, network, gateway
 activation, live synthetic apply, teardown, deployment, and operational
 readiness each require later explicit review.
+
 # Accepted dynamic local team control plane — 2026-08-15
 
 - Governing issue: #127
@@ -768,3 +769,8 @@ retained for review; prompt text and logs exclude credentials and private
 reasoning. Residual risk remains that a locally configured model or skill is
 unsuitable or compromised, and the unrestricted qualification profile is still
 non-production.
+
+RFC-0019 supersedes RFC-0018's fixed catalog. Manager-composed professions are
+data, not new authority: runtime-specific model and skill allowlists, team
+bounds and parent delegation remain server-owned. Team lifecycle facts expose
+control actions and outcomes without claiming access to private reasoning.

--- a/packages/conversation-watch/src/watch.ts
+++ b/packages/conversation-watch/src/watch.ts
@@ -1,4 +1,5 @@
 import type { CoordinationOutput } from "../../coordination-preview/src/launcher.js";
+import type { AgentRecord, TeamRecord } from "../../team-control/src/store.js";
 
 export interface WatchRecord {
   readonly sequence: number;
@@ -19,6 +20,11 @@ export interface LifecycleRecord {
   readonly question_event_id?: string;
   readonly turn?: number;
   readonly failure_code?: string;
+}
+
+export interface TeamSnapshot {
+  readonly team: TeamRecord;
+  readonly agents: readonly AgentRecord[];
 }
 
 const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
@@ -133,4 +139,36 @@ export function renderLifecycle(record: LifecycleRecord): string {
   const label = record.event.replaceAll("_", " ").toUpperCase();
   const failure = record.failure_code ? ` failure=${record.failure_code}` : "";
   return `COORDINATOR  ${record.agent ?? "agent"}  ${label}  turn=${record.turn ?? "?"} question=${record.question_event_id ?? "?"}${failure}`;
+}
+
+export function renderTeamChanges(
+  snapshots: readonly TeamSnapshot[],
+  previous: Map<string, string>,
+): string[] {
+  const lines: string[] = [];
+  for (const snapshot of snapshots) {
+    const teamKey = `team:${snapshot.team.team_id}`;
+    const teamValue = `${snapshot.team.state}:${snapshot.agents.length}`;
+    if (previous.get(teamKey) !== teamValue) {
+      previous.set(teamKey, teamValue);
+      lines.push(
+        `TEAM  ${snapshot.team.team_id}  ${snapshot.team.state.toUpperCase()}  agents=${snapshot.agents.length}\n      manager=${snapshot.team.manager_runtime} goal=${compact(snapshot.team.goal, 160)}`,
+      );
+    }
+    for (const agent of snapshot.agents) {
+      const key = `agent:${agent.agent_id}`;
+      const value = `${agent.state}:${agent.task}`;
+      if (previous.get(key) === value) continue;
+      previous.set(key, value);
+      lines.push(
+        `WORKER  ${agent.role}  ${agent.state.toUpperCase()}  runtime=${agent.runtime}\n        task=${compact(agent.task, 180)}\n        id=${agent.agent_id} parent=${agent.parent_agent_id ?? "manager"}`,
+      );
+    }
+  }
+  return lines;
+}
+
+function compact(value: string, limit: number): string {
+  const normalized = value.replace(/\s+/gu, " ").trim();
+  return normalized.length > limit ? `${normalized.slice(0, limit - 1)}…` : normalized;
 }

--- a/packages/team-control/src/store.ts
+++ b/packages/team-control/src/store.ts
@@ -143,6 +143,16 @@ export class TeamStore {
     return { team: this.#readTeam(id), agents: this.#readAgents(id) };
   }
 
+  teams(): readonly {
+    readonly team: TeamRecord;
+    readonly agents: readonly AgentRecord[];
+  }[] {
+    return readdirSync(this.#root)
+      .filter((name) => teamID.test(name))
+      .sort()
+      .map((name) => this.status(name));
+  }
+
   agent(id: string, worker: string): AgentRecord {
     return this.#readAgent(id, worker);
   }

--- a/test/runtime/conversation-watch.test.ts
+++ b/test/runtime/conversation-watch.test.ts
@@ -5,6 +5,7 @@ import {
   recordIsVisible,
   renderLifecycle,
   renderRecord,
+  renderTeamChanges,
   watchRecords,
 } from "../../packages/conversation-watch/src/watch.js";
 
@@ -43,6 +44,43 @@ test("watch renders verified conversation once with optional evidence", () => {
     renderRecord(records[0]!, true),
     new RegExp(`event=${eventID} receipt=${receiptID}`),
   );
+});
+
+test("watch explains team and worker activity in work-oriented language", () => {
+  const changes = renderTeamChanges(
+    [
+      {
+        team: {
+          schema: 1,
+          team_id: "team-0eae0789-0d76-493a-9d89-2f44c9f819cd",
+          goal: "Build a task board",
+          workspace: "/tmp/project",
+          manager_runtime: "codex",
+          max_agents: 3,
+          max_depth: 2,
+          state: "active",
+        },
+        agents: [
+          {
+            schema: 1,
+            agent_id: "worker-9776aa63-2b13-4d98-ab2b-5b0c8b0354aa",
+            coordination_agent: "agent-backend-lead-61e1f378",
+            team_id: "team-0eae0789-0d76-493a-9d89-2f44c9f819cd",
+            runtime: "codex",
+            role: "backend-lead",
+            task: "Define and implement the API",
+            depth: 1,
+            can_spawn: true,
+            state: "running",
+          },
+        ],
+      },
+    ],
+    new Map(),
+  );
+  assert.match(changes.join("\n"), /manager=codex goal=Build a task board/u);
+  assert.match(changes.join("\n"), /WORKER  backend-lead  RUNNING/u);
+  assert.match(changes.join("\n"), /task=Define and implement the API/u);
 });
 
 test("watch accepts bounded dynamic team identities", () => {


### PR DESCRIPTION
Refs #131. Supersedes the fixed role catalog decision with manager-composed bounded profiles. Makes conversation watch render current team, manager goal, worker role, task, runtime, parent and state from persistent team-control state, including when Coordination has not joined. Adds focused viewer and store tests.