### PR TITLE
Budget root managers and require team action receipts

### DIFF
--- a/.context/rfcs/RFC-0021-budgeted-root-manager-and-action-receipts.md
+++ b/.context/rfcs/RFC-0021-budgeted-root-manager-and-action-receipts.md
@@ -1,0 +1,65 @@
+# RFC-0021 — Budgeted root manager and action receipts
+
+- Status: Accepted
+- Authors: Nomed with Codex implementation support
+- Created: 2026-08-16
+- Accepted: 2026-08-16
+- Decider: project owner
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/139
+- Supersedes the external-manager portion of: RFC-0020
+
+## Decision
+
+A model session outside Yukh cannot be the authoritative team manager because
+its runtime usage and tool actions are not enforceable team evidence. The
+public `manager.start` operation creates a team, reserves a root manager budget
+and then launches that manager through the same accounted wrapper as
+workers. The root manager is persistent agent state at depth zero. Its token
+allocation consumes the team budget before any worker allocation.
+
+The older `team.create` operation remains available only for readable legacy
+logical-team state. An unaccounted external caller cannot use `agent.engage` or
+`agent.spawn`; both fail with `manager_runtime_required`. Existing stored teams
+remain readable and stoppable.
+
+## Action evidence
+
+`manager.start` accepts a closed set of required actions: `team.status`,
+`agent.engage` and `agent.await`. Successful tool execution emits a bounded,
+server-authored receipt containing only opaque team, actor, subject and receipt
+identifiers, the action and its successful outcome. Free text, prompts, model
+reasoning, tool input and tool output are excluded.
+
+The wrapper checks persistent receipts before releasing a successful manager
+completion. A plausible final response without every required receipt becomes
+`required_action_missing`. The store independently rejects a forged successful
+completion with missing receipts. At most 256 receipts are retained per team.
+
+## Accounting and limits
+
+Manager and worker usage use the same exact runtime evidence from RFC-0020.
+Status and the observer expose total, input, cached-input, output and
+reasoning-output counts. Cached input remains part of input and is never hidden
+from total context consumption. Runtime reporting is still post-turn; the
+declared budget does not claim preemptive mid-turn interruption.
+
+Prompts instruct managers to keep inspection and tool output bounded, but this
+is not a security control. A manager overrun is persisted and fails exactly as
+a worker overrun. No child starts unless its manager is a registered caller and
+the aggregate reservation, model and skill checks succeed.
+
+## Qualification
+
+- reserve manager tokens before allowing worker allocation;
+- reject manager allocation above the team budget;
+- deny external unaccounted engagement;
+- reject successful completion when a required receipt is absent;
+- persist successful action receipts and show them in team status and observer;
+- show exact token categories without double-counting cached input;
+- qualify `manager.start` through the MCP transport before a real model retry.
+
+## Rollback
+
+Disable `manager.start` and all worker engagement. Preserve team, manager,
+usage, completion and receipt records for inspection. Restoring unaccounted
+external managers or accepting textual action claims is forbidden.

--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -74,7 +74,86 @@ export function createTeamControlServer(
     {
       capabilities: { tools: { listChanged: false } },
       instructions:
-        "Create bounded local teams with explicit token budgets. The team already exists for delegated workers: they must not call team.create. Engage children with smaller budgets, use returned coordination_participant identifiers exactly, wait with agent.await, and consume every successful completion before synthesis. Team state is persistent; creating a team does not start workers.",
+        "Start a budgeted root manager with manager.start. Direct team.create is a legacy logical-team operation and cannot engage workers from an unaccounted external manager. A launched manager or delegated worker uses returned identifiers exactly, waits with agent.await, and must satisfy every declared required action with server-issued receipts before successful completion.",
+    },
+  );
+
+  server.registerTool(
+    "manager.start",
+    {
+      title: "Start a budgeted root team manager",
+      description: "Create a team, reserve the manager budget, then start its accounted runtime",
+      inputSchema: z
+        .object({
+          goal: z.string().min(1).max(4_096),
+          runtime: z.enum(["codex", "copilot"]),
+          role: z
+            .string()
+            .regex(/^[a-z][a-z0-9-]{0,31}$/u)
+            .default("delivery-manager"),
+          mission: z.string().min(1).max(1_024),
+          model: z.string().regex(/^[a-z0-9][a-z0-9._:-]{0,63}$/u),
+          skills: z.array(z.string().regex(/^[a-z0-9][a-z0-9._:-]{0,63}$/u)).max(16),
+          instructions: z.string().min(1).max(4_096),
+          task: z.string().min(1).max(4_096),
+          required_actions: z
+            .array(z.enum(["team.status", "agent.engage", "agent.await"]))
+            .max(3)
+            .default([]),
+          max_agents: z.number().int().min(1).max(32).default(16),
+          max_depth: z.number().int().min(1).max(5).default(3),
+          team_token_budget: z.number().int().min(1_000).max(10_000_000),
+          manager_token_budget: z.number().int().min(1_000).max(2_000_000),
+        })
+        .strict(),
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+    },
+    (input) => {
+      if (options.caller) throw new Error("agent_delegation_denied");
+      let managed: ReturnType<TeamStore["createManaged"]> | undefined;
+      try {
+        assertProfileAvailable(options, input.runtime, input.model, input.skills);
+        managed = store.createManaged(
+          input.goal,
+          input.runtime,
+          input.max_agents,
+          input.max_depth,
+          input.team_token_budget,
+          {
+            role: input.role,
+            profile: {
+              schema: 1,
+              mission: input.mission,
+              model: input.model,
+              skills: input.skills,
+              instructions: input.instructions,
+            },
+            task: input.task,
+            token_budget: input.manager_token_budget,
+            required_actions: input.required_actions,
+          },
+        );
+        const runtime = supervisor.launch(managed.manager);
+        const receipt = store.receipt(
+          managed.team.team_id,
+          "manager.start",
+          undefined,
+          managed.manager.agent_id,
+        );
+        return result({ ...managed, receipt, runtime });
+      } catch (error) {
+        if (managed) {
+          try {
+            store.transition(managed.team.team_id, managed.manager.agent_id, "failed");
+            store.stop(managed.team.team_id);
+          } catch {}
+        }
+        return stableFailure(
+          error,
+          new Set(["agent_model_unavailable", "agent_skill_unavailable", "agent_spawn_failed"]),
+          "manager_start_failed",
+        );
+      }
     },
   );
 
