### PR TITLE
Reduce manager planning context below 20k tokens

### DIFF
--- a/.context/rfcs/RFC-0022-isolated-minimal-manager-context.md
+++ b/.context/rfcs/RFC-0022-isolated-minimal-manager-context.md
@@ -1,0 +1,55 @@
+# RFC-0022 — Isolated minimal manager context
+
+- Status: Accepted
+- Authors: Nomed with Codex implementation support
+- Created: 2026-08-16
+- Accepted: 2026-08-16
+- Decider: project owner
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/143
+- Depends on: RFC-0020 and RFC-0021
+
+## Decision
+
+Accounted Codex runtimes start with `--ignore-user-config`. Authentication is
+retained by the CLI, while user-configured MCP servers, plugins and unrelated
+instructions are excluded. Yukh injects only its reviewed runtime configuration.
+Failure to start the isolated profile remains a terminal runtime failure.
+
+The team-control MCP exposes only tools required by the current agent record.
+A pure planning manager receives no model-facing MCP server; `manager.start`
+and terminal state are verified by the controller. A manager that explicitly
+requires `team.status` receives only that tool and no Coordination MCP.
+Managers that must engage or await workers
+receive those explicitly required tools and Coordination. Workers receive a
+bounded tool set derived from delegation authority.
+
+Accounted `team.status` returns a compact projection containing team bounds,
+token totals, agent identifiers, roles, states, budgets and completion outcomes,
+plus the exact new receipt. It excludes goals, tasks, missions, instructions,
+skills, Coordination identities, completion summaries and prior receipts. The
+operator and watcher retain the full persistent status.
+
+## Accounting
+
+Optimization never changes token semantics. Total remains input plus output;
+cached input remains visible within input. A real bounded planning turn must be
+measured after implementation. Raising a budget is not accepted as evidence of
+reduced consumption.
+
+## Qualification
+
+- prove the Codex invocation contains `--ignore-user-config`;
+- prove a pure planning manager receives no MCP and a status-only manager receives only `team.status`;
+- prove accounted status excludes prompt-derived fields;
+- keep external full status compatible;
+- run one real tool-free planning turn and target fewer than 20,000 total tokens.
+
+The real Codex qualification completed at 14,382 total tokens: 13,735 input,
+9,984 of that cached, and 647 output. The equivalent status-tool profiles used
+39,219 and 43,289 total tokens. Pure planning therefore remains tool-free;
+operational tool turns are separately budgeted and receipt-backed.
+
+## Rollback
+
+Disable dynamic manager launch. Do not restore inherited user configuration or
+unbounded model-facing tool surfaces as a compatibility fallback.

--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -67,13 +67,52 @@ export function readTeamStatus(
 ):
   | ReturnType<TeamStore["status"]>
   | {
-      readonly status: ReturnType<TeamStore["status"]>;
+      readonly status: {
+        readonly team: {
+          readonly team_id: string;
+          readonly state: "active" | "stopped";
+          readonly max_agents: number;
+          readonly max_depth: number;
+          readonly token_budget: number;
+        };
+        readonly agents: readonly {
+          readonly agent_id: string;
+          readonly kind: "manager" | "worker";
+          readonly role: string;
+          readonly state: "defined" | "running" | "completed" | "failed" | "stopped";
+          readonly token_budget: number;
+          readonly observed_tokens: number;
+          readonly completion: string;
+        }[];
+        readonly tokens: ReturnType<TeamStore["status"]>["tokens"];
+      };
       readonly receipt: ReturnType<TeamStore["receipt"]>;
     } {
   const status = store.status(teamId);
   if (!caller) return status;
   const receipt = store.receipt(teamId, "team.status", caller.agent_id, caller.agent_id);
-  return { status, receipt };
+  return {
+    status: {
+      team: {
+        team_id: status.team.team_id,
+        state: status.team.state,
+        max_agents: status.team.max_agents,
+        max_depth: status.team.max_depth,
+        token_budget: status.team.token_budget,
+      },
+      agents: status.agents.map((agent) => ({
+        agent_id: agent.agent_id,
+        kind: agent.kind,
+        role: agent.role,
+        state: agent.state,
+        token_budget: agent.token_budget,
+        observed_tokens: agent.usage?.total_tokens ?? 0,
+        completion: agent.completion?.outcome ?? "pending",
+      })),
+      tokens: status.tokens,
+    },
+    receipt,
+  };
 }
 
 export function createTeamControlServer(

--- a/apps/team-worker/src/main.ts
+++ b/apps/team-worker/src/main.ts
@@ -26,7 +26,25 @@ const mcpEnv = {
 };
 const profile = agent.profile;
 const requiredActions = agent.required_actions.join(", ") || "none";
-const prompt = `You are ${agent.role}, ${agent.kind} ${agent.agent_id} in team ${agent.team_id}.${profile ? ` Mission: ${profile.mission}\nOperating instructions: ${profile.instructions}\nRequired skills: ${profile.skills.length > 0 ? profile.skills.join(", ") : "none"}.` : ""}\nComplete this task: ${agent.task}\nToken budget: ${agent.token_budget} total input plus output tokens. Keep inspection and tool output bounded. The team already exists: do not call team.create. Required receipt-backed actions before success: ${requiredActions}. A textual claim is not evidence; invoke each required yukh-team-control tool successfully. When engaging a child, use the returned coordination_participant exactly and never add another agent: prefix. Wait for each child with agent.await and inspect its completion before synthesizing. Your Coordination session is already bootstrapped and joined. Use yukh-coordination to replay messages and communicate decisions and blockers. End with one concise public-safe completion summary of at most 4096 UTF-8 bytes; the wrapper persists that final response. You may create a bounded child only when explicitly delegated.`;
+const modelUsesCoordination =
+  agent.kind === "worker" || agent.required_actions.some((action) => action !== "team.status");
+const modelTeamTools = [
+  ...new Set(
+    agent.kind === "manager"
+      ? agent.required_actions
+      : agent.can_spawn
+        ? ["team.status", "agent.status", "agent.engage", "agent.await"]
+        : ["team.status", "agent.status"],
+  ),
+];
+const modelUsesTeamControl = modelTeamTools.length > 0;
+const coordinationInstruction = modelUsesCoordination
+  ? "Your Coordination session is already bootstrapped and joined. Use yukh-coordination only for necessary team communication."
+  : "Coordination model tools are omitted for this bounded turn because no communication action is required.";
+const teamControlInstruction = modelUsesTeamControl
+  ? `Required receipt-backed actions before success: ${requiredActions}. A textual claim is not evidence; invoke each required yukh-team-control tool successfully.`
+  : "No model-facing team-control tools are required or exposed for this single-pass turn; the controller verifies manager.start and terminal state.";
+const prompt = `You are ${agent.role}, ${agent.kind} ${agent.agent_id} in team ${agent.team_id}.${profile ? ` Mission: ${profile.mission}\nOperating instructions: ${profile.instructions}\nRequired skills: ${profile.skills.length > 0 ? profile.skills.join(", ") : "none"}.` : ""}\nComplete this task: ${agent.task}\nToken budget: ${agent.token_budget} total input plus output tokens. Keep inspection and tool output bounded. The team already exists: do not call team.create. ${teamControlInstruction} When engaging a child, use the returned coordination_participant exactly and never add another agent: prefix. Wait for each child with agent.await and inspect its completion before synthesizing. ${coordinationInstruction} End with one concise public-safe completion summary of at most 4096 UTF-8 bytes; the wrapper persists that final response. You may create a bounded child only when explicitly delegated.`;
 const teamControlEnv = {
   YUKH_TEAM_WORKSPACE: workspace,
   YUKH_COORDINATION_LAUNCHER: launcher,
@@ -51,24 +69,35 @@ const args =
         "exec",
         "--ephemeral",
         "--json",
+        "--ignore-user-config",
         "--dangerously-bypass-approvals-and-sandbox",
         ...(profile && profile.model !== "default" ? ["--model", profile.model] : []),
-        "-c",
-        `mcp_servers.yukh-coordination.command=${JSON.stringify(node)}`,
-        "-c",
-        `mcp_servers.yukh-coordination.args=${JSON.stringify([mcpMain])}`,
-        "-c",
-        `mcp_servers.yukh-coordination.env.YUKH_COORDINATION_AGENT=${JSON.stringify(agent.coordination_agent)}`,
-        "-c",
-        `mcp_servers.yukh-coordination.env.YUKH_COORDINATION_LAUNCHER=${JSON.stringify(launcher)}`,
-        "-c",
-        `mcp_servers.yukh-team-control.command=${JSON.stringify(node)}`,
-        "-c",
-        `mcp_servers.yukh-team-control.args=${JSON.stringify([teamControlMain])}`,
-        ...Object.entries(teamControlEnv).flatMap(([name, value]) => [
-          "-c",
-          `mcp_servers.yukh-team-control.env.${name}=${JSON.stringify(value)}`,
-        ]),
+        ...(modelUsesCoordination
+          ? [
+              "-c",
+              `mcp_servers.yukh-coordination.command=${JSON.stringify(node)}`,
+              "-c",
+              `mcp_servers.yukh-coordination.args=${JSON.stringify([mcpMain])}`,
+              "-c",
+              `mcp_servers.yukh-coordination.env.YUKH_COORDINATION_AGENT=${JSON.stringify(agent.coordination_agent)}`,
+              "-c",
+              `mcp_servers.yukh-coordination.env.YUKH_COORDINATION_LAUNCHER=${JSON.stringify(launcher)}`,
+            ]
+          : []),
+        ...(modelUsesTeamControl
+          ? [
+              "-c",
+              `mcp_servers.yukh-team-control.command=${JSON.stringify(node)}`,
+              "-c",
+              `mcp_servers.yukh-team-control.args=${JSON.stringify([teamControlMain])}`,
+              "-c",
+              `mcp_servers.yukh-team-control.enabled_tools=${JSON.stringify(modelTeamTools)}`,
+              ...Object.entries(teamControlEnv).flatMap(([name, value]) => [
+                "-c",
+                `mcp_servers.yukh-team-control.env.${name}=${JSON.stringify(value)}`,
+              ]),
+            ]
+          : []),
         prompt,
       ]
     : [
@@ -82,20 +111,28 @@ const args =
         ...(profile && profile.model !== "default" ? ["--model", profile.model] : []),
         `--additional-mcp-config=${JSON.stringify({
           mcpServers: {
-            "yukh-coordination": {
-              type: "stdio",
-              command: node,
-              args: [mcpMain],
-              env: mcpEnv,
-              tools: ["*"],
-            },
-            "yukh-team-control": {
-              type: "stdio",
-              command: node,
-              args: [teamControlMain],
-              env: teamControlEnv,
-              tools: ["*"],
-            },
+            ...(modelUsesCoordination
+              ? {
+                  "yukh-coordination": {
+                    type: "stdio" as const,
+                    command: node,
+                    args: [mcpMain],
+                    env: mcpEnv,
+                    tools: ["*"],
+                  },
+                }
+              : {}),
+            ...(modelUsesTeamControl
+              ? {
+                  "yukh-team-control": {
+                    type: "stdio" as const,
+                    command: node,
+                    args: [teamControlMain],
+                    env: teamControlEnv,
+                    tools: modelTeamTools,
+                  },
+                }
+              : {}),
           },
         })}`,
       ];

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -94,17 +94,28 @@ the manager:
 
 ```text
 Use yukh-team-control. Call manager.start with a 120000-token team budget and a
-45000-token Codex manager budget. Require agent.engage and agent.await receipts.
+20000-token Codex planning-manager budget and no required actions. Ask it for a
+single-pass proposal using only supplied facts. After approving the proposal,
+start a separate operational manager that requires agent.engage and agent.await
+receipts.
 Ask the manager to engage one Codex backend developer with a 50000-token budget,
 wait for its completion, inspect its summary and usage, then report the result.
 Do not use team.create and do not engage a runtime that cannot provide token
 accounting.
 ```
 
-The 45,000-token manager allocation reflects the measured bounded planning
-profile with no repository, shell or web inspection. Treat it as an initial
-qualification value, not a universal estimate. `team.status` returns its newly
-issued receipt directly to an accounted manager while also persisting it.
+The tool-free planning profile measured 14,382 total tokens: 13,735 input,
+including 9,984 cached, and 647 output. The 20,000-token allocation provides a
+bounded margin; it is not a universal estimate. Every operational tool call is
+a separate context round and needs its own justified budget. `team.status`
+returns its newly issued receipt directly to an accounted manager while also
+persisting it.
+
+Codex managers run without inherited user configuration. Yukh injects only the
+tools required by the manager record; a pure planning turn receives no
+model-facing MCP at all. A status-only operational turn receives only compact
+team status and no Coordination tools. Its status result is a compact projection,
+while the operator and conversation viewer retain full persistent state.
 
 `agent.spawn` starts a real detached CLI and returns its PID and log path. A
 worker with `can_spawn=true` receives the same team-control MCP but can create

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -249,6 +249,21 @@ The observer exposes exact runtime token categories. Residual risk remains
 post-turn budget detection because the agent CLI does not provide a trusted
 preemptive token-control boundary.
 
+## Accepted isolated minimal manager context — 2026-08-16
+
+- Governing issue: #143
+- Accepted architecture: RFC-0022
+- Scope: Codex configuration isolation, per-agent MCP minimization and compact status
+
+Accounted Codex runtimes ignore user configuration and receive only explicit
+Yukh MCP overrides. Tool exposure is derived from the persistent agent record;
+a pure planning manager receives no model-facing MCP, while a status-only
+manager receives neither unrelated team tools nor Coordination. Accounted
+status excludes prompt-derived task, mission,
+instruction and skill text while retaining exact bounds, states, token totals
+and the current receipt. External operator status remains complete. Residual
+risk is the provider's irreducible system/context cost and post-turn accounting.
+
 ## Capability contract implementation review — 2026-08-03
 
 - Governing issue: #5

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -305,6 +305,8 @@ test("accounted manager receives the exact persisted team status receipt", async
     if (!("status" in accounted)) throw new Error("missing accounted status");
     assert.equal(accounted.receipt.action, "team.status");
     assert.equal(accounted.receipt.actor_agent_id, managed.manager.agent_id);
+    assert.equal("profile" in accounted.status.agents[0]!, false);
+    assert.equal("task" in accounted.status.agents[0]!, false);
     assert.equal(
       store.status(managed.team.team_id).receipts.at(-1)?.receipt_id,
       accounted.receipt.receipt_id,
@@ -738,11 +740,13 @@ test("root manager fails closed when a required action has no receipt", async ()
   const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-manager-receipt-deny-")));
   try {
     const executable = join(root, "agent-cli");
+    const argumentsFile = join(root, "agent-arguments");
     const launcher = join(root, "launcher");
     const support = join(root, "support.mjs");
     await writeFile(
       executable,
       `#!/bin/sh
+printf '%s\n' "$@" >${argumentsFile}
 printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"I claim the team was inspected"}}'
 printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":20,"reasoning_output_tokens":5}}'
 `,
@@ -791,6 +795,81 @@ printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_inpu
     assert.equal(failed.state, "failed");
     assert.equal(failed.completion?.outcome, "required_action_missing");
     assert.equal(failed.usage?.total_tokens, 120);
+    const runtimeArguments = await readFile(argumentsFile, "utf8");
+    assert.match(runtimeArguments, /--ignore-user-config/u);
+    assert.match(
+      runtimeArguments,
+      /mcp_servers\.yukh-team-control\.enabled_tools=\["team\.status"\]/u,
+    );
+    assert.doesNotMatch(runtimeArguments, /mcp_servers\.yukh-coordination\.command/u);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("pure planning manager receives no model-facing MCP configuration", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-manager-tool-free-")));
+  try {
+    const executable = join(root, "agent-cli");
+    const argumentsFile = join(root, "agent-arguments");
+    const launcher = join(root, "launcher");
+    const support = join(root, "support.mjs");
+    await writeFile(
+      executable,
+      `#!/bin/sh
+printf '%s\n' "$@" >${argumentsFile}
+printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"One-pass plan"}}'
+printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_input_tokens":0,"output_tokens":20,"reasoning_output_tokens":5}}'
+`,
+      { mode: 0o700 },
+    );
+    await writeFile(
+      launcher,
+      '#!/bin/sh\ncat >/dev/null\nprintf \'{"schema":1,"status":"ok","command":"test"}\\n\'\n',
+      { mode: 0o700 },
+    );
+    await writeFile(support, "", { mode: 0o600 });
+    const store = new TeamStore(root);
+    const managed = store.createManaged("Plan once", "codex", 2, 1, 5_000, {
+      role: "delivery-manager",
+      profile: {
+        schema: 1,
+        mission: "Return one compact plan",
+        model: "default",
+        skills: [],
+        instructions: "Use only supplied facts.",
+      },
+      task: "Propose the plan",
+      token_budget: 2_000,
+      required_actions: [],
+    });
+    const child = spawn(
+      process.execPath,
+      ["--import", tsxLoader, workerMain, managed.team.team_id, managed.manager.agent_id],
+      {
+        cwd: root,
+        stdio: "ignore",
+        env: {
+          HOME: process.env.HOME ?? "",
+          PATH: process.env.PATH ?? "/usr/bin:/bin",
+          YUKH_TEAM_WORKSPACE: root,
+          YUKH_COORDINATION_LAUNCHER: launcher,
+          YUKH_COORDINATION_MCP_MAIN: support,
+          YUKH_TEAM_CONTROL_MCP_MAIN: support,
+          YUKH_CODEX_EXECUTABLE: executable,
+          YUKH_COPILOT_EXECUTABLE: executable,
+        },
+      },
+    );
+    assert.equal(await new Promise<number | null>((resolve) => child.once("close", resolve)), 0);
+    const runtimeArguments = await readFile(argumentsFile, "utf8");
+    assert.match(runtimeArguments, /--ignore-user-config/u);
+    assert.doesNotMatch(runtimeArguments, /mcp_servers\.yukh-team-control/u);
+    assert.doesNotMatch(runtimeArguments, /mcp_servers\.yukh-coordination/u);
+    assert.equal(
+      store.agent(managed.team.team_id, managed.manager.agent_id).completion?.outcome,
+      "succeeded",
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #143

## What changed

- starts accounted Codex runtimes with `--ignore-user-config` and explicit Yukh overrides only
- derives the model-facing team tool allowlist from required actions and delegation authority
- exposes no model-facing MCP at all for pure planning turns
- omits Coordination for status-only managers
- returns compact accounted status without prompt-derived profile, instruction or task fields
- keeps full operator/watcher state and exact token semantics
- adds accepted RFC-0022 and threat-model impact

## Measured impact

- previous status-tool planning profiles: 39,219 and 43,289 total tokens
- optimized tool-free planning profile: 14,382 total tokens
- reduction: 63–67%
- optimized breakdown: 13,735 input, 9,984 cached input, 647 output, 104 reasoning output
- outcome: succeeded within the unchanged 20,000 manager budget

## Validation

- `npm test` — 255 tests passed
- `npm run typecheck`
- `npm run build`
- `npm run format:check`
- `git diff --check`
- real Codex manager qualification — succeeded at `14382/20000`, no workers and one server-authored manager.start receipt
