### PR TITLE
Return exact manager action receipts

### DIFF
--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -60,6 +60,22 @@ export async function awaitAgent(
   }
 }
 
+export function readTeamStatus(
+  store: TeamStore,
+  teamId: string,
+  caller?: { readonly team_id: string; readonly agent_id: string },
+):
+  | ReturnType<TeamStore["status"]>
+  | {
+      readonly status: ReturnType<TeamStore["status"]>;
+      readonly receipt: ReturnType<TeamStore["receipt"]>;
+    } {
+  const status = store.status(teamId);
+  if (!caller) return status;
+  const receipt = store.receipt(teamId, "team.status", caller.agent_id, caller.agent_id);
+  return { status, receipt };
+}
+
 export function createTeamControlServer(
   store: TeamStore,
   supervisor: TeamSupervisor,
@@ -207,10 +223,7 @@ export function createTeamControlServer(
     },
     ({ team_id }) => {
       authorizeTeam(team_id);
-      const status = store.status(team_id);
-      if (options.caller)
-        store.receipt(team_id, "team.status", options.caller.agent_id, options.caller.agent_id);
-      return result(status);
+      return result(readTeamStatus(store, team_id, options.caller));
     },
   );
 

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -94,12 +94,17 @@ the manager:
 
 ```text
 Use yukh-team-control. Call manager.start with a 120000-token team budget and a
-30000-token Codex manager budget. Require agent.engage and agent.await receipts.
+45000-token Codex manager budget. Require agent.engage and agent.await receipts.
 Ask the manager to engage one Codex backend developer with a 50000-token budget,
 wait for its completion, inspect its summary and usage, then report the result.
 Do not use team.create and do not engage a runtime that cannot provide token
 accounting.
 ```
+
+The 45,000-token manager allocation reflects the measured bounded planning
+profile with no repository, shell or web inspection. Treat it as an initial
+qualification value, not a universal estimate. `team.status` returns its newly
+issued receipt directly to an accounted manager while also persisting it.
 
 `agent.spawn` starts a real detached CLI and returns its PID and log path. A
 worker with `can_spawn=true` receives the same team-control MCP but can create

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -8,7 +8,11 @@ import test from "node:test";
 import { TeamStore } from "../../packages/team-control/src/store.js";
 import { TeamSupervisor } from "../../packages/team-control/src/supervisor.js";
 import { RuntimeOutput } from "../../packages/team-control/src/runtime-output.js";
-import { assertProfileAvailable, awaitAgent } from "../../apps/team-control/src/server.js";
+import {
+  assertProfileAvailable,
+  awaitAgent,
+  readTeamStatus,
+} from "../../apps/team-control/src/server.js";
 
 const workerMain = fileURLToPath(new URL("../../apps/team-worker/src/main.ts", import.meta.url));
 const tsxLoader = fileURLToPath(import.meta.resolve("tsx"));
@@ -268,6 +272,42 @@ test("managed team rejects a manager budget above the team budget", async () => 
           required_actions: [],
         }),
       /invalid manager definition/u,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("accounted manager receives the exact persisted team status receipt", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-manager-status-receipt-")));
+  try {
+    const store = new TeamStore(root);
+    const managed = store.createManaged("Inspect exact state", "codex", 2, 1, 50_000, {
+      role: "delivery-manager",
+      profile: {
+        schema: 1,
+        mission: "Inspect one team",
+        model: "default",
+        skills: [],
+        instructions: "Use the returned receipt as evidence.",
+      },
+      task: "Call team.status",
+      token_budget: 40_000,
+      required_actions: ["team.status"],
+    });
+    const external = readTeamStatus(store, managed.team.team_id);
+    assert.equal("status" in external, false);
+    const accounted = readTeamStatus(store, managed.team.team_id, {
+      team_id: managed.team.team_id,
+      agent_id: managed.manager.agent_id,
+    });
+    assert.equal("status" in accounted, true);
+    if (!("status" in accounted)) throw new Error("missing accounted status");
+    assert.equal(accounted.receipt.action, "team.status");
+    assert.equal(accounted.receipt.actor_agent_id, managed.manager.agent_id);
+    assert.equal(
+      store.status(managed.team.team_id).receipts.at(-1)?.receipt_id,
+      accounted.receipt.receipt_id,
     );
   } finally {
     await rm(root, { recursive: true, force: true });


### PR DESCRIPTION
Closes #141

## What changed

- returns the newly persisted `team.status` receipt directly to accounted managers
- preserves the existing external read-only status shape
- documents the measured bounded planning baseline and raises the example manager allocation to 45,000 tokens
- adds a regression test proving the returned receipt is the exact persisted receipt

## Evidence

The first accounted real manager run correctly failed closed at 39,219 observed tokens against a 20,000 budget and started no workers. Its required status receipt was persisted, but not visible in the same tool result.

## Validation

- `npm test` — 254 tests passed
- `npm run typecheck`
- `npm run build`
- `npm run format:check`
- `git diff --check`