@@ -128,7 +207,10 @@ export function createTeamControlServer(
     },
     ({ team_id }) => {
       authorizeTeam(team_id);
-      return result(store.status(team_id));
+      const status = store.status(team_id);
+      if (options.caller)
+        store.receipt(team_id, "team.status", options.caller.agent_id, options.caller.agent_id);
+      return result(status);
     },
   );
 
@@ -159,6 +241,7 @@ export function createTeamControlServer(
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
     },
     (input) => {
+      if (!options.caller) return failure("manager_runtime_required");
       try {
         assertProfileAvailable(options, input.runtime, input.model, input.skills);
       } catch (error) {
@@ -196,7 +279,13 @@ export function createTeamControlServer(
           token_budget: input.token_budget,
         });
         const runtime = supervisor.launch(agent);
-        return result({ agent, ...runtime });
+        const receipt = store.receipt(
+          input.team_id,
+          "agent.engage",
+          options.caller.agent_id,
+          agent.agent_id,
+        );
+        return result({ agent, receipt, ...runtime });
       } catch (error) {
         return stableFailure(
           error,
@@ -238,6 +327,7 @@ export function createTeamControlServer(
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
     },
     (input) => {
+      if (!options.caller) return failure("manager_runtime_required");
       if (
         options.caller &&
         (input.team_id !== options.caller.team_id ||
@@ -296,7 +386,11 @@ export function createTeamControlServer(
     async ({ team_id, agent_id, timeout_ms }) => {
       authorizeTeam(team_id);
       const agent = await awaitAgent(store, team_id, agent_id, timeout_ms);
-      return agent ? result(agent) : failure("agent_wait_timeout");
+      if (!agent) return failure("agent_wait_timeout");
+      const receipt = options.caller
+        ? store.receipt(team_id, "agent.await", options.caller.agent_id, agent_id)
+        : undefined;
+      return result({ agent, ...(receipt ? { receipt } : {}) });
     },
   );
 

--- a/apps/team-worker/src/main.ts
+++ b/apps/team-worker/src/main.ts
@@ -25,7 +25,8 @@ const mcpEnv = {
   YUKH_COORDINATION_LAUNCHER: launcher,
 };
 const profile = agent.profile;
-const prompt = `You are ${agent.role}, worker ${agent.agent_id} in team ${agent.team_id}.${profile ? ` Mission: ${profile.mission}\nOperating instructions: ${profile.instructions}\nRequired skills: ${profile.skills.length > 0 ? profile.skills.join(", ") : "none"}.` : ""}\nComplete this task: ${agent.task}\nToken budget: ${agent.token_budget} total input plus output tokens. Keep inspection and tool output bounded. The team already exists: do not call team.create. When engaging a child, use the returned coordination_participant exactly and never add another agent: prefix. Wait for each child with agent.await and inspect its completion before synthesizing. Your Coordination session is already bootstrapped and joined. Use yukh-coordination to replay messages and communicate decisions and blockers. End with one concise public-safe completion summary of at most 4096 UTF-8 bytes; the wrapper persists that final response for the manager. You may create a bounded child only when explicitly delegated.`;
+const requiredActions = agent.required_actions.join(", ") || "none";
+const prompt = `You are ${agent.role}, ${agent.kind} ${agent.agent_id} in team ${agent.team_id}.${profile ? ` Mission: ${profile.mission}\nOperating instructions: ${profile.instructions}\nRequired skills: ${profile.skills.length > 0 ? profile.skills.join(", ") : "none"}.` : ""}\nComplete this task: ${agent.task}\nToken budget: ${agent.token_budget} total input plus output tokens. Keep inspection and tool output bounded. The team already exists: do not call team.create. Required receipt-backed actions before success: ${requiredActions}. A textual claim is not evidence; invoke each required yukh-team-control tool successfully. When engaging a child, use the returned coordination_participant exactly and never add another agent: prefix. Wait for each child with agent.await and inspect its completion before synthesizing. Your Coordination session is already bootstrapped and joined. Use yukh-coordination to replay messages and communicate decisions and blockers. End with one concise public-safe completion summary of at most 4096 UTF-8 bytes; the wrapper persists that final response. You may create a bounded child only when explicitly delegated.`;
 const teamControlEnv = {
   YUKH_TEAM_WORKSPACE: workspace,
   YUKH_COORDINATION_LAUNCHER: launcher,
@@ -209,6 +210,7 @@ if (joined && "output" in outcome) {
   } else {
     const summary = outcome.output.summary();
     const usage = outcome.output.usage(agent.token_budget);
+    const missingActions = store.missingRequiredActions(teamID, agentID);
     const completion =
       outcome.exitCode !== 0
         ? { schema: 1 as const, outcome: "agent_exit_nonzero" as const, summary }
@@ -216,9 +218,15 @@ if (joined && "output" in outcome) {
           ? { schema: 1 as const, outcome: "token_accounting_unavailable" as const, summary }
           : usage.budget_outcome === "exceeded"
             ? { schema: 1 as const, outcome: "token_budget_exceeded" as const, summary }
-            : !summary
-              ? { schema: 1 as const, outcome: "completion_missing" as const, summary: "" }
-              : { schema: 1 as const, outcome: "succeeded" as const, summary };
+            : missingActions.length > 0
+              ? {
+                  schema: 1 as const,
+                  outcome: "required_action_missing" as const,
+                  summary: `Missing required action receipts: ${missingActions.join(", ")}`,
+                }
+              : !summary
+                ? { schema: 1 as const, outcome: "completion_missing" as const, summary: "" }
+                : { schema: 1 as const, outcome: "succeeded" as const, summary };
     store.finish(teamID, agentID, completion, usage);
     if (completion.outcome !== "succeeded") wrapperExitCode = 1;
   }

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -58,7 +58,7 @@ paths to the project workspace, Coordination launcher and both agent CLIs:
 command = "node"
 args = ["/path/to/yukh-mcp/dist/apps/team-control/src/main.js"]
 env = { YUKH_TEAM_WORKSPACE = "/path/to/project", YUKH_COORDINATION_LAUNCHER = "/path/to/yukh-local-agent.py", YUKH_CODEX_EXECUTABLE = "/absolute/path/to/codex", YUKH_COPILOT_EXECUTABLE = "/absolute/path/to/copilot" }
-enabled_tools = ["team.create", "team.status", "agent.engage", "agent.await", "agent.status", "task.assign", "team.stop"]
+enabled_tools = ["manager.start", "team.status", "agent.await", "agent.status", "team.stop"]
 default_tools_approval_mode = "writes"
 ```
 
@@ -68,13 +68,18 @@ Add comma-separated local allowlists when using composed profiles:
 env = { YUKH_CODEX_MODELS = "default,approved-codex-model", YUKH_COPILOT_MODELS = "default,approved-copilot-model", YUKH_CODEX_SKILLS = "api-design,testing,review", YUKH_COPILOT_SKILLS = "frontend,testing,product" }
 ```
 
-The manager uses `agent.engage` to compose any bounded professional role. Model
+Start work with `manager.start`, not `team.create`. It creates the team and a
+depth-zero manager runtime together, reserves the manager budget and returns a
+server receipt plus the manager agent ID. Use `agent.await` from the controlling
+session to retrieve its terminal completion. The manager uses `agent.engage`
+from inside its accounted runtime to compose bounded professional roles. Model
 and skill values outside these allowlists fail before process launch. The
 worker must bootstrap and join Coordination before its agent CLI starts. Set an
-explicit team `token_budget` in `team.create` and a smaller `token_budget` for
-every `agent.engage`. Allocations above the team budget are rejected.
-Teams created by an older preview remain readable with budget zero but cannot
-engage more workers; stop and recreate them with an explicit budget.
+explicit `team_token_budget` and `manager_token_budget` in `manager.start`, then
+a smaller `token_budget` for every `agent.engage`. Manager and worker
+allocations above the team budget are rejected. Teams created by an older
+preview remain readable but an external unaccounted session cannot engage
+workers. Stop and recreate them with `manager.start`.
 
 After engaging a child, use the returned `coordination_participant` exactly and
 call `agent.await`. A successful terminal record contains the child's bounded
@@ -88,10 +93,12 @@ For Copilot, use the equivalent MCP server values in `copilot mcp add`. Then ask
 the manager:
 
 ```text
-Use yukh-team-control. Create a 120000-token team for this workspace. Engage one
-Codex backend developer with a 50000-token budget. Wait for its completion,
-inspect its summary and usage, then report the result. Do not engage a runtime
-that cannot provide token accounting.
+Use yukh-team-control. Call manager.start with a 120000-token team budget and a
+30000-token Codex manager budget. Require agent.engage and agent.await receipts.
+Ask the manager to engage one Codex backend developer with a 50000-token budget,
+wait for its completion, inspect its summary and usage, then report the result.
+Do not use team.create and do not engage a runtime that cannot provide token
+accounting.
 ```
 
 `agent.spawn` starts a real detached CLI and returns its PID and log path. A

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -230,6 +230,25 @@ tools, repository content and transcript are all trusted for this session;
 agent-authored changes require operator review. Compact rendering is a display
 policy only and does not alter the verified transcript.
 
+## Accepted budgeted root manager and action receipts — 2026-08-16
+
+- Governing issue: #139
+- Accepted architecture: RFC-0021
+- Scope: local root-manager launch, token reservation and receipt-backed team actions
+
+An external model session is not trusted to report its own token use or prove
+that it invoked a required tool. `manager.start` creates the team and an
+accounted depth-zero manager together; its budget is reserved before child
+allocation. Unaccounted external callers cannot engage or spawn workers.
+
+Successful `team.status`, `agent.engage` and `agent.await` calls produce closed
+server-authored receipts. A manager completion without every declared receipt
+fails as `required_action_missing`; prose is not accepted as action evidence.
+Receipts exclude prompts, reasoning and tool payloads and are capped per team.
+The observer exposes exact runtime token categories. Residual risk remains
+post-turn budget detection because the agent CLI does not provide a trusted
+preemptive token-control boundary.
+
 ## Capability contract implementation review — 2026-08-03
 
 - Governing issue: #5

--- a/packages/conversation-watch/src/watch.ts
+++ b/packages/conversation-watch/src/watch.ts
@@ -1,5 +1,5 @@
 import type { CoordinationOutput } from "../../coordination-preview/src/launcher.js";
-import type { AgentRecord, TeamRecord } from "../../team-control/src/store.js";
+import type { AgentRecord, TeamActionReceipt, TeamRecord } from "../../team-control/src/store.js";
 
 export interface WatchRecord {
   readonly sequence: number;
@@ -25,6 +25,7 @@ export interface LifecycleRecord {
 export interface TeamSnapshot {
   readonly team: TeamRecord;
   readonly agents: readonly AgentRecord[];
+  readonly receipts: readonly TeamActionReceipt[];
   readonly tokens: {
     readonly budget: number;
     readonly allocated: number;
@@ -157,11 +158,11 @@ export function renderTeamChanges(
   const lines: string[] = [];
   for (const snapshot of snapshots) {
     const teamKey = `team:${snapshot.team.team_id}`;
-    const teamValue = `${snapshot.team.state}:${snapshot.agents.length}:${snapshot.tokens.allocated}:${snapshot.tokens.observed}:${snapshot.tokens.pending_agents}:${snapshot.tokens.unaccounted_agents}:${snapshot.tokens.exceeded_agents}`;
+    const teamValue = `${snapshot.team.state}:${snapshot.agents.length}:${snapshot.receipts.length}:${snapshot.tokens.allocated}:${snapshot.tokens.observed}:${snapshot.tokens.pending_agents}:${snapshot.tokens.unaccounted_agents}:${snapshot.tokens.exceeded_agents}`;
     if (previous.get(teamKey) !== teamValue) {
       previous.set(teamKey, teamValue);
       lines.push(
-        `TEAM  ${snapshot.team.team_id}  ${snapshot.team.state.toUpperCase()}  agents=${snapshot.agents.length}\n      manager=${snapshot.team.manager_role ?? "manager"} runtime=${snapshot.team.manager_runtime} goal=${compact(snapshot.team.goal, 160)}${snapshot.team.manager_mission ? `\n      mission=${compact(snapshot.team.manager_mission, 160)}` : ""}\n      tokens=${snapshot.tokens.observed}/${snapshot.tokens.budget} allocated=${snapshot.tokens.allocated} pending=${snapshot.tokens.pending_agents} unaccounted=${snapshot.tokens.unaccounted_agents} exceeded=${snapshot.tokens.exceeded_agents}`,
+        `TEAM  ${snapshot.team.team_id}  ${snapshot.team.state.toUpperCase()}  agents=${snapshot.agents.length}\n      manager=${snapshot.team.manager_role ?? "manager"} runtime=${snapshot.team.manager_runtime} goal=${compact(snapshot.team.goal, 160)}${snapshot.team.manager_mission ? `\n      mission=${compact(snapshot.team.manager_mission, 160)}` : ""}\n      tokens=${snapshot.tokens.observed}/${snapshot.tokens.budget} allocated=${snapshot.tokens.allocated} pending=${snapshot.tokens.pending_agents} unaccounted=${snapshot.tokens.unaccounted_agents} exceeded=${snapshot.tokens.exceeded_agents} receipts=${snapshot.receipts.length}`,
       );
     }
     for (const agent of snapshot.agents) {
@@ -170,7 +171,12 @@ export function renderTeamChanges(
       if (previous.get(key) === value) continue;
       previous.set(key, value);
       lines.push(
-        `WORKER  ${agent.role}  ${agent.state.toUpperCase()}  runtime=${agent.runtime}${agent.profile ? ` model=${agent.profile.model}` : ""}\n        task=${compact(agent.task, 180)}${agent.profile ? `\n        mission=${compact(agent.profile.mission, 160)} skills=${agent.profile.skills.join(",") || "none"}` : ""}\n        tokens=${agent.usage?.total_tokens ?? "pending"}/${agent.token_budget} accounting=${agent.usage?.source ?? "pending"} completion=${agent.completion?.outcome ?? "pending"}\n        coordination=${agent.coordination_participant} id=${agent.agent_id} parent=${agent.parent_agent_id ?? "manager"}`,
+        `${agent.kind === "manager" ? "MANAGER" : "WORKER"}  ${agent.role}  ${agent.state.toUpperCase()}  runtime=${agent.runtime}${agent.profile ? ` model=${agent.profile.model}` : ""}\n        task=${compact(agent.task, 180)}${agent.profile ? `\n        mission=${compact(agent.profile.mission, 160)} skills=${agent.profile.skills.join(",") || "none"}` : ""}\n        tokens=${agent.usage?.total_tokens ?? "pending"}/${agent.token_budget} input=${agent.usage?.input_tokens ?? "pending"} cached=${agent.usage?.cached_input_tokens ?? "pending"} output=${agent.usage?.output_tokens ?? "pending"} reasoning=${agent.usage?.reasoning_output_tokens ?? "pending"} accounting=${agent.usage?.source ?? "pending"} completion=${agent.completion?.outcome ?? "pending"}\n        required=${agent.required_actions.join(",") || "none"} receipts=${
+          snapshot.receipts
+            .filter((receipt) => receipt.actor_agent_id === agent.agent_id)
+            .map((receipt) => receipt.action)
+            .join(",") || "none"
+        }\n        coordination=${agent.coordination_participant} id=${agent.agent_id} parent=${agent.parent_agent_id ?? (agent.kind === "manager" ? "root" : "manager")}`,
       );
     }
   }

--- a/packages/team-control/src/store.ts
+++ b/packages/team-control/src/store.ts
@@ -11,6 +11,7 @@ import { randomUUID } from "node:crypto";
 import { isAbsolute, join } from "node:path";
 
 export type AgentRuntime = "codex" | "copilot";
+export type AgentKind = "manager" | "worker";
 export type TeamState = "active" | "stopped";
 export type AgentState = "defined" | "running" | "completed" | "failed" | "stopped";
 
@@ -31,6 +32,7 @@ export interface AgentCompletion {
     | "succeeded"
     | "agent_exit_nonzero"
     | "completion_missing"
+    | "required_action_missing"
     | "token_accounting_unavailable"
     | "token_budget_exceeded";
   readonly summary: string;
@@ -61,6 +63,7 @@ export interface TeamRecord {
 export interface AgentRecord {
   readonly schema: 1;
   readonly agent_id: string;
+  readonly kind: AgentKind;
   readonly coordination_agent: `agent-${string}`;
   readonly coordination_participant: `agent:${string}`;
   readonly team_id: string;
@@ -72,9 +75,22 @@ export interface AgentRecord {
   readonly depth: number;
   readonly can_spawn: boolean;
   readonly token_budget: number;
+  readonly required_actions: readonly TeamAction[];
   readonly usage?: AgentUsage;
   readonly completion?: AgentCompletion;
   readonly state: AgentState;
+}
+
+export type TeamAction = "manager.start" | "team.status" | "agent.engage" | "agent.await";
+
+export interface TeamActionReceipt {
+  readonly schema: 1;
+  readonly receipt_id: string;
+  readonly team_id: string;
+  readonly action: TeamAction;
+  readonly actor_agent_id?: string;
+  readonly subject_agent_id?: string;
+  readonly outcome: "succeeded";
 }
 
 const teamID = /^team-[0-9a-f-]{36}$/u;
@@ -149,6 +165,67 @@ export class TeamStore {
     return record;
   }
 
+  createManaged(
+    goal: string,
+    managerRuntime: AgentRuntime,
+    maxAgents: number,
+    maxDepth: number,
+    tokenBudget: number,
+    manager: {
+      readonly role: string;
+      readonly profile: ComposedAgentProfile;
+      readonly task: string;
+      readonly token_budget: number;
+      readonly required_actions: readonly TeamAction[];
+    },
+  ): {
+    readonly team: TeamRecord;
+    readonly manager: AgentRecord;
+  } {
+    if (
+      !Number.isSafeInteger(manager.token_budget) ||
+      manager.token_budget < 1_000 ||
+      manager.token_budget > 2_000_000 ||
+      manager.token_budget > tokenBudget ||
+      manager.required_actions.length > 3 ||
+      new Set(manager.required_actions).size !== manager.required_actions.length ||
+      manager.required_actions.some(
+        (action) => !["team.status", "agent.engage", "agent.await"].includes(action),
+      )
+    )
+      throw new TypeError("invalid manager definition");
+    this.#validateProfile(manager.profile);
+    const team = this.create(goal, managerRuntime, maxAgents, maxDepth, tokenBudget, {
+      role: manager.role,
+      mission: manager.profile.mission,
+    });
+    const suffix = randomUUID().replaceAll("-", "").slice(0, 8);
+    const coordination = `agent-${manager.role.slice(0, 32)}-${suffix}` as const;
+    const record: AgentRecord = {
+      schema: 1,
+      agent_id: `worker-${randomUUID()}`,
+      kind: "manager",
+      coordination_agent: coordination,
+      coordination_participant: `agent:${coordination.slice("agent-".length)}`,
+      team_id: team.team_id,
+      runtime: managerRuntime,
+      role: manager.role,
+      profile: manager.profile,
+      task: manager.task,
+      depth: 0,
+      can_spawn: true,
+      token_budget: manager.token_budget,
+      required_actions: manager.required_actions,
+      state: "defined",
+    };
+    this.#write(
+      join(this.#teamDirectory(team.team_id), "agents", `${record.agent_id}.json`),
+      record,
+      true,
+    );
+    return { team, manager: record };
+  }
+
   spawn(
     id: string,
     input: {
@@ -197,6 +274,7 @@ export class TeamStore {
     const record: AgentRecord = {
       schema: 1,
       agent_id: `worker-${randomUUID()}`,
+      kind: "worker",
       coordination_agent: coordination,
       coordination_participant: `agent:${coordination.slice("agent-".length)}`,
       team_id: id,
@@ -208,6 +286,7 @@ export class TeamStore {
       depth,
       can_spawn: input.can_spawn ?? false,
       token_budget: input.token_budget,
+      required_actions: [],
       state: "defined",
     };
     this.#write(join(this.#teamDirectory(id), "agents", `${record.agent_id}.json`), record, true);
@@ -217,6 +296,7 @@ export class TeamStore {
   status(id: string): {
     readonly team: TeamRecord;
     readonly agents: readonly AgentRecord[];
+    readonly receipts: readonly TeamActionReceipt[];
     readonly tokens: {
       readonly budget: number;
       readonly allocated: number;
@@ -229,11 +309,13 @@ export class TeamStore {
   } {
     const team = this.#readTeam(id);
     const agents = this.#readAgents(id);
+    const receipts = this.#readReceipts(id);
     const allocated = agents.reduce((total, agent) => total + agent.token_budget, 0);
     const observed = agents.reduce((total, agent) => total + (agent.usage?.total_tokens ?? 0), 0);
     return {
       team,
       agents,
+      receipts,
       tokens: {
         budget: team.token_budget,
         allocated,
@@ -281,11 +363,50 @@ export class TeamStore {
     const current = this.#readAgent(id, worker);
     if (current.state !== "running") throw new Error("invalid_agent_transition");
     this.#validateCompletion(completion);
+    if (completion.outcome === "succeeded" && this.missingRequiredActions(id, worker).length > 0)
+      throw new Error("required_action_missing");
     if (usage) this.#validateUsage(current, usage);
     const state: AgentState = completion.outcome === "succeeded" ? "completed" : "failed";
     const updated: AgentRecord = { ...current, state, completion, ...(usage ? { usage } : {}) };
     this.#write(join(this.#teamDirectory(id), "agents", `${worker}.json`), updated, false);
     return updated;
+  }
+
+  missingRequiredActions(id: string, worker: string): readonly TeamAction[] {
+    const agent = this.#readAgent(id, worker);
+    const completed = new Set(
+      this.#readReceipts(id)
+        .filter((receipt) => receipt.actor_agent_id === worker)
+        .map((receipt) => receipt.action),
+    );
+    return agent.required_actions.filter((action) => !completed.has(action));
+  }
+
+  receipt(
+    id: string,
+    action: TeamAction,
+    actorAgentId?: string,
+    subjectAgentId?: string,
+  ): TeamActionReceipt {
+    this.#readTeam(id);
+    if (!["manager.start", "team.status", "agent.engage", "agent.await"].includes(action))
+      throw new TypeError("invalid team action");
+    if (actorAgentId) this.#readAgent(id, actorAgentId);
+    if (subjectAgentId) this.#readAgent(id, subjectAgentId);
+    const receipt: TeamActionReceipt = {
+      schema: 1,
+      receipt_id: `receipt-${randomUUID()}`,
+      team_id: id,
+      action,
+      ...(actorAgentId ? { actor_agent_id: actorAgentId } : {}),
+      ...(subjectAgentId ? { subject_agent_id: subjectAgentId } : {}),
+      outcome: "succeeded",
+    };
+    const directory = join(this.#teamDirectory(id), "receipts");
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+    if (this.#readReceipts(id).length >= 256) throw new Error("team_receipt_limit");
+    this.#write(join(directory, `${receipt.receipt_id}.json`), receipt, true);
+    return receipt;
   }
 
   assign(id: string, worker: string, task: string): AgentRecord {
@@ -335,6 +456,7 @@ export class TeamStore {
         "succeeded",
         "agent_exit_nonzero",
         "completion_missing",
+        "required_action_missing",
         "token_accounting_unavailable",
         "token_budget_exceeded",
       ].includes(completion.outcome) ||
@@ -378,6 +500,8 @@ export class TeamStore {
       `agent:${value.coordination_agent.slice("agent-".length)}` as const;
     return {
       ...value,
+      kind: value.kind ?? "worker",
+      required_actions: Array.isArray(value.required_actions) ? value.required_actions : [],
       ...(Number.isSafeInteger(value.token_budget) ? {} : { token_budget: 0 }),
       ...(value.coordination_participant
         ? {}
@@ -391,6 +515,19 @@ export class TeamStore {
       .filter((name) => /^worker-[0-9a-f-]{36}\.json$/u.test(name))
       .sort()
       .map((name) => this.#readAgent(id, name.slice(0, -".json".length)));
+  }
+
+  #readReceipts(id: string): readonly TeamActionReceipt[] {
+    const directory = join(this.#teamDirectory(id), "receipts");
+    try {
+      return readdirSync(directory)
+        .filter((name) => /^receipt-[0-9a-f-]{36}\.json$/u.test(name))
+        .sort()
+        .map((name) => this.#read(join(directory, name)) as TeamActionReceipt);
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
+      throw error;
+    }
   }
 
   #read(path: string): unknown {

--- a/test/runtime/conversation-watch.test.ts
+++ b/test/runtime/conversation-watch.test.ts
@@ -65,6 +65,7 @@ test("watch explains team and worker activity in work-oriented language", () => 
           {
             schema: 1,
             agent_id: "worker-9776aa63-2b13-4d98-ab2b-5b0c8b0354aa",
+            kind: "worker",
             coordination_agent: "agent-backend-lead-61e1f378",
             coordination_participant: "agent:backend-lead-61e1f378",
             team_id: "team-0eae0789-0d76-493a-9d89-2f44c9f819cd",
@@ -74,9 +75,11 @@ test("watch explains team and worker activity in work-oriented language", () => 
             depth: 1,
             can_spawn: true,
             token_budget: 50_000,
+            required_actions: [],
             state: "running",
           },
         ],
+        receipts: [],
         tokens: {
           budget: 200_000,
           allocated: 50_000,
@@ -93,6 +96,83 @@ test("watch explains team and worker activity in work-oriented language", () => 
   assert.match(changes.join("\n"), /manager=manager runtime=codex goal=Build a task board/u);
   assert.match(changes.join("\n"), /WORKER  backend-lead  RUNNING/u);
   assert.match(changes.join("\n"), /task=Define and implement the API/u);
+});
+
+test("watch exposes manager accounting and receipt-backed actions", () => {
+  const teamID = "team-0eae0789-0d76-493a-9d89-2f44c9f819cd";
+  const managerID = "worker-9776aa63-2b13-4d98-ab2b-5b0c8b0354aa";
+  const changes = renderTeamChanges(
+    [
+      {
+        team: {
+          schema: 1,
+          team_id: teamID,
+          goal: "Improve Yukh",
+          workspace: "/tmp/project",
+          manager_runtime: "codex",
+          manager_role: "delivery-manager",
+          manager_mission: "Deliver one verified increment",
+          max_agents: 3,
+          max_depth: 2,
+          token_budget: 60_000,
+          state: "active",
+        },
+        agents: [
+          {
+            schema: 1,
+            agent_id: managerID,
+            kind: "manager",
+            coordination_agent: "agent-delivery-manager-61e1f378",
+            coordination_participant: "agent:delivery-manager-61e1f378",
+            team_id: teamID,
+            runtime: "codex",
+            role: "delivery-manager",
+            task: "Inspect and report",
+            depth: 0,
+            can_spawn: true,
+            token_budget: 20_000,
+            required_actions: ["team.status"],
+            usage: {
+              schema: 1,
+              source: "codex-json-v1",
+              input_tokens: 5_000,
+              cached_input_tokens: 3_000,
+              output_tokens: 500,
+              reasoning_output_tokens: 100,
+              total_tokens: 5_500,
+              budget_outcome: "within",
+            },
+            completion: { schema: 1, outcome: "succeeded", summary: "Verified" },
+            state: "completed",
+          },
+        ],
+        receipts: [
+          {
+            schema: 1,
+            receipt_id: "receipt-9776aa63-2b13-4d98-ab2b-5b0c8b0354aa",
+            team_id: teamID,
+            action: "team.status",
+            actor_agent_id: managerID,
+            subject_agent_id: managerID,
+            outcome: "succeeded",
+          },
+        ],
+        tokens: {
+          budget: 60_000,
+          allocated: 20_000,
+          observed: 5_500,
+          remaining: 54_500,
+          pending_agents: 0,
+          unaccounted_agents: 0,
+          exceeded_agents: 0,
+        },
+      },
+    ],
+    new Map(),
+  ).join("\n");
+  assert.match(changes, /MANAGER  delivery-manager  COMPLETED/u);
+  assert.match(changes, /input=5000 cached=3000 output=500 reasoning=100/u);
+  assert.match(changes, /required=team.status receipts=team.status/u);
 });
 
 test("watch accepts bounded dynamic team identities", () => {

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -163,6 +163,117 @@ test("team store reserves budgets and persists bounded completion usage", async 
   }
 });
 
+test("managed teams reserve root usage and require server-issued action receipts", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-root-manager-budget-")));
+  try {
+    const store = new TeamStore(root);
+    const managed = store.createManaged("Improve the suite", "codex", 3, 2, 60_000, {
+      role: "delivery-manager",
+      profile: {
+        schema: 1,
+        mission: "Plan and verify one bounded increment",
+        model: "default",
+        skills: ["product", "testing"],
+        instructions: "Use receipts as evidence and keep output bounded.",
+      },
+      task: "Engage one reviewer and wait for its completion",
+      token_budget: 20_000,
+      required_actions: ["agent.engage", "agent.await"],
+    });
+    assert.equal(managed.manager.kind, "manager");
+    assert.equal(managed.manager.depth, 0);
+    const started = store.receipt(
+      managed.team.team_id,
+      "manager.start",
+      undefined,
+      managed.manager.agent_id,
+    );
+    assert.equal(started.action, "manager.start");
+    assert.equal(store.status(managed.team.team_id).tokens.allocated, 20_000);
+    assert.throws(
+      () =>
+        store.spawn(managed.team.team_id, {
+          parent_agent_id: managed.manager.agent_id,
+          runtime: "codex",
+          role: "oversized-worker",
+          task: "Cannot consume beyond the team reservation",
+          token_budget: 50_000,
+        }),
+      /team_token_budget_exceeded/u,
+    );
+    const worker = store.spawn(managed.team.team_id, {
+      parent_agent_id: managed.manager.agent_id,
+      runtime: "codex",
+      role: "bounded-reviewer",
+      task: "Review the proposal",
+      token_budget: 20_000,
+    });
+    store.receipt(managed.team.team_id, "agent.engage", managed.manager.agent_id, worker.agent_id);
+    store.transition(managed.team.team_id, managed.manager.agent_id, "running");
+    const usage = {
+      schema: 1 as const,
+      source: "codex-json-v1" as const,
+      input_tokens: 5_000,
+      cached_input_tokens: 3_000,
+      output_tokens: 500,
+      reasoning_output_tokens: 100,
+      total_tokens: 5_500,
+      budget_outcome: "within" as const,
+    };
+    assert.throws(
+      () =>
+        store.finish(
+          managed.team.team_id,
+          managed.manager.agent_id,
+          { schema: 1, outcome: "succeeded", summary: "Plausible but unverified plan" },
+          usage,
+        ),
+      /required_action_missing/u,
+    );
+    store.receipt(managed.team.team_id, "agent.await", managed.manager.agent_id, worker.agent_id);
+    const completed = store.finish(
+      managed.team.team_id,
+      managed.manager.agent_id,
+      { schema: 1, outcome: "succeeded", summary: "Verified manager result" },
+      usage,
+    );
+    assert.equal(completed.state, "completed");
+    assert.equal(store.status(managed.team.team_id).tokens.observed, 5_500);
+    assert.deepEqual(
+      store.missingRequiredActions(managed.team.team_id, managed.manager.agent_id),
+      [],
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("managed team rejects a manager budget above the team budget", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-root-manager-overrun-")));
+  try {
+    const store = new TeamStore(root);
+    assert.throws(
+      () =>
+        store.createManaged("Reject invalid reservation", "codex", 2, 1, 10_000, {
+          role: "delivery-manager",
+          profile: {
+            schema: 1,
+            mission: "Stay bounded",
+            model: "default",
+            skills: [],
+            instructions: "Do not exceed the team budget.",
+          },
+          task: "Plan",
+          token_budget: 11_000,
+          required_actions: [],
+        }),
+      /invalid manager definition/u,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("runtime output extracts Codex completion and refuses invented Copilot token usage", () => {
   const codex = new RuntimeOutput("codex");
   codex.line(
@@ -578,6 +689,68 @@ printf '%s\n' '{"type":"result","exitCode":0,"usage":{"premiumRequests":1,"sessi
     assert.equal(failed.completion?.outcome, "token_accounting_unavailable");
     assert.equal(failed.usage, undefined);
     assert.equal(store.status(team.team_id).tokens.unaccounted_agents, 1);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("root manager fails closed when a required action has no receipt", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-manager-receipt-deny-")));
+  try {
+    const executable = join(root, "agent-cli");
+    const launcher = join(root, "launcher");
+    const support = join(root, "support.mjs");
+    await writeFile(
+      executable,
+      `#!/bin/sh
+printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"I claim the team was inspected"}}'
+printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":20,"reasoning_output_tokens":5}}'
+`,
+      { mode: 0o700 },
+    );
+    await writeFile(
+      launcher,
+      '#!/bin/sh\ncat >/dev/null\nprintf \'{"schema":1,"status":"ok","command":"test"}\\n\'\n',
+      { mode: 0o700 },
+    );
+    await writeFile(support, "", { mode: 0o600 });
+    const store = new TeamStore(root);
+    const managed = store.createManaged("Require action evidence", "codex", 2, 1, 10_000, {
+      role: "delivery-manager",
+      profile: {
+        schema: 1,
+        mission: "Inspect the team through its bounded tool",
+        model: "default",
+        skills: [],
+        instructions: "Do not substitute prose for a receipt.",
+      },
+      task: "Call team.status and summarize",
+      token_budget: 5_000,
+      required_actions: ["team.status"],
+    });
+    const child = spawn(
+      process.execPath,
+      ["--import", tsxLoader, workerMain, managed.team.team_id, managed.manager.agent_id],
+      {
+        cwd: root,
+        stdio: "ignore",
+        env: {
+          HOME: process.env.HOME ?? "",
+          PATH: process.env.PATH ?? "/usr/bin:/bin",
+          YUKH_TEAM_WORKSPACE: root,
+          YUKH_COORDINATION_LAUNCHER: launcher,
+          YUKH_COORDINATION_MCP_MAIN: support,
+          YUKH_TEAM_CONTROL_MCP_MAIN: support,
+          YUKH_CODEX_EXECUTABLE: executable,
+          YUKH_COPILOT_EXECUTABLE: executable,
+        },
+      },
+    );
+    assert.equal(await new Promise<number | null>((resolve) => child.once("close", resolve)), 1);
+    const failed = store.agent(managed.team.team_id, managed.manager.agent_id);
+    assert.equal(failed.state, "failed");
+    assert.equal(failed.completion?.outcome, "required_action_missing");
+    assert.equal(failed.usage?.total_tokens, 120);
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #139

## What changed

- adds `manager.start` to create an accounted depth-zero manager and reserve its budget before worker allocation
- denies external unaccounted `agent.engage` and `agent.spawn` calls with `manager_runtime_required`
- persists closed server-issued receipts for manager start, team status, worker engagement and await
- fails manager completion when a required action receipt is missing
- exposes manager state, receipts and input/cached/output/reasoning token categories in team status and the watcher
- adds accepted RFC-0021, threat-model impact and concise migration guidance

## Why

The first real self-hosting planning run consumed 339,291 total input/output tokens outside the team budget and produced no MCP call or team record. A model session outside Yukh cannot be authoritative evidence for manager usage or claimed team actions.

## Validation

- `npm test` — 253 tests passed
- `npm run typecheck`
- `npm run build`
- `npm run format:check`
- `git diff --check`
- MCP E2E with synthetic Codex runtime — `manager.start`, manager accounting (`1500/4000`), team accounting (`1500/10000`), await, start receipt and external engagement denial passed
