### PR TITLE
Engage composed agents with verified profiles

### DIFF
--- a/apps/team-control/src/main.ts
+++ b/apps/team-control/src/main.ts
@@ -26,11 +26,28 @@ const supervisor = new TeamSupervisor({
   codex,
   copilot,
   workspace,
+  profileEnvironment: Object.fromEntries(
+    ["YUKH_CODEX_MODELS", "YUKH_COPILOT_MODELS", "YUKH_CODEX_SKILLS", "YUKH_COPILOT_SKILLS"]
+      .filter((name) => process.env[name] !== undefined)
+      .map((name) => [name, process.env[name]!] as const),
+  ),
 });
+const allowlist = (name: string, fallback: readonly string[] = []): ReadonlySet<string> => {
+  const raw = process.env[name];
+  return new Set(raw ? raw.split(",").filter(Boolean) : fallback);
+};
 
 serveStdio(
   () =>
     createTeamControlServer(store, supervisor, {
+      models: {
+        codex: allowlist("YUKH_CODEX_MODELS", ["default"]),
+        copilot: allowlist("YUKH_COPILOT_MODELS", ["default"]),
+      },
+      skills: {
+        codex: allowlist("YUKH_CODEX_SKILLS"),
+        copilot: allowlist("YUKH_COPILOT_SKILLS"),
+      },
       ...(callerTeamId && callerAgentId
         ? { caller: { team_id: callerTeamId, agent_id: callerAgentId } }
         : {}),

--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -14,6 +14,20 @@ function result(value: unknown) {
 
 export interface TeamControlOptions {
   readonly caller?: { readonly team_id: string; readonly agent_id: string };
+  readonly models?: Readonly<Record<"codex" | "copilot", ReadonlySet<string>>>;
+  readonly skills?: Readonly<Record<"codex" | "copilot", ReadonlySet<string>>>;
+}
+
+export function assertProfileAvailable(
+  options: TeamControlOptions,
+  runtime: "codex" | "copilot",
+  model: string,
+  skills: readonly string[],
+): void {
+  if (!options.models?.[runtime].has(model)) throw new Error("agent_model_unavailable");
+  const availableSkills = options.skills?.[runtime] ?? new Set<string>();
+  if (skills.some((skill) => !availableSkills.has(skill)))
+    throw new Error("agent_skill_unavailable");
 }
 
 export function createTeamControlServer(
@@ -43,15 +57,25 @@ export function createTeamControlServer(
         .object({
           goal: z.string().min(1).max(4_096),
           manager_runtime: z.enum(["codex", "copilot"]),
+          manager_role: z
+            .string()
+            .regex(/^[a-z][a-z0-9-]{0,31}$/u)
+            .optional(),
+          manager_mission: z.string().min(1).max(1_024).optional(),
           max_agents: z.number().int().min(1).max(32).default(16),
           max_depth: z.number().int().min(1).max(5).default(3),
         })
         .strict(),
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
     },
-    ({ goal, manager_runtime, max_agents, max_depth }) => {
+    ({ goal, manager_runtime, manager_role, manager_mission, max_agents, max_depth }) => {
       if (options.caller) throw new Error("agent_delegation_denied");
-      return result(store.create(goal, manager_runtime, max_agents, max_depth));
+      return result(
+        store.create(goal, manager_runtime, max_agents, max_depth, {
+          role: manager_role ?? "delivery-manager",
+          mission: manager_mission ?? goal,
+        }),
+      );
     },
   );
 
@@ -66,6 +90,63 @@ export function createTeamControlServer(
     ({ team_id }) => {
       authorizeTeam(team_id);
       return result(store.status(team_id));
+    },
+  );
+
+  server.registerTool(
+    "agent.engage",
+    {
+      title: "Compose and engage a specialist agent",
+      description:
+        "Validate a manager-composed role, model, skills and instructions, then start the worker",
+      inputSchema: z
+        .object({
+          team_id: id,
+          parent_agent_id: z
+            .string()
+            .regex(/^worker-[0-9a-f-]{36}$/u)
+            .optional(),
+          runtime: z.enum(["codex", "copilot"]),
+          role: z.string().regex(/^[a-z][a-z0-9-]{0,31}$/u),
+          mission: z.string().min(1).max(1_024),
+          model: z.string().regex(/^[a-z0-9][a-z0-9._:-]{0,63}$/u),
+          skills: z.array(z.string().regex(/^[a-z0-9][a-z0-9._:-]{0,63}$/u)).max(16),
+          instructions: z.string().min(1).max(4_096),
+          task: z.string().min(1).max(4_096),
+          can_spawn: z.boolean().default(false),
+        })
+        .strict(),
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+    },
+    (input) => {
+      assertProfileAvailable(options, input.runtime, input.model, input.skills);
+      if (
+        options.caller &&
+        (input.team_id !== options.caller.team_id ||
+          (input.parent_agent_id !== undefined &&
+            input.parent_agent_id !== options.caller.agent_id))
+      )
+        throw new Error("agent_delegation_denied");
+      const agent = store.spawn(input.team_id, {
+        ...(options.caller
+          ? { parent_agent_id: options.caller.agent_id }
+          : input.parent_agent_id
+            ? { parent_agent_id: input.parent_agent_id }
+            : {}),
+        runtime: input.runtime,
+        role: input.role,
+        profile: {
+          schema: 1,
+          mission: input.mission,
+          model: input.model,
+          skills: input.skills,
+          instructions: input.instructions,
+        },
+        task: input.task,
+        can_spawn: input.can_spawn,
+      });
+      const runtime = supervisor.launch(agent);
+      return result({ agent, ...runtime });
     },
   );
 

--- a/apps/team-worker/src/main.ts
+++ b/apps/team-worker/src/main.ts
@@ -13,7 +13,6 @@ if (!teamID || !agentID) throw new TypeError("invalid team worker arguments");
 const workspace = required("YUKH_TEAM_WORKSPACE");
 const store = new TeamStore(workspace);
 const agent = store.agent(teamID, agentID);
-if (agent.state === "defined") store.transition(teamID, agentID, "running");
 
 const node = process.execPath;
 const launcher = required("YUKH_COORDINATION_LAUNCHER");
@@ -23,7 +22,8 @@ const mcpEnv = {
   YUKH_COORDINATION_AGENT: agent.coordination_agent,
   YUKH_COORDINATION_LAUNCHER: launcher,
 };
-const prompt = `You are ${agent.role}, worker ${agent.agent_id} in team ${agent.team_id}. Complete this task: ${agent.task}\nUse yukh-coordination to bootstrap if required, join with your role, replay messages, and communicate blockers or completion. You may create a bounded child team only when explicitly delegated.`;
+const profile = agent.profile;
+const prompt = `You are ${agent.role}, worker ${agent.agent_id} in team ${agent.team_id}.${profile ? ` Mission: ${profile.mission}\nOperating instructions: ${profile.instructions}\nRequired skills: ${profile.skills.length > 0 ? profile.skills.join(", ") : "none"}.` : ""}\nComplete this task: ${agent.task}\nYour Coordination session is already bootstrapped and joined. Use yukh-coordination to replay messages and communicate decisions, questions, blockers and completion. You may create a bounded child only when explicitly delegated.`;
 const teamControlEnv = {
   YUKH_TEAM_WORKSPACE: workspace,
   YUKH_COORDINATION_LAUNCHER: launcher,
@@ -31,6 +31,11 @@ const teamControlEnv = {
   YUKH_COPILOT_EXECUTABLE: required("YUKH_COPILOT_EXECUTABLE"),
   YUKH_CALLER_TEAM_ID: agent.team_id,
   YUKH_CALLER_AGENT_ID: agent.agent_id,
+  ...Object.fromEntries(
+    ["YUKH_CODEX_MODELS", "YUKH_COPILOT_MODELS", "YUKH_CODEX_SKILLS", "YUKH_COPILOT_SKILLS"]
+      .filter((name) => process.env[name] !== undefined)
+      .map((name) => [name, process.env[name]!] as const),
+  ),
 };
 
 const command =
@@ -43,6 +48,7 @@ const args =
         "exec",
         "--ephemeral",
         "--dangerously-bypass-approvals-and-sandbox",
+        ...(profile && profile.model !== "default" ? ["--model", profile.model] : []),
         "-c",
         `mcp_servers.yukh-coordination.command=${JSON.stringify(node)}`,
         "-c",
@@ -67,6 +73,7 @@ const args =
         "-s",
         "--no-ask-user",
         "--allow-all",
+        ...(profile && profile.model !== "default" ? ["--model", profile.model] : []),
         `--additional-mcp-config=${JSON.stringify({
           mcpServers: {
             "yukh-coordination": {
@@ -87,34 +94,82 @@ const args =
         })}`,
       ];
 
-const outcome = await new Promise<{ readonly exitCode: number; readonly stopped: boolean }>(
-  (resolve) => {
-    const child = spawn(command, args, {
+async function coordination(commandArgs: readonly string[], input?: object): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    const child = spawn(launcher, [agent.coordination_agent, ...commandArgs], {
       cwd: workspace,
       shell: false,
-      stdio: ["ignore", "inherit", "inherit"],
+      stdio: ["pipe", "pipe", "inherit"],
       env: { HOME: process.env.HOME ?? "", PATH: process.env.PATH ?? "/usr/bin:/bin" },
     });
-    let stopped = false;
-    let killTimer: NodeJS.Timeout | undefined;
-    const monitor = setInterval(() => {
-      if (stopped || store.status(teamID).team.state !== "stopped") return;
-      stopped = true;
-      child.kill("SIGTERM");
-      killTimer = setTimeout(() => child.kill("SIGKILL"), 5_000);
-    }, 500);
-    const finish = (exitCode: number): void => {
-      clearInterval(monitor);
-      if (killTimer) clearTimeout(killTimer);
-      resolve({ exitCode, stopped });
-    };
-    child.once("error", () => finish(1));
-    child.once("close", (code) => finish(code ?? 1));
-  },
-);
-store.transition(
-  teamID,
-  agentID,
-  outcome.stopped ? "stopped" : outcome.exitCode === 0 ? "completed" : "failed",
-);
+    const chunks: Buffer[] = [];
+    child.stdout.on("data", (chunk: Buffer) => chunks.push(chunk));
+    if (input) child.stdin.end(`${JSON.stringify(input)}\n`);
+    else child.stdin.end();
+    const timer = setTimeout(() => child.kill("SIGKILL"), 10_000);
+    child.once("error", () => {
+      clearTimeout(timer);
+      resolve(false);
+    });
+    child.once("close", (code) => {
+      clearTimeout(timer);
+      try {
+        const output = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+          status?: unknown;
+        };
+        resolve(code === 0 && output.status === "ok");
+      } catch {
+        resolve(false);
+      }
+    });
+  });
+}
+
+const bootstrapped = await coordination(["session", "bootstrap"]);
+const joined =
+  bootstrapped &&
+  (await coordination(["session", "join"], {
+    capabilities: ["publish", "replay"],
+    session_label: agent.role,
+    status: "available",
+  }));
+if (!joined) {
+  process.stderr.write("yukh-team-worker: coordination bootstrap or join failed\n");
+  store.transition(teamID, agentID, "failed");
+  process.exitCode = 1;
+} else {
+  store.transition(teamID, agentID, "running");
+}
+
+const outcome = !joined
+  ? { exitCode: 1, stopped: false }
+  : await new Promise<{ readonly exitCode: number; readonly stopped: boolean }>((resolve) => {
+      const child = spawn(command, args, {
+        cwd: workspace,
+        shell: false,
+        stdio: ["ignore", "inherit", "inherit"],
+        env: { HOME: process.env.HOME ?? "", PATH: process.env.PATH ?? "/usr/bin:/bin" },
+      });
+      let stopped = false;
+      let killTimer: NodeJS.Timeout | undefined;
+      const monitor = setInterval(() => {
+        if (stopped || store.status(teamID).team.state !== "stopped") return;
+        stopped = true;
+        child.kill("SIGTERM");
+        killTimer = setTimeout(() => child.kill("SIGKILL"), 5_000);
+      }, 500);
+      const finish = (exitCode: number): void => {
+        clearInterval(monitor);
+        if (killTimer) clearTimeout(killTimer);
+        resolve({ exitCode, stopped });
+      };
+      child.once("error", () => finish(1));
+      child.once("close", (code) => finish(code ?? 1));
+    });
+if (joined)
+  store.transition(
+    teamID,
+    agentID,
+    outcome.stopped ? "stopped" : outcome.exitCode === 0 ? "completed" : "failed",
+  );
 process.exitCode = outcome.stopped ? 0 : outcome.exitCode;

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -62,6 +62,16 @@ enabled_tools = ["team.create", "team.status", "agent.spawn", "agent.status", "t
 default_tools_approval_mode = "writes"
 ```
 
+Add comma-separated local allowlists when using composed profiles:
+
+```toml
+env = { YUKH_CODEX_MODELS = "default,approved-codex-model", YUKH_COPILOT_MODELS = "default,approved-copilot-model", YUKH_CODEX_SKILLS = "api-design,testing,review", YUKH_COPILOT_SKILLS = "frontend,testing,product" }
+```
+
+The manager uses `agent.engage` to compose any bounded professional role. Model
+and skill values outside these allowlists fail before process launch. The
+worker must bootstrap and join Coordination before its agent CLI starts.
+
 For Copilot, use the equivalent MCP server values in `copilot mcp add`. Then ask
 the manager:
 

--- a/packages/conversation-watch/src/watch.ts
+++ b/packages/conversation-watch/src/watch.ts
@@ -152,7 +152,7 @@ export function renderTeamChanges(
     if (previous.get(teamKey) !== teamValue) {
       previous.set(teamKey, teamValue);
       lines.push(
-        `TEAM  ${snapshot.team.team_id}  ${snapshot.team.state.toUpperCase()}  agents=${snapshot.agents.length}\n      manager=${snapshot.team.manager_runtime} goal=${compact(snapshot.team.goal, 160)}`,
+        `TEAM  ${snapshot.team.team_id}  ${snapshot.team.state.toUpperCase()}  agents=${snapshot.agents.length}\n      manager=${snapshot.team.manager_role ?? "manager"} runtime=${snapshot.team.manager_runtime} goal=${compact(snapshot.team.goal, 160)}${snapshot.team.manager_mission ? `\n      mission=${compact(snapshot.team.manager_mission, 160)}` : ""}`,
       );
     }
     for (const agent of snapshot.agents) {
@@ -161,7 +161,7 @@ export function renderTeamChanges(
       if (previous.get(key) === value) continue;
       previous.set(key, value);
       lines.push(
-        `WORKER  ${agent.role}  ${agent.state.toUpperCase()}  runtime=${agent.runtime}\n        task=${compact(agent.task, 180)}\n        id=${agent.agent_id} parent=${agent.parent_agent_id ?? "manager"}`,
+        `WORKER  ${agent.role}  ${agent.state.toUpperCase()}  runtime=${agent.runtime}${agent.profile ? ` model=${agent.profile.model}` : ""}\n        task=${compact(agent.task, 180)}${agent.profile ? `\n        mission=${compact(agent.profile.mission, 160)} skills=${agent.profile.skills.join(",") || "none"}` : ""}\n        id=${agent.agent_id} parent=${agent.parent_agent_id ?? "manager"}`,
       );
     }
   }

--- a/packages/team-control/src/store.ts
+++ b/packages/team-control/src/store.ts
@@ -14,12 +14,22 @@ export type AgentRuntime = "codex" | "copilot";
 export type TeamState = "active" | "stopped";
 export type AgentState = "defined" | "running" | "completed" | "failed" | "stopped";
 
+export interface ComposedAgentProfile {
+  readonly schema: 1;
+  readonly mission: string;
+  readonly model: string;
+  readonly skills: readonly string[];
+  readonly instructions: string;
+}
+
 export interface TeamRecord {
   readonly schema: 1;
   readonly team_id: string;
   readonly goal: string;
   readonly workspace: string;
   readonly manager_runtime: AgentRuntime;
+  readonly manager_role?: string;
+  readonly manager_mission?: string;
   readonly max_agents: number;
   readonly max_depth: number;
   readonly state: TeamState;
@@ -33,6 +43,7 @@ export interface AgentRecord {
   readonly parent_agent_id?: string;
   readonly runtime: AgentRuntime;
   readonly role: string;
+  readonly profile?: ComposedAgentProfile;
   readonly task: string;
   readonly depth: number;
   readonly can_spawn: boolean;
@@ -61,7 +72,13 @@ export class TeamStore {
     if (lstatSync(this.#root).isSymbolicLink()) throw new TypeError("invalid team state path");
   }
 
-  create(goal: string, managerRuntime: AgentRuntime, maxAgents = 16, maxDepth = 3): TeamRecord {
+  create(
+    goal: string,
+    managerRuntime: AgentRuntime,
+    maxAgents = 16,
+    maxDepth = 3,
+    manager?: { readonly role: string; readonly mission: string },
+  ): TeamRecord {
     if (
       goal.trim() !== goal ||
       goal.length < 1 ||
@@ -75,12 +92,21 @@ export class TeamStore {
       maxDepth > 5
     )
       throw new TypeError("invalid team definition");
+    if (
+      manager &&
+      (!roleName.test(manager.role) ||
+        manager.mission.trim() !== manager.mission ||
+        manager.mission.length < 1 ||
+        manager.mission.length > 1_024)
+    )
+      throw new TypeError("invalid manager profile");
     const record: TeamRecord = {
       schema: 1,
       team_id: `team-${randomUUID()}`,
       goal,
       workspace: this.#workspace,
       manager_runtime: managerRuntime,
+      ...(manager ? { manager_role: manager.role, manager_mission: manager.mission } : {}),
       max_agents: maxAgents,
       max_depth: maxDepth,
       state: "active",
@@ -97,6 +123,7 @@ export class TeamStore {
       readonly parent_agent_id?: string;
       readonly runtime: AgentRuntime;
       readonly role: string;
+      readonly profile?: ComposedAgentProfile;
       readonly task: string;
       readonly can_spawn?: boolean;
     },
@@ -111,6 +138,7 @@ export class TeamStore {
       input.task.length > 4_096
     )
       throw new TypeError("invalid agent definition");
+    if (input.profile) this.#validateProfile(input.profile);
     const agents = this.#readAgents(id);
     if (agents.length >= team.max_agents) throw new Error("team_agent_limit");
     const parent = input.parent_agent_id
@@ -130,6 +158,7 @@ export class TeamStore {
       ...(parent ? { parent_agent_id: parent.agent_id } : {}),
       runtime: input.runtime,
       role: input.role,
+      ...(input.profile ? { profile: input.profile } : {}),
       task: input.task,
       depth,
       can_spawn: input.can_spawn ?? false,
@@ -160,7 +189,7 @@ export class TeamStore {
   transition(id: string, worker: string, state: AgentState): AgentRecord {
     const current = this.#readAgent(id, worker);
     const allowed: Readonly<Record<AgentState, readonly AgentState[]>> = {
-      defined: ["running", "stopped"],
+      defined: ["running", "failed", "stopped"],
       running: ["completed", "failed", "stopped"],
       completed: [],
       failed: [],
@@ -191,6 +220,25 @@ export class TeamStore {
   #teamDirectory(id: string): string {
     if (!teamID.test(id)) throw new TypeError("invalid team id");
     return join(this.#root, id);
+  }
+
+  #validateProfile(profile: ComposedAgentProfile): void {
+    const token = /^[a-z0-9][a-z0-9._:-]{0,63}$/u;
+    if (
+      profile.schema !== 1 ||
+      profile.mission.trim() !== profile.mission ||
+      profile.mission.length < 1 ||
+      profile.mission.length > 1_024 ||
+      !token.test(profile.model) ||
+      !Array.isArray(profile.skills) ||
+      profile.skills.length > 16 ||
+      new Set(profile.skills).size !== profile.skills.length ||
+      profile.skills.some((skill) => !token.test(skill)) ||
+      profile.instructions.trim() !== profile.instructions ||
+      profile.instructions.length < 1 ||
+      profile.instructions.length > 4_096
+    )
+      throw new TypeError("invalid agent profile");
   }
 
   #readTeam(id: string): TeamRecord {

--- a/packages/team-control/src/supervisor.ts
+++ b/packages/team-control/src/supervisor.ts
@@ -33,6 +33,7 @@ export class TeamSupervisor {
   readonly #codex: string;
   readonly #copilot: string;
   readonly #workspace: string;
+  readonly #profileEnvironment: Readonly<Record<string, string>>;
 
   constructor(options: {
     readonly node: string;
@@ -43,6 +44,7 @@ export class TeamSupervisor {
     readonly codex: string;
     readonly copilot: string;
     readonly workspace: string;
+    readonly profileEnvironment?: Readonly<Record<string, string>>;
   }) {
     this.#node = executable(options.node);
     this.#worker = file(options.worker);
@@ -52,6 +54,7 @@ export class TeamSupervisor {
     this.#codex = executable(options.codex);
     this.#copilot = executable(options.copilot);
     this.#workspace = realpathSync(options.workspace);
+    this.#profileEnvironment = options.profileEnvironment ?? {};
     if (!lstatSync(this.#workspace).isDirectory()) throw new TypeError("invalid team workspace");
   }
 
@@ -79,6 +82,7 @@ export class TeamSupervisor {
         YUKH_TEAM_CONTROL_MCP_MAIN: this.#teamControlMcp,
         YUKH_CODEX_EXECUTABLE: this.#codex,
         YUKH_COPILOT_EXECUTABLE: this.#copilot,
+        ...this.#profileEnvironment,
       },
     });
     closeSync(output);

--- a/test/runtime/conversation-watch.test.ts
+++ b/test/runtime/conversation-watch.test.ts
@@ -78,7 +78,7 @@ test("watch explains team and worker activity in work-oriented language", () => 
     ],
     new Map(),
   );
-  assert.match(changes.join("\n"), /manager=codex goal=Build a task board/u);
+  assert.match(changes.join("\n"), /manager=manager runtime=codex goal=Build a task board/u);
   assert.match(changes.join("\n"), /WORKER  backend-lead  RUNNING/u);
   assert.match(changes.join("\n"), /task=Define and implement the API/u);
 });

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -7,9 +7,28 @@ import { fileURLToPath } from "node:url";
 import test from "node:test";
 import { TeamStore } from "../../packages/team-control/src/store.js";
 import { TeamSupervisor } from "../../packages/team-control/src/supervisor.js";
+import { assertProfileAvailable } from "../../apps/team-control/src/server.js";
 
 const workerMain = fileURLToPath(new URL("../../apps/team-worker/src/main.ts", import.meta.url));
 const tsxLoader = fileURLToPath(import.meta.resolve("tsx"));
+
+test("composed profiles require allowlisted runtime models and skills", () => {
+  const options = {
+    models: { codex: new Set(["deep-model"]), copilot: new Set(["fast-model"]) },
+    skills: { codex: new Set(["api-design", "testing"]), copilot: new Set(["frontend"]) },
+  };
+  assert.doesNotThrow(() =>
+    assertProfileAvailable(options, "codex", "deep-model", ["api-design", "testing"]),
+  );
+  assert.throws(
+    () => assertProfileAvailable(options, "codex", "fast-model", []),
+    /agent_model_unavailable/u,
+  );
+  assert.throws(
+    () => assertProfileAvailable(options, "copilot", "fast-model", ["api-design"]),
+    /agent_skill_unavailable/u,
+  );
+});
 
 test("team store creates dynamic workers and bounded delegated children", async () => {
   const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-team-control-")));
@@ -19,6 +38,13 @@ test("team store creates dynamic workers and bounded delegated children", async 
     const backend = store.spawn(team.team_id, {
       runtime: "codex",
       role: "backend-developer",
+      profile: {
+        schema: 1,
+        mission: "Own the backend delivery",
+        model: "reasoning-model",
+        skills: ["api-design", "testing"],
+        instructions: "Inspect, implement, test and communicate the API contract.",
+      },
       task: "Implement the API",
       can_spawn: true,
     });
@@ -29,6 +55,7 @@ test("team store creates dynamic workers and bounded delegated children", async 
       task: "Test the API",
     });
     assert.equal(testWorker.parent_agent_id, backend.agent_id);
+    assert.deepEqual(backend.profile?.skills, ["api-design", "testing"]);
     assert.equal(testWorker.depth, 2);
     assert.notEqual(testWorker.coordination_agent, backend.coordination_agent);
     assert.equal(store.status(team.team_id).agents.length, 2);
@@ -138,8 +165,14 @@ test("stopping a team makes its wrapper terminate the owned agent CLI", async ()
   const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-team-stop-")));
   try {
     const executable = join(root, "agent-cli");
+    const launcher = join(root, "launcher");
     const support = join(root, "support.mjs");
     await writeFile(executable, "#!/bin/sh\nsleep 30\n", { mode: 0o700 });
+    await writeFile(
+      launcher,
+      '#!/bin/sh\ncat >/dev/null\nprintf \'{"schema":1,"status":"ok","command":"test"}\\n\'\n',
+      { mode: 0o700 },
+    );
     await writeFile(support, "", { mode: 0o600 });
     const store = new TeamStore(root);
     const team = store.create("Stop worker", "codex");
@@ -158,7 +191,7 @@ test("stopping a team makes its wrapper terminate the owned agent CLI", async ()
           HOME: process.env.HOME ?? "",
           PATH: process.env.PATH ?? "/usr/bin:/bin",
           YUKH_TEAM_WORKSPACE: root,
-          YUKH_COORDINATION_LAUNCHER: executable,
+          YUKH_COORDINATION_LAUNCHER: launcher,
           YUKH_COORDINATION_MCP_MAIN: support,
           YUKH_TEAM_CONTROL_MCP_MAIN: support,
           YUKH_CODEX_EXECUTABLE: executable,
@@ -175,6 +208,53 @@ test("stopping a team makes its wrapper terminate the owned agent CLI", async ()
     const exitCode = await new Promise<number | null>((resolve) => child.once("close", resolve));
     assert.equal(exitCode, 0);
     assert.equal(store.agent(team.team_id, agent.agent_id).state, "stopped");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("worker fails closed before agent launch when Coordination cannot join", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-team-coordination-deny-")));
+  try {
+    const marker = join(root, "agent-started");
+    const executable = join(root, "agent-cli");
+    const launcher = join(root, "launcher");
+    const support = join(root, "support.mjs");
+    await writeFile(executable, `#!/bin/sh\ntouch ${marker}\n`, { mode: 0o700 });
+    await writeFile(
+      launcher,
+      '#!/bin/sh\ncat >/dev/null\nprintf \'{"schema":1,"status":"error","code":"YKC-AUTH-001"}\\n\'\n',
+      { mode: 0o700 },
+    );
+    await writeFile(support, "", { mode: 0o600 });
+    const store = new TeamStore(root);
+    const team = store.create("Require Coordination", "codex");
+    const agent = store.spawn(team.team_id, {
+      runtime: "codex",
+      role: "delivery-lead",
+      task: "Do not start without Coordination",
+    });
+    const child = spawn(
+      process.execPath,
+      ["--import", tsxLoader, workerMain, team.team_id, agent.agent_id],
+      {
+        cwd: root,
+        stdio: "ignore",
+        env: {
+          HOME: process.env.HOME ?? "",
+          PATH: process.env.PATH ?? "/usr/bin:/bin",
+          YUKH_TEAM_WORKSPACE: root,
+          YUKH_COORDINATION_LAUNCHER: launcher,
+          YUKH_COORDINATION_MCP_MAIN: support,
+          YUKH_TEAM_CONTROL_MCP_MAIN: support,
+          YUKH_CODEX_EXECUTABLE: executable,
+          YUKH_COPILOT_EXECUTABLE: executable,
+        },
+      },
+    );
+    assert.equal(await new Promise<number | null>((resolve) => child.once("close", resolve)), 1);
+    assert.equal(store.agent(team.team_id, agent.agent_id).state, "failed");
+    await assert.rejects(readFile(marker), /ENOENT/u);
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #131. Implements manager-composed agent.engage profiles with explicit manager role/mission, runtime model and skill allowlists, persisted mission/model/skills/instructions, model injection into Codex/Copilot, viewer rendering, and fail-closed Coordination bootstrap/join before the agent CLI starts. Includes denial tests for unknown model/skill and a real child-process test proving the agent is not launched when Coordination fails.