### PR TITLE
Retry transient dynamic Coordination bootstrap

### DIFF
--- a/apps/team-worker/src/main.ts
+++ b/apps/team-worker/src/main.ts
@@ -94,8 +94,16 @@ const args =
         })}`,
       ];
 
-async function coordination(commandArgs: readonly string[], input?: object): Promise<boolean> {
-  return await new Promise<boolean>((resolve) => {
+interface CoordinationAttempt {
+  readonly ok: boolean;
+  readonly code?: string;
+}
+
+async function coordination(
+  commandArgs: readonly string[],
+  input?: object,
+): Promise<CoordinationAttempt> {
+  return await new Promise<CoordinationAttempt>((resolve) => {
     const child = spawn(launcher, [agent.coordination_agent, ...commandArgs], {
       cwd: workspace,
       shell: false,
@@ -109,30 +117,42 @@ async function coordination(commandArgs: readonly string[], input?: object): Pro
     const timer = setTimeout(() => child.kill("SIGKILL"), 10_000);
     child.once("error", () => {
       clearTimeout(timer);
-      resolve(false);
+      resolve({ ok: false });
     });
     child.once("close", (code) => {
       clearTimeout(timer);
       try {
         const output = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
           status?: unknown;
+          code?: unknown;
         };
-        resolve(code === 0 && output.status === "ok");
+        resolve({
+          ok: code === 0 && output.status === "ok",
+          ...(typeof output.code === "string" ? { code: output.code } : {}),
+        });
       } catch {
-        resolve(false);
+        resolve({ ok: false });
       }
     });
   });
 }
 
-const bootstrapped = await coordination(["session", "bootstrap"]);
+let bootstrap: CoordinationAttempt = { ok: false };
+for (let attempt = 1; attempt <= 3; attempt++) {
+  bootstrap = await coordination(["session", "bootstrap"]);
+  if (bootstrap.ok || bootstrap.code !== "YKC-UNAVAILABLE-001") break;
+  process.stderr.write(`yukh-team-worker: coordination bootstrap unavailable attempt=${attempt}\n`);
+  await new Promise((resolve) => setTimeout(resolve, 250 * attempt));
+}
 const joined =
-  bootstrapped &&
-  (await coordination(["session", "join"], {
-    capabilities: ["publish", "replay"],
-    session_label: agent.role,
-    status: "available",
-  }));
+  bootstrap.ok &&
+  (
+    await coordination(["session", "join"], {
+      capabilities: ["publish", "replay"],
+      session_label: agent.role,
+      status: "available",
+    })
+  ).ok;
 if (!joined) {
   process.stderr.write("yukh-team-worker: coordination bootstrap or join failed\n");
   store.transition(teamID, agentID, "failed");

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -259,3 +259,63 @@ test("worker fails closed before agent launch when Coordination cannot join", as
     await rm(root, { recursive: true, force: true });
   }
 });
+
+test("worker retries bounded transient Coordination unavailability before launch", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-team-coordination-retry-")));
+  try {
+    const marker = join(root, "agent-started");
+    const counter = join(root, "attempts");
+    const executable = join(root, "agent-cli");
+    const launcher = join(root, "launcher");
+    const support = join(root, "support.mjs");
+    await writeFile(executable, `#!/bin/sh\ntouch ${marker}\n`, { mode: 0o700 });
+    await writeFile(
+      launcher,
+      `#!/bin/sh
+cat >/dev/null
+count=0
+test ! -f ${counter} || count="$(cat ${counter})"
+count=$((count + 1))
+printf '%s' "$count" >${counter}
+if test "$count" -lt 3; then
+  printf '{"schema":1,"status":"error","code":"YKC-UNAVAILABLE-001"}\\n'
+  exit 7
+fi
+printf '{"schema":1,"status":"ok","command":"test"}\\n'
+`,
+      { mode: 0o700 },
+    );
+    await writeFile(support, "", { mode: 0o600 });
+    const store = new TeamStore(root);
+    const team = store.create("Retry Coordination", "codex");
+    const agent = store.spawn(team.team_id, {
+      runtime: "codex",
+      role: "delivery-lead",
+      task: "Start after Coordination recovers",
+    });
+    const child = spawn(
+      process.execPath,
+      ["--import", tsxLoader, workerMain, team.team_id, agent.agent_id],
+      {
+        cwd: root,
+        stdio: "ignore",
+        env: {
+          HOME: process.env.HOME ?? "",
+          PATH: process.env.PATH ?? "/usr/bin:/bin",
+          YUKH_TEAM_WORKSPACE: root,
+          YUKH_COORDINATION_LAUNCHER: launcher,
+          YUKH_COORDINATION_MCP_MAIN: support,
+          YUKH_TEAM_CONTROL_MCP_MAIN: support,
+          YUKH_CODEX_EXECUTABLE: executable,
+          YUKH_COPILOT_EXECUTABLE: executable,
+        },
+      },
+    );
+    assert.equal(await new Promise<number | null>((resolve) => child.once("close", resolve)), 0);
+    assert.equal(await readFile(counter, "utf8"), "4");
+    assert.equal(store.agent(team.team_id, agent.agent_id).state, "completed");
+    assert.equal((await readFile(marker)).length, 0);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #135. Retries only transient YKC-UNAVAILABLE-001 bootstrap failures three times with bounded backoff. Authentication errors and exhausted retries remain fail-closed before agent CLI launch. Adds real child-process tests for recovery and denial.