### PR TITLE
Execute approved team plans deterministically

### DIFF
--- a/.context/rfcs/RFC-0023-deterministic-team-plan-execution.md
+++ b/.context/rfcs/RFC-0023-deterministic-team-plan-execution.md
@@ -1,0 +1,63 @@
+# RFC-0023 — Deterministic team plan execution
+
+- Status: Accepted
+- Authors: Nomed with Codex implementation support
+- Created: 2026-08-16
+- Accepted: 2026-08-16
+- Decider: project owner
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/145
+- Depends on: RFC-0020, RFC-0021 and RFC-0022
+
+## Decision
+
+A planning manager may declare the `team-plan-v1` output contract. It runs once,
+without model-facing tools, and must emit a closed structured plan containing
+bounded worker profiles and one separately budgeted synthesis profile. The
+accounted wrapper validates the plan, binds it to the manager and team, computes
+its SHA-256 digest and persists it as proposed state. Text that merely resembles
+a plan is not executable authority.
+
+The external controller executes the proposed plan by presenting its exact
+digest. Before creating or launching any worker, Yukh verifies that the manager
+completed successfully, the plan is still proposed, every model and skill is
+allowlisted, the team has enough agent slots and the aggregate manager, worker
+and synthesis allocation fits the team budget. Validation failure has no worker
+side effects.
+
+After reservation, a deterministic executor launches the workers, waits once
+for each terminal completion and records execution receipts. It does not invoke
+the planning manager again. If every worker succeeds, it launches exactly one
+tool-free synthesis agent with the bounded public completion artifacts as its
+input. Synthesis has its own allocation and exact runtime usage. Worker failure,
+timeout or oversized synthesis input stops the plan without inventing a result.
+
+## Approval and replay
+
+The public execution request is the explicit approval boundary for this
+non-destructive local preview operation. It must contain the persisted plan
+digest. A changed, substituted or stale digest fails closed. A plan may execute
+only once; repeated execution requests return its existing terminal or running
+state and never duplicate workers.
+
+## Accounting and privacy
+
+The team allocation reserves planning, all workers and synthesis. Observed
+tokens remain the exact runtime totals defined by RFC-0020. Executor control
+work consumes no model tokens. Only bounded public-safe completion summaries
+enter synthesis; prompts, private reasoning and raw provider streams do not.
+
+## Qualification
+
+- reject unknown plan fields and malformed profiles;
+- reject stale digests, unavailable profiles, insufficient agent slots and
+  aggregate over-allocation before creating a worker;
+- prove execution launches and awaits workers without another manager turn;
+- invoke synthesis only after all workers succeed and expose its exact usage;
+- prove replay does not duplicate workers;
+- expose plan state, worker identities, synthesis identity and receipts.
+
+## Rollback
+
+Disable plan execution and preserve proposed plans, agents, usage and receipts
+for inspection. Do not fall back to manager-driven engage/await loops for a
+`team-plan-v1` manager.

--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -60,6 +60,76 @@ export async function awaitAgent(
   }
 }
 
+export async function executePlan(
+  store: TeamStore,
+  supervisor: Pick<TeamSupervisor, "launch">,
+  options: TeamControlOptions,
+  teamId: string,
+  planId: string,
+  digest: string,
+  timeoutMs: number,
+) {
+  let plan = store.plan(teamId, planId);
+  if (plan.digest !== digest) throw new Error("team_plan_digest_mismatch");
+  if (["running", "synthesizing", "completed", "failed", "reserved"].includes(plan.state))
+    return plan;
+  for (const profile of [...plan.document.workers, plan.document.synthesis])
+    assertProfileAvailable(options, profile.runtime, profile.model, profile.skills);
+  plan = store.reservePlan(teamId, planId, digest);
+  const deadline = Date.now() + timeoutMs;
+  try {
+    for (const agentId of plan.worker_agent_ids) {
+      const agent = store.agent(teamId, agentId);
+      supervisor.launch(agent);
+      store.receipt(teamId, "plan.execute", undefined, agentId);
+    }
+    plan = store.updatePlan(teamId, planId, { state: "running" });
+    const completed: AgentRecord[] = [];
+    for (const agentId of plan.worker_agent_ids) {
+      const terminal = await awaitAgent(store, teamId, agentId, Math.max(0, deadline - Date.now()));
+      if (!terminal) throw new Error("team_plan_wait_timeout");
+      if (terminal.state !== "completed" || terminal.completion?.outcome !== "succeeded")
+        throw new Error("team_plan_worker_failed");
+      completed.push(terminal);
+    }
+    const synthesisInput = JSON.stringify({
+      schema: 1,
+      worker_completions: completed.map((agent) => ({
+        agent_id: agent.agent_id,
+        role: agent.role,
+        summary: agent.completion?.summary,
+      })),
+    });
+    if (Buffer.byteLength(synthesisInput, "utf8") > 4_096)
+      throw new Error("team_plan_synthesis_input_too_large");
+    if (!plan.synthesis_agent_id) throw new Error("team_plan_state_invalid");
+    const synthesisAgentId = plan.synthesis_agent_id;
+    const synthesis = plan.document.synthesis;
+    const synthesisTask = `${synthesis.task}\n\nUse only these verified worker completion artifacts:\n${synthesisInput}`;
+    if (Buffer.byteLength(synthesisTask, "utf8") > 4_096)
+      throw new Error("team_plan_synthesis_input_too_large");
+    store.assign(teamId, synthesisAgentId, synthesisTask);
+    plan = store.updatePlan(teamId, planId, { state: "synthesizing" });
+    const synthesizer = store.agent(teamId, synthesisAgentId);
+    supervisor.launch(synthesizer);
+    store.receipt(teamId, "plan.synthesize", undefined, synthesizer.agent_id);
+    const terminal = await awaitAgent(
+      store,
+      teamId,
+      synthesizer.agent_id,
+      Math.max(0, deadline - Date.now()),
+    );
+    if (!terminal) throw new Error("team_plan_wait_timeout");
+    if (terminal.state !== "completed" || terminal.completion?.outcome !== "succeeded")
+      throw new Error("team_plan_synthesis_failed");
+    return store.updatePlan(teamId, planId, { state: "completed" });
+  } catch (error) {
+    const failureCode = error instanceof Error ? error.message : "team_plan_execution_failed";
+    store.updatePlan(teamId, planId, { state: "failed", failure_code: failureCode });
+    throw error;
+  }
+}
+
 export function readTeamStatus(
   store: TeamStore,
   teamId: string,
@@ -155,6 +225,7 @@ export function createTeamControlServer(
             .array(z.enum(["team.status", "agent.engage", "agent.await"]))
             .max(3)
             .default([]),
+          output_contract: z.enum(["summary", "team-plan-v1"]).default("summary"),
           max_agents: z.number().int().min(1).max(32).default(16),
           max_depth: z.number().int().min(1).max(5).default(3),
           team_token_budget: z.number().int().min(1_000).max(10_000_000),
@@ -186,6 +257,7 @@ export function createTeamControlServer(
             task: input.task,
             token_budget: input.manager_token_budget,
             required_actions: input.required_actions,
+            output_contract: input.output_contract,
           },
         );
         const runtime = supervisor.launch(managed.manager);
@@ -207,6 +279,77 @@ export function createTeamControlServer(
           error,
           new Set(["agent_model_unavailable", "agent_skill_unavailable", "agent_spawn_failed"]),
           "manager_start_failed",
+        );
+      }
+    },
+  );
+
+  server.registerTool(
+    "plan.status",
+    {
+      title: "Inspect a deterministic team plan",
+      description: "Read the persisted proposal, digest, execution state and assigned agents",
+      inputSchema: z
+        .object({
+          team_id: id,
+          plan_id: z.string().regex(/^plan-[0-9a-f-]{36}$/u),
+        })
+        .strict(),
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    },
+    ({ team_id, plan_id }) => {
+      if (options.caller) throw new Error("agent_delegation_denied");
+      return result(store.plan(team_id, plan_id));
+    },
+  );
+
+  server.registerTool(
+    "plan.execute",
+    {
+      title: "Execute an approved deterministic team plan",
+      description:
+        "Validate the exact proposed digest, run and await all workers, then run one tool-free synthesis",
+      inputSchema: z
+        .object({
+          team_id: id,
+          plan_id: z.string().regex(/^plan-[0-9a-f-]{36}$/u),
+          approved_digest: z.string().regex(/^sha-256:[0-9a-f]{64}$/u),
+          timeout_ms: z.number().int().min(1_000).max(300_000).default(300_000),
+        })
+        .strict(),
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+    },
+    async ({ team_id, plan_id, approved_digest, timeout_ms }) => {
+      if (options.caller) throw new Error("agent_delegation_denied");
+      try {
+        return result(
+          await executePlan(
+            store,
+            supervisor,
+            options,
+            team_id,
+            plan_id,
+            approved_digest,
+            timeout_ms,
+          ),
+        );
+      } catch (error) {
+        return stableFailure(
+          error,
+          new Set([
+            "team_plan_digest_mismatch",
+            "team_plan_manager_incomplete",
+            "agent_model_unavailable",
+            "agent_skill_unavailable",
+            "team_agent_limit",
+            "team_token_budget_exceeded",
+            "team_plan_wait_timeout",
+            "team_plan_worker_failed",
+            "team_plan_synthesis_input_too_large",
+            "team_plan_synthesis_failed",
+            "agent_spawn_failed",
+          ]),
+          "team_plan_execution_failed",
         );
       }
     },

--- a/apps/team-worker/src/main.ts
+++ b/apps/team-worker/src/main.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { createInterface } from "node:readline";
+import { fileURLToPath } from "node:url";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
 import { RuntimeOutput } from "../../../packages/team-control/src/runtime-output.js";
 
@@ -25,16 +26,20 @@ const mcpEnv = {
   YUKH_COORDINATION_LAUNCHER: launcher,
 };
 const profile = agent.profile;
+const modelToolsDisabled = agent.model_tool_mode === "none";
 const requiredActions = agent.required_actions.join(", ") || "none";
 const modelUsesCoordination =
-  agent.kind === "worker" || agent.required_actions.some((action) => action !== "team.status");
+  !modelToolsDisabled &&
+  (agent.kind === "worker" || agent.required_actions.some((action) => action !== "team.status"));
 const modelTeamTools = [
   ...new Set(
-    agent.kind === "manager"
-      ? agent.required_actions
-      : agent.can_spawn
-        ? ["team.status", "agent.status", "agent.engage", "agent.await"]
-        : ["team.status", "agent.status"],
+    modelToolsDisabled
+      ? []
+      : agent.kind === "manager"
+        ? agent.required_actions
+        : agent.can_spawn
+          ? ["team.status", "agent.status", "agent.engage", "agent.await"]
+          : ["team.status", "agent.status"],
   ),
 ];
 const modelUsesTeamControl = modelTeamTools.length > 0;
@@ -44,7 +49,14 @@ const coordinationInstruction = modelUsesCoordination
 const teamControlInstruction = modelUsesTeamControl
   ? `Required receipt-backed actions before success: ${requiredActions}. A textual claim is not evidence; invoke each required yukh-team-control tool successfully.`
   : "No model-facing team-control tools are required or exposed for this single-pass turn; the controller verifies manager.start and terminal state.";
-const prompt = `You are ${agent.role}, ${agent.kind} ${agent.agent_id} in team ${agent.team_id}.${profile ? ` Mission: ${profile.mission}\nOperating instructions: ${profile.instructions}\nRequired skills: ${profile.skills.length > 0 ? profile.skills.join(", ") : "none"}.` : ""}\nComplete this task: ${agent.task}\nToken budget: ${agent.token_budget} total input plus output tokens. Keep inspection and tool output bounded. The team already exists: do not call team.create. ${teamControlInstruction} When engaging a child, use the returned coordination_participant exactly and never add another agent: prefix. Wait for each child with agent.await and inspect its completion before synthesizing. ${coordinationInstruction} End with one concise public-safe completion summary of at most 4096 UTF-8 bytes; the wrapper persists that final response. You may create a bounded child only when explicitly delegated.`;
+const outputInstruction =
+  agent.output_contract === "team-plan-v1"
+    ? "Return only the JSON team execution plan required by the supplied output schema. Include the minimum specialists needed and one concise delivery synthesizer. Do not wrap JSON in Markdown."
+    : "End with one concise public-safe completion summary of at most 4096 UTF-8 bytes; the wrapper persists that final response.";
+const prompt = `You are ${agent.role}, ${agent.kind} ${agent.agent_id} in team ${agent.team_id}.${profile ? ` Mission: ${profile.mission}\nOperating instructions: ${profile.instructions}\nRequired skills: ${profile.skills.length > 0 ? profile.skills.join(", ") : "none"}.` : ""}\nComplete this task: ${agent.task}\nToken budget: ${agent.token_budget} total input plus output tokens. Keep inspection and tool output bounded. The team already exists: do not call team.create. ${teamControlInstruction} When engaging a child, use the returned coordination_participant exactly and never add another agent: prefix. Wait for each child with agent.await and inspect its completion before synthesizing. ${coordinationInstruction} ${outputInstruction} You may create a bounded child only when explicitly delegated.`;
+const planSchema = fileURLToPath(
+  new URL("../../../contracts/team-execution-plan-v1.schema.json", import.meta.url),
+);
 const teamControlEnv = {
   YUKH_TEAM_WORKSPACE: workspace,
   YUKH_COORDINATION_LAUNCHER: launcher,
@@ -71,6 +83,7 @@ const args =
         "--json",
         "--ignore-user-config",
         "--dangerously-bypass-approvals-and-sandbox",
+        ...(agent.output_contract === "team-plan-v1" ? ["--output-schema", planSchema] : []),
         ...(profile && profile.model !== "default" ? ["--model", profile.model] : []),
         ...(modelUsesCoordination
           ? [
@@ -248,6 +261,21 @@ if (joined && "output" in outcome) {
     const summary = outcome.output.summary();
     const usage = outcome.output.usage(agent.token_budget);
     const missingActions = store.missingRequiredActions(teamID, agentID);
+    let proposedPlan: ReturnType<TeamStore["proposePlan"]> | undefined;
+    let planInvalid = false;
+    if (
+      outcome.exitCode === 0 &&
+      usage?.budget_outcome === "within" &&
+      missingActions.length === 0 &&
+      summary &&
+      agent.output_contract === "team-plan-v1"
+    ) {
+      try {
+        proposedPlan = store.proposePlan(teamID, agentID, summary);
+      } catch {
+        planInvalid = true;
+      }
+    }
     const completion =
       outcome.exitCode !== 0
         ? { schema: 1 as const, outcome: "agent_exit_nonzero" as const, summary }
@@ -263,7 +291,18 @@ if (joined && "output" in outcome) {
                 }
               : !summary
                 ? { schema: 1 as const, outcome: "completion_missing" as const, summary: "" }
-                : { schema: 1 as const, outcome: "succeeded" as const, summary };
+                : planInvalid
+                  ? {
+                      schema: 1 as const,
+                      outcome: "team_plan_invalid" as const,
+                      summary: "Structured team plan validation failed",
+                    }
+                  : {
+                      schema: 1 as const,
+                      outcome: "succeeded" as const,
+                      summary,
+                      ...(proposedPlan ? { plan_id: proposedPlan.plan_id } : {}),
+                    };
     store.finish(teamID, agentID, completion, usage);
     if (completion.outcome !== "succeeded") wrapperExitCode = 1;
   }

--- a/contracts/team-execution-plan-v1.schema.json
+++ b/contracts/team-execution-plan-v1.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yukh.dev/contracts/team-execution-plan-v1.schema.json",
+  "title": "Yukh deterministic team execution plan v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "workers", "synthesis"],
+  "properties": {
+    "schema": { "const": 1 },
+    "workers": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 8,
+      "items": { "$ref": "#/$defs/agent" }
+    },
+    "synthesis": { "$ref": "#/$defs/agent" }
+  },
+  "$defs": {
+    "token": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._:-]{0,63}$"
+    },
+    "agent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "runtime",
+        "role",
+        "mission",
+        "model",
+        "skills",
+        "instructions",
+        "task",
+        "token_budget"
+      ],
+      "properties": {
+        "runtime": { "enum": ["codex", "copilot"] },
+        "role": { "type": "string", "pattern": "^[a-z][a-z0-9-]{0,31}$" },
+        "mission": { "type": "string", "minLength": 1, "maxLength": 1024 },
+        "model": { "$ref": "#/$defs/token" },
+        "skills": {
+          "type": "array",
+          "maxItems": 16,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/token" }
+        },
+        "instructions": { "type": "string", "minLength": 1, "maxLength": 4096 },
+        "task": { "type": "string", "minLength": 1, "maxLength": 4096 },
+        "token_budget": {
+          "type": "integer",
+          "minimum": 1000,
+          "maximum": 2000000
+        }
+      }
+    }
+  }
+}

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -58,7 +58,7 @@ paths to the project workspace, Coordination launcher and both agent CLIs:
 command = "node"
 args = ["/path/to/yukh-mcp/dist/apps/team-control/src/main.js"]
 env = { YUKH_TEAM_WORKSPACE = "/path/to/project", YUKH_COORDINATION_LAUNCHER = "/path/to/yukh-local-agent.py", YUKH_CODEX_EXECUTABLE = "/absolute/path/to/codex", YUKH_COPILOT_EXECUTABLE = "/absolute/path/to/copilot" }
-enabled_tools = ["manager.start", "team.status", "agent.await", "agent.status", "team.stop"]
+enabled_tools = ["manager.start", "team.status", "plan.status", "plan.execute", "agent.status", "team.stop"]
 default_tools_approval_mode = "writes"
 ```
 
@@ -71,21 +71,24 @@ env = { YUKH_CODEX_MODELS = "default,approved-codex-model", YUKH_COPILOT_MODELS 
 Start work with `manager.start`, not `team.create`. It creates the team and a
 depth-zero manager runtime together, reserves the manager budget and returns a
 server receipt plus the manager agent ID. Use `agent.await` from the controlling
-session to retrieve its terminal completion. The manager uses `agent.engage`
-from inside its accounted runtime to compose bounded professional roles. Model
-and skill values outside these allowlists fail before process launch. The
+session to retrieve its terminal completion. For efficient automatic work, set
+`output_contract` to `team-plan-v1`: the manager returns one structured proposal
+without tools. Read its plan ID and digest from status, then call `plan.execute`
+with that exact digest. Model and skill values outside these allowlists fail
+before process launch. The
 worker must bootstrap and join Coordination before its agent CLI starts. Set an
 explicit `team_token_budget` and `manager_token_budget` in `manager.start`, then
-a smaller `token_budget` for every `agent.engage`. Manager and worker
-allocations above the team budget are rejected. Teams created by an older
+a smaller `token_budget` for every planned worker and for synthesis. All
+allocations are validated together before a worker starts. Teams created by an older
 preview remain readable but an external unaccounted session cannot engage
 workers. Stop and recreate them with `manager.start`.
 
-After engaging a child, use the returned `coordination_participant` exactly and
-call `agent.await`. A successful terminal record contains the child's bounded
-completion summary and structured usage. The viewer shows observed/team budget,
-accounting source and completion outcome. Codex currently supplies trustworthy
-token counts. Copilot exposes credits and duration but not tokens, so a
+`plan.execute` reserves every worker plus one synthesizer, starts and awaits the
+workers without another manager model turn, then gives their bounded completion
+artifacts to the separately budgeted tool-free synthesizer. Repeating the same
+plan does not duplicate workers. The viewer shows plan state, observed/team
+budget, accounting source and completion outcome. Codex currently supplies
+trustworthy token counts. Copilot exposes credits and duration but not tokens, so a
 token-strict Copilot worker terminates with `token_accounting_unavailable`
 rather than inventing a conversion.
 
@@ -94,12 +97,11 @@ the manager:
 
 ```text
 Use yukh-team-control. Call manager.start with a 120000-token team budget and a
-20000-token Codex planning-manager budget and no required actions. Ask it for a
-single-pass proposal using only supplied facts. After approving the proposal,
-start a separate operational manager that requires agent.engage and agent.await
-receipts.
-Ask the manager to engage one Codex backend developer with a 50000-token budget,
-wait for its completion, inspect its summary and usage, then report the result.
+20000-token Codex planning-manager budget, no required actions and
+output_contract team-plan-v1. Ask for the minimum specialists needed, explicit
+worker budgets and one small synthesis budget. Show me the proposed plan and its
+digest. After I approve that exact digest, call plan.execute once and report its
+terminal state and exact usage.
 Do not use team.create and do not engage a runtime that cannot provide token
 accounting.
 ```
@@ -107,9 +109,9 @@ accounting.
 The tool-free planning profile measured 14,382 total tokens: 13,735 input,
 including 9,984 cached, and 647 output. The 20,000-token allocation provides a
 bounded margin; it is not a universal estimate. Every operational tool call is
-a separate context round and needs its own justified budget. `team.status`
-returns its newly issued receipt directly to an accounted manager while also
-persisting it.
+a separate context round and needs its own justified budget. Deterministic plan
+execution adds no manager context rounds; only useful workers and the explicit
+final synthesis consume additional model tokens.
 
 Codex managers run without inherited user configuration. Yukh injects only the
 tools required by the manager record; a pure planning turn receives no

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -55,6 +55,18 @@ availability guarantees require later accepted provider profiles.
 
 ## Abuse cases and required response
 
+### Team plan substitution and model-loop exhaustion
+
+A caller may alter a manager proposal, replay execution, select unavailable
+profiles or induce repeated model tool turns. Executable team plans use a closed
+versioned schema, are persisted against the originating manager and team, and
+require their exact server-computed digest at execution. Profiles, agent slots
+and aggregate token allocations are validated before worker creation. Execution
+is single-use and deterministic: it launches and awaits reserved workers without
+calling the planning model again. Final synthesis is a separate tool-free,
+budgeted runtime over bounded public completion artifacts. Mismatch, replay,
+worker failure or incomplete accounting fails closed and remains observable.
+
 ### Prompt and content injection
 
 An inspected file, issue, target response, or tool result instructs the model to
@@ -834,3 +846,18 @@ claim successful collaboration without a bounded public-safe completion and
 accounted usage. Local runtime JSON logs may contain operational detail and
 remain private; only completion, usage counts and stable outcomes enter team
 state and the viewer.
+
+## Accepted deterministic team plan execution — 2026-08-16
+
+- Governing issue: #145
+- Accepted architecture: RFC-0023
+
+A tool-free planning manager may emit one closed plan that is persisted with a
+server-computed digest. Exact-digest execution validates every profile, agent
+slot and aggregate allocation before worker creation. The executor launches and
+awaits reserved workers without another planning-model turn; a separate
+tool-free synthesizer receives only bounded public completion artifacts and has
+its own token allocation. Digest substitution, replay, unavailable profiles,
+over-allocation, worker failure and incomplete accounting fail closed. The
+remaining cost risk is the provider's post-turn usage boundary described by
+RFC-0020.

--- a/packages/conversation-watch/src/watch.ts
+++ b/packages/conversation-watch/src/watch.ts
@@ -1,5 +1,10 @@
 import type { CoordinationOutput } from "../../coordination-preview/src/launcher.js";
-import type { AgentRecord, TeamActionReceipt, TeamRecord } from "../../team-control/src/store.js";
+import type {
+  AgentRecord,
+  TeamActionReceipt,
+  TeamExecutionPlanRecord,
+  TeamRecord,
+} from "../../team-control/src/store.js";
 
 export interface WatchRecord {
   readonly sequence: number;
@@ -26,6 +31,7 @@ export interface TeamSnapshot {
   readonly team: TeamRecord;
   readonly agents: readonly AgentRecord[];
   readonly receipts: readonly TeamActionReceipt[];
+  readonly plans?: readonly TeamExecutionPlanRecord[];
   readonly tokens: {
     readonly budget: number;
     readonly allocated: number;
@@ -177,6 +183,15 @@ export function renderTeamChanges(
             .map((receipt) => receipt.action)
             .join(",") || "none"
         }\n        coordination=${agent.coordination_participant} id=${agent.agent_id} parent=${agent.parent_agent_id ?? (agent.kind === "manager" ? "root" : "manager")}`,
+      );
+    }
+    for (const plan of snapshot.plans ?? []) {
+      const key = `plan:${plan.plan_id}`;
+      const value = `${plan.state}:${plan.worker_agent_ids.join(",")}:${plan.synthesis_agent_id ?? "pending"}:${plan.failure_code ?? "none"}`;
+      if (previous.get(key) === value) continue;
+      previous.set(key, value);
+      lines.push(
+        `PLAN  ${plan.plan_id}  ${plan.state.toUpperCase()}  workers=${plan.worker_agent_ids.length} synthesis=${plan.synthesis_agent_id ?? "pending"}\n      digest=${plan.digest} manager=${plan.manager_agent_id}${plan.failure_code ? ` failure=${plan.failure_code}` : ""}`,
       );
     }
   }

--- a/packages/team-control/src/store.ts
+++ b/packages/team-control/src/store.ts
@@ -7,11 +7,12 @@ import {
   renameSync,
   writeFileSync,
 } from "node:fs";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { isAbsolute, join } from "node:path";
 
 export type AgentRuntime = "codex" | "copilot";
 export type AgentKind = "manager" | "worker";
+export type ManagerOutputContract = "summary" | "team-plan-v1";
 export type TeamState = "active" | "stopped";
 export type AgentState = "defined" | "running" | "completed" | "failed" | "stopped";
 
@@ -32,10 +33,12 @@ export interface AgentCompletion {
     | "succeeded"
     | "agent_exit_nonzero"
     | "completion_missing"
+    | "team_plan_invalid"
     | "required_action_missing"
     | "token_accounting_unavailable"
     | "token_budget_exceeded";
   readonly summary: string;
+  readonly plan_id?: string;
 }
 
 export interface ComposedAgentProfile {
@@ -76,12 +79,50 @@ export interface AgentRecord {
   readonly can_spawn: boolean;
   readonly token_budget: number;
   readonly required_actions: readonly TeamAction[];
+  readonly output_contract?: ManagerOutputContract;
+  readonly model_tool_mode?: "default" | "none";
   readonly usage?: AgentUsage;
   readonly completion?: AgentCompletion;
   readonly state: AgentState;
 }
 
-export type TeamAction = "manager.start" | "team.status" | "agent.engage" | "agent.await";
+export type TeamAction =
+  | "manager.start"
+  | "team.status"
+  | "agent.engage"
+  | "agent.await"
+  | "plan.execute"
+  | "plan.synthesize";
+
+export interface PlannedAgent {
+  readonly runtime: AgentRuntime;
+  readonly role: string;
+  readonly mission: string;
+  readonly model: string;
+  readonly skills: readonly string[];
+  readonly instructions: string;
+  readonly task: string;
+  readonly token_budget: number;
+}
+
+export interface TeamExecutionPlanDocument {
+  readonly schema: 1;
+  readonly workers: readonly PlannedAgent[];
+  readonly synthesis: PlannedAgent;
+}
+
+export interface TeamExecutionPlanRecord {
+  readonly schema: 1;
+  readonly plan_id: string;
+  readonly team_id: string;
+  readonly manager_agent_id: string;
+  readonly digest: `sha-256:${string}`;
+  readonly document: TeamExecutionPlanDocument;
+  readonly state: "proposed" | "reserved" | "running" | "synthesizing" | "completed" | "failed";
+  readonly worker_agent_ids: readonly string[];
+  readonly synthesis_agent_id?: string;
+  readonly failure_code?: string;
+}
 
 export interface TeamActionReceipt {
   readonly schema: 1;
@@ -177,6 +218,7 @@ export class TeamStore {
       readonly task: string;
       readonly token_budget: number;
       readonly required_actions: readonly TeamAction[];
+      readonly output_contract?: ManagerOutputContract;
     },
   ): {
     readonly team: TeamRecord;
@@ -189,6 +231,7 @@ export class TeamStore {
       manager.token_budget > tokenBudget ||
       manager.required_actions.length > 3 ||
       new Set(manager.required_actions).size !== manager.required_actions.length ||
+      (manager.output_contract === "team-plan-v1" && manager.required_actions.length > 0) ||
       manager.required_actions.some(
         (action) => !["team.status", "agent.engage", "agent.await"].includes(action),
       )
@@ -216,6 +259,7 @@ export class TeamStore {
       can_spawn: true,
       token_budget: manager.token_budget,
       required_actions: manager.required_actions,
+      output_contract: manager.output_contract ?? "summary",
       state: "defined",
     };
     this.#write(
@@ -236,6 +280,7 @@ export class TeamStore {
       readonly task: string;
       readonly can_spawn?: boolean;
       readonly token_budget: number;
+      readonly model_tool_mode?: "default" | "none";
     },
   ): AgentRecord {
     const team = this.#readTeam(id);
@@ -287,6 +332,7 @@ export class TeamStore {
       can_spawn: input.can_spawn ?? false,
       token_budget: input.token_budget,
       required_actions: [],
+      model_tool_mode: input.model_tool_mode ?? "default",
       state: "defined",
     };
     this.#write(join(this.#teamDirectory(id), "agents", `${record.agent_id}.json`), record, true);
@@ -297,6 +343,7 @@ export class TeamStore {
     readonly team: TeamRecord;
     readonly agents: readonly AgentRecord[];
     readonly receipts: readonly TeamActionReceipt[];
+    readonly plans: readonly TeamExecutionPlanRecord[];
     readonly tokens: {
       readonly budget: number;
       readonly allocated: number;
@@ -310,12 +357,14 @@ export class TeamStore {
     const team = this.#readTeam(id);
     const agents = this.#readAgents(id);
     const receipts = this.#readReceipts(id);
+    const plans = this.#readPlans(id);
     const allocated = agents.reduce((total, agent) => total + agent.token_budget, 0);
     const observed = agents.reduce((total, agent) => total + (agent.usage?.total_tokens ?? 0), 0);
     return {
       team,
       agents,
       receipts,
+      plans,
       tokens: {
         budget: team.token_budget,
         allocated,
@@ -342,6 +391,120 @@ export class TeamStore {
 
   agent(id: string, worker: string): AgentRecord {
     return this.#readAgent(id, worker);
+  }
+
+  proposePlan(id: string, managerAgentId: string, raw: string): TeamExecutionPlanRecord {
+    const manager = this.#readAgent(id, managerAgentId);
+    if (manager.kind !== "manager" || manager.output_contract !== "team-plan-v1")
+      throw new Error("team_plan_not_expected");
+    if (this.#readPlans(id).some((plan) => plan.manager_agent_id === managerAgentId))
+      throw new Error("team_plan_already_exists");
+    let value: unknown;
+    try {
+      value = JSON.parse(raw);
+    } catch {
+      throw new TypeError("invalid team plan");
+    }
+    const document = this.#validatePlanDocument(value);
+    const digest =
+      `sha-256:${createHash("sha256").update(JSON.stringify(document)).digest("hex")}` as const;
+    const plan: TeamExecutionPlanRecord = {
+      schema: 1,
+      plan_id: `plan-${randomUUID()}`,
+      team_id: id,
+      manager_agent_id: managerAgentId,
+      digest,
+      document,
+      state: "proposed",
+      worker_agent_ids: [],
+    };
+    const directory = join(this.#teamDirectory(id), "plans");
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+    this.#write(join(directory, `${plan.plan_id}.json`), plan, true);
+    return plan;
+  }
+
+  plan(id: string, planId: string): TeamExecutionPlanRecord {
+    if (!/^plan-[0-9a-f-]{36}$/u.test(planId)) throw new TypeError("invalid plan id");
+    return this.#read(
+      join(this.#teamDirectory(id), "plans", `${planId}.json`),
+    ) as TeamExecutionPlanRecord;
+  }
+
+  reservePlan(id: string, planId: string, digest: string): TeamExecutionPlanRecord {
+    const plan = this.plan(id, planId);
+    if (plan.digest !== digest) throw new Error("team_plan_digest_mismatch");
+    if (plan.state !== "proposed") return plan;
+    const manager = this.#readAgent(id, plan.manager_agent_id);
+    if (
+      manager.state !== "completed" ||
+      manager.completion?.outcome !== "succeeded" ||
+      manager.completion.plan_id !== planId
+    )
+      throw new Error("team_plan_manager_incomplete");
+    const status = this.status(id);
+    const allocations = [
+      ...plan.document.workers.map((worker) => worker.token_budget),
+      plan.document.synthesis.token_budget,
+    ];
+    if (status.agents.length + allocations.length > status.team.max_agents)
+      throw new Error("team_agent_limit");
+    if (
+      status.tokens.allocated + allocations.reduce((total, value) => total + value, 0) >
+      status.team.token_budget
+    )
+      throw new Error("team_token_budget_exceeded");
+    const workers = plan.document.workers.map((worker) =>
+      this.spawn(id, {
+        parent_agent_id: plan.manager_agent_id,
+        runtime: worker.runtime,
+        role: worker.role,
+        profile: {
+          schema: 1,
+          mission: worker.mission,
+          model: worker.model,
+          skills: worker.skills,
+          instructions: worker.instructions,
+        },
+        task: worker.task,
+        token_budget: worker.token_budget,
+      }),
+    );
+    const synthesis = plan.document.synthesis;
+    const synthesizer = this.spawn(id, {
+      parent_agent_id: plan.manager_agent_id,
+      runtime: synthesis.runtime,
+      role: synthesis.role,
+      profile: {
+        schema: 1,
+        mission: synthesis.mission,
+        model: synthesis.model,
+        skills: synthesis.skills,
+        instructions: synthesis.instructions,
+      },
+      task: "Awaiting deterministic worker completion artifacts.",
+      token_budget: synthesis.token_budget,
+      model_tool_mode: "none",
+    });
+    return this.updatePlan(id, planId, {
+      state: "reserved",
+      worker_agent_ids: workers.map((worker) => worker.agent_id),
+      synthesis_agent_id: synthesizer.agent_id,
+    });
+  }
+
+  updatePlan(
+    id: string,
+    planId: string,
+    change: Pick<TeamExecutionPlanRecord, "state"> &
+      Partial<
+        Pick<TeamExecutionPlanRecord, "worker_agent_ids" | "synthesis_agent_id" | "failure_code">
+      >,
+  ): TeamExecutionPlanRecord {
+    const current = this.plan(id, planId);
+    const updated: TeamExecutionPlanRecord = { ...current, ...change };
+    this.#write(join(this.#teamDirectory(id), "plans", `${planId}.json`), updated, false);
+    return updated;
   }
 
   transition(id: string, worker: string, state: AgentState): AgentRecord {
@@ -389,7 +552,16 @@ export class TeamStore {
     subjectAgentId?: string,
   ): TeamActionReceipt {
     this.#readTeam(id);
-    if (!["manager.start", "team.status", "agent.engage", "agent.await"].includes(action))
+    if (
+      ![
+        "manager.start",
+        "team.status",
+        "agent.engage",
+        "agent.await",
+        "plan.execute",
+        "plan.synthesize",
+      ].includes(action)
+    )
       throw new TypeError("invalid team action");
     if (actorAgentId) this.#readAgent(id, actorAgentId);
     if (subjectAgentId) this.#readAgent(id, subjectAgentId);
@@ -456,14 +628,79 @@ export class TeamStore {
         "succeeded",
         "agent_exit_nonzero",
         "completion_missing",
+        "team_plan_invalid",
         "required_action_missing",
         "token_accounting_unavailable",
         "token_budget_exceeded",
       ].includes(completion.outcome) ||
       completion.summary.trim() !== completion.summary ||
-      Buffer.byteLength(completion.summary, "utf8") > 4_096
+      Buffer.byteLength(completion.summary, "utf8") > 4_096 ||
+      (completion.plan_id !== undefined && !/^plan-[0-9a-f-]{36}$/u.test(completion.plan_id))
     )
       throw new TypeError("invalid agent completion");
+  }
+
+  #validatePlanDocument(value: unknown): TeamExecutionPlanDocument {
+    const exact = (
+      candidate: unknown,
+      keys: readonly string[],
+    ): candidate is Record<string, unknown> =>
+      typeof candidate === "object" &&
+      candidate !== null &&
+      !Array.isArray(candidate) &&
+      Object.keys(candidate).sort().join("\n") === [...keys].sort().join("\n");
+    if (!exact(value, ["schema", "workers", "synthesis"]) || value.schema !== 1)
+      throw new TypeError("invalid team plan");
+    if (!Array.isArray(value.workers) || value.workers.length < 1 || value.workers.length > 8)
+      throw new TypeError("invalid team plan");
+    const normalize = (candidate: unknown): PlannedAgent => {
+      const keys = [
+        "runtime",
+        "role",
+        "mission",
+        "model",
+        "skills",
+        "instructions",
+        "task",
+        "token_budget",
+      ];
+      if (!exact(candidate, keys)) throw new TypeError("invalid team plan");
+      const profile = {
+        schema: 1 as const,
+        mission: candidate.mission,
+        model: candidate.model,
+        skills: candidate.skills,
+        instructions: candidate.instructions,
+      };
+      if (
+        !["codex", "copilot"].includes(String(candidate.runtime)) ||
+        typeof candidate.role !== "string" ||
+        !roleName.test(candidate.role) ||
+        typeof candidate.task !== "string" ||
+        candidate.task.trim() !== candidate.task ||
+        candidate.task.length < 1 ||
+        candidate.task.length > 4_096 ||
+        !Number.isSafeInteger(candidate.token_budget) ||
+        Number(candidate.token_budget) < 1_000 ||
+        Number(candidate.token_budget) > 2_000_000
+      )
+        throw new TypeError("invalid team plan");
+      this.#validateProfile(profile as ComposedAgentProfile);
+      return {
+        runtime: candidate.runtime as AgentRuntime,
+        role: candidate.role,
+        mission: candidate.mission as string,
+        model: candidate.model as string,
+        skills: candidate.skills as readonly string[],
+        instructions: candidate.instructions as string,
+        task: candidate.task,
+        token_budget: candidate.token_budget as number,
+      };
+    };
+    const workers = value.workers.map(normalize);
+    if (new Set(workers.map((worker) => worker.role)).size !== workers.length)
+      throw new TypeError("invalid team plan");
+    return { schema: 1, workers, synthesis: normalize(value.synthesis) };
   }
 
   #validateUsage(agent: AgentRecord, usage: AgentUsage): void {
@@ -530,9 +767,22 @@ export class TeamStore {
     }
   }
 
+  #readPlans(id: string): readonly TeamExecutionPlanRecord[] {
+    const directory = join(this.#teamDirectory(id), "plans");
+    try {
+      return readdirSync(directory)
+        .filter((name) => /^plan-[0-9a-f-]{36}\.json$/u.test(name))
+        .sort()
+        .map((name) => this.#read(join(directory, name)) as TeamExecutionPlanRecord);
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
+      throw error;
+    }
+  }
+
   #read(path: string): unknown {
     const raw = readFileSync(path, "utf8");
-    if (raw.length < 2 || raw.length > 16_384) throw new Error("invalid team state");
+    if (raw.length < 2 || raw.length > 65_536) throw new Error("invalid team state");
     return JSON.parse(raw) as unknown;
   }
 

--- a/test/contracts/team-execution-plan-v1.test.mjs
+++ b/test/contracts/team-execution-plan-v1.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import Ajv2020 from "ajv/dist/2020.js";
+
+const schema = JSON.parse(
+  readFileSync(
+    new URL("../../contracts/team-execution-plan-v1.schema.json", import.meta.url),
+    "utf8",
+  ),
+);
+const validate = new Ajv2020({ allErrors: true, strict: true }).compile(schema);
+const agent = {
+  runtime: "codex",
+  role: "backend-developer",
+  mission: "Implement one bounded increment",
+  model: "default",
+  skills: ["testing"],
+  instructions: "Inspect relevant files, implement and test.",
+  task: "Deliver the increment.",
+  token_budget: 20_000,
+};
+
+test("team execution plan contract accepts a closed bounded proposal", () => {
+  assert.equal(
+    validate({
+      schema: 1,
+      workers: [agent],
+      synthesis: { ...agent, role: "delivery-synthesizer", skills: [] },
+    }),
+    true,
+    JSON.stringify(validate.errors),
+  );
+});
+
+test("team execution plan contract rejects unknown fields and unbounded allocations", () => {
+  assert.equal(
+    validate({
+      schema: 1,
+      workers: [{ ...agent, shell: "unrestricted" }],
+      synthesis: { ...agent, role: "delivery-synthesizer", token_budget: 2_000_001 },
+    }),
+    false,
+  );
+  assert.ok(validate.errors?.some((error) => error.keyword === "additionalProperties"));
+  assert.ok(validate.errors?.some((error) => error.keyword === "maximum"));
+});

--- a/test/runtime/conversation-watch.test.ts
+++ b/test/runtime/conversation-watch.test.ts
@@ -157,6 +157,43 @@ test("watch exposes manager accounting and receipt-backed actions", () => {
             outcome: "succeeded",
           },
         ],
+        plans: [
+          {
+            schema: 1,
+            plan_id: "plan-9776aa63-2b13-4d98-ab2b-5b0c8b0354aa",
+            team_id: teamID,
+            manager_agent_id: managerID,
+            digest: `sha-256:${"1".repeat(64)}`,
+            document: {
+              schema: 1,
+              workers: [
+                {
+                  runtime: "codex",
+                  role: "backend-developer",
+                  mission: "Implement",
+                  model: "default",
+                  skills: [],
+                  instructions: "Implement and test.",
+                  task: "Deliver one increment.",
+                  token_budget: 20_000,
+                },
+              ],
+              synthesis: {
+                runtime: "codex",
+                role: "delivery-synthesizer",
+                mission: "Summarize",
+                model: "default",
+                skills: [],
+                instructions: "Use verified evidence.",
+                task: "Summarize the delivery.",
+                token_budget: 5_000,
+              },
+            },
+            state: "running",
+            worker_agent_ids: ["worker-3dc1c6d1-ac73-4f39-9d48-301123385534"],
+            synthesis_agent_id: "worker-4dc1c6d1-ac73-4f39-9d48-301123385534",
+          },
+        ],
         tokens: {
           budget: 60_000,
           allocated: 20_000,
@@ -173,6 +210,8 @@ test("watch exposes manager accounting and receipt-backed actions", () => {
   assert.match(changes, /MANAGER  delivery-manager  COMPLETED/u);
   assert.match(changes, /input=5000 cached=3000 output=500 reasoning=100/u);
   assert.match(changes, /required=team.status receipts=team.status/u);
+  assert.match(changes, /PLAN  plan-9776aa63-2b13-4d98-ab2b-5b0c8b0354aa  RUNNING/u);
+  assert.match(changes, /workers=1 synthesis=worker-4dc1c6d1/u);
 });
 
 test("watch accepts bounded dynamic team identities", () => {

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -11,8 +11,46 @@ import { RuntimeOutput } from "../../packages/team-control/src/runtime-output.js
 import {
   assertProfileAvailable,
   awaitAgent,
+  executePlan,
   readTeamStatus,
 } from "../../apps/team-control/src/server.js";
+
+const usage = {
+  schema: 1 as const,
+  source: "codex-json-v1" as const,
+  input_tokens: 100,
+  cached_input_tokens: 20,
+  output_tokens: 20,
+  reasoning_output_tokens: 5,
+  total_tokens: 120,
+  budget_outcome: "within" as const,
+};
+
+const planDocument = (workerBudget = 2_000, synthesisBudget = 2_000) => ({
+  schema: 1,
+  workers: [
+    {
+      runtime: "codex",
+      role: "backend-developer",
+      mission: "Implement the bounded backend increment",
+      model: "default",
+      skills: [],
+      instructions: "Inspect only relevant files, implement and test the requested increment.",
+      task: "Implement and verify the backend increment.",
+      token_budget: workerBudget,
+    },
+  ],
+  synthesis: {
+    runtime: "codex",
+    role: "delivery-synthesizer",
+    mission: "Produce the final evidence-based delivery summary",
+    model: "default",
+    skills: [],
+    instructions: "Use only supplied verified completion artifacts and remain concise.",
+    task: "Synthesize outcome, remaining gaps and the next action.",
+    token_budget: synthesisBudget,
+  },
+});
 
 const workerMain = fileURLToPath(new URL("../../apps/team-worker/src/main.ts", import.meta.url));
 const tsxLoader = fileURLToPath(import.meta.resolve("tsx"));
@@ -270,6 +308,33 @@ test("managed team rejects a manager budget above the team budget", async () => 
           task: "Plan",
           token_budget: 11_000,
           required_actions: [],
+        }),
+      /invalid manager definition/u,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("structured planning contract rejects model-facing manager actions", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-plan-tools-denied-")));
+  try {
+    const store = new TeamStore(root);
+    assert.throws(
+      () =>
+        store.createManaged("Plan without tool loops", "codex", 3, 1, 10_000, {
+          role: "delivery-manager",
+          profile: {
+            schema: 1,
+            mission: "Return one structured plan",
+            model: "default",
+            skills: [],
+            instructions: "Do not invoke operational tools.",
+          },
+          task: "Plan",
+          token_budget: 2_000,
+          required_actions: ["team.status"],
+          output_contract: "team-plan-v1",
         }),
       /invalid manager definition/u,
     );
@@ -870,6 +935,300 @@ printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_inpu
       store.agent(managed.team.team_id, managed.manager.agent_id).completion?.outcome,
       "succeeded",
     );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("structured planning manager persists a closed digest-bound plan", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-structured-plan-")));
+  try {
+    const executable = join(root, "agent-cli");
+    const argumentsFile = join(root, "agent-arguments");
+    const launcher = join(root, "launcher");
+    const support = join(root, "support.mjs");
+    const document = JSON.stringify(planDocument());
+    await writeFile(
+      executable,
+      `#!/bin/sh
+printf '%s\n' "$@" >${argumentsFile}
+printf '%s\n' ${JSON.stringify(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: document } }))}
+printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":20,"reasoning_output_tokens":5}}'
+`,
+      { mode: 0o700 },
+    );
+    await writeFile(
+      launcher,
+      '#!/bin/sh\ncat >/dev/null\nprintf \'{"schema":1,"status":"ok","command":"test"}\\n\'\n',
+      { mode: 0o700 },
+    );
+    await writeFile(support, "", { mode: 0o600 });
+    const store = new TeamStore(root);
+    const managed = store.createManaged("Plan deterministically", "codex", 4, 1, 10_000, {
+      role: "delivery-manager",
+      profile: {
+        schema: 1,
+        mission: "Return one executable structured plan",
+        model: "default",
+        skills: [],
+        instructions: "Select only necessary specialists.",
+      },
+      task: "Plan one increment",
+      token_budget: 2_000,
+      required_actions: [],
+      output_contract: "team-plan-v1",
+    });
+    const child = spawn(
+      process.execPath,
+      ["--import", tsxLoader, workerMain, managed.team.team_id, managed.manager.agent_id],
+      {
+        cwd: root,
+        stdio: "ignore",
+        env: {
+          HOME: process.env.HOME ?? "",
+          PATH: process.env.PATH ?? "/usr/bin:/bin",
+          YUKH_TEAM_WORKSPACE: root,
+          YUKH_COORDINATION_LAUNCHER: launcher,
+          YUKH_COORDINATION_MCP_MAIN: support,
+          YUKH_TEAM_CONTROL_MCP_MAIN: support,
+          YUKH_CODEX_EXECUTABLE: executable,
+          YUKH_COPILOT_EXECUTABLE: executable,
+        },
+      },
+    );
+    assert.equal(await new Promise<number | null>((resolve) => child.once("close", resolve)), 0);
+    const manager = store.agent(managed.team.team_id, managed.manager.agent_id);
+    assert.equal(manager.completion?.outcome, "succeeded");
+    assert.match(manager.completion?.plan_id ?? "", /^plan-/u);
+    const plan = store.plan(managed.team.team_id, manager.completion?.plan_id ?? "invalid");
+    assert.match(plan.digest, /^sha-256:[0-9a-f]{64}$/u);
+    assert.equal(plan.state, "proposed");
+    const runtimeArguments = await readFile(argumentsFile, "utf8");
+    assert.match(runtimeArguments, /--output-schema/u);
+    assert.doesNotMatch(runtimeArguments, /mcp_servers\.yukh-team-control/u);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("deterministic executor reserves, runs, awaits and synthesizes without manager relaunch", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-plan-executor-")));
+  try {
+    const store = new TeamStore(root);
+    const managed = store.createManaged("Execute once", "codex", 4, 1, 10_000, {
+      role: "delivery-manager",
+      profile: {
+        schema: 1,
+        mission: "Plan a bounded increment",
+        model: "default",
+        skills: [],
+        instructions: "Return a closed plan.",
+      },
+      task: "Plan",
+      token_budget: 2_000,
+      required_actions: [],
+      output_contract: "team-plan-v1",
+    });
+    store.transition(managed.team.team_id, managed.manager.agent_id, "running");
+    const plan = store.proposePlan(
+      managed.team.team_id,
+      managed.manager.agent_id,
+      JSON.stringify(planDocument()),
+    );
+    store.finish(
+      managed.team.team_id,
+      managed.manager.agent_id,
+      {
+        schema: 1,
+        outcome: "succeeded",
+        summary: JSON.stringify(planDocument()),
+        plan_id: plan.plan_id,
+      },
+      usage,
+    );
+    const launches: string[] = [];
+    const supervisor = {
+      launch(agent: ReturnType<TeamStore["agent"]>) {
+        launches.push(agent.agent_id);
+        store.transition(agent.team_id, agent.agent_id, "running");
+        queueMicrotask(() =>
+          store.finish(
+            agent.team_id,
+            agent.agent_id,
+            { schema: 1, outcome: "succeeded", summary: `${agent.role} completed` },
+            usage,
+          ),
+        );
+        return { pid: 1, log: "test" };
+      },
+    };
+    const options = {
+      models: { codex: new Set(["default"]), copilot: new Set(["default"]) },
+      skills: { codex: new Set<string>(), copilot: new Set<string>() },
+    };
+    const completed = await executePlan(
+      store,
+      supervisor,
+      options,
+      managed.team.team_id,
+      plan.plan_id,
+      plan.digest,
+      2_000,
+    );
+    assert.equal(completed.state, "completed");
+    assert.equal(launches.length, 2);
+    assert.ok(!launches.includes(managed.manager.agent_id));
+    assert.equal(
+      store.agent(managed.team.team_id, completed.synthesis_agent_id ?? "invalid").model_tool_mode,
+      "none",
+    );
+    assert.deepEqual(
+      store
+        .status(managed.team.team_id)
+        .receipts.map((receipt) => receipt.action)
+        .sort(),
+      ["plan.execute", "plan.synthesize"],
+    );
+    assert.equal(store.status(managed.team.team_id).tokens.allocated, 6_000);
+    assert.equal(store.status(managed.team.team_id).tokens.observed, 360);
+    await executePlan(
+      store,
+      supervisor,
+      options,
+      managed.team.team_id,
+      plan.plan_id,
+      plan.digest,
+      2_000,
+    );
+    assert.equal(launches.length, 2);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("deterministic executor fails before worker creation for malformed, stale and unavailable plans", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-plan-denials-")));
+  try {
+    const store = new TeamStore(root);
+    const managed = store.createManaged("Deny unsafe plan", "codex", 4, 1, 10_000, {
+      role: "delivery-manager",
+      profile: {
+        schema: 1,
+        mission: "Plan safely",
+        model: "default",
+        skills: [],
+        instructions: "Use a closed plan.",
+      },
+      task: "Plan",
+      token_budget: 2_000,
+      required_actions: [],
+      output_contract: "team-plan-v1",
+    });
+    assert.throws(
+      () =>
+        store.proposePlan(
+          managed.team.team_id,
+          managed.manager.agent_id,
+          JSON.stringify({ ...planDocument(), unexpected: true }),
+        ),
+      /invalid team plan/u,
+    );
+    store.transition(managed.team.team_id, managed.manager.agent_id, "running");
+    const unavailable = planDocument();
+    unavailable.workers[0]!.model = "unavailable";
+    const plan = store.proposePlan(
+      managed.team.team_id,
+      managed.manager.agent_id,
+      JSON.stringify(unavailable),
+    );
+    store.finish(
+      managed.team.team_id,
+      managed.manager.agent_id,
+      {
+        schema: 1,
+        outcome: "succeeded",
+        summary: JSON.stringify(unavailable),
+        plan_id: plan.plan_id,
+      },
+      usage,
+    );
+    const supervisor = { launch: () => ({ pid: 1, log: "test" }) };
+    const options = {
+      models: { codex: new Set(["default"]), copilot: new Set(["default"]) },
+      skills: { codex: new Set<string>(), copilot: new Set<string>() },
+    };
+    await assert.rejects(
+      executePlan(
+        store,
+        supervisor,
+        options,
+        managed.team.team_id,
+        plan.plan_id,
+        `sha-256:${"0".repeat(64)}`,
+        2_000,
+      ),
+      /team_plan_digest_mismatch/u,
+    );
+    await assert.rejects(
+      executePlan(
+        store,
+        supervisor,
+        options,
+        managed.team.team_id,
+        plan.plan_id,
+        plan.digest,
+        2_000,
+      ),
+      /agent_model_unavailable/u,
+    );
+    assert.equal(store.status(managed.team.team_id).agents.length, 1);
+    assert.equal(store.plan(managed.team.team_id, plan.plan_id).state, "proposed");
+
+    const overManaged = store.createManaged("Deny over-allocation", "codex", 4, 1, 10_000, {
+      role: "delivery-manager",
+      profile: {
+        schema: 1,
+        mission: "Plan within the aggregate budget",
+        model: "default",
+        skills: [],
+        instructions: "Reserve planning, work and synthesis.",
+      },
+      task: "Plan",
+      token_budget: 2_000,
+      required_actions: [],
+      output_contract: "team-plan-v1",
+    });
+    store.transition(overManaged.team.team_id, overManaged.manager.agent_id, "running");
+    const oversizedDocument = planDocument(5_000, 5_000);
+    const oversizedPlan = store.proposePlan(
+      overManaged.team.team_id,
+      overManaged.manager.agent_id,
+      JSON.stringify(oversizedDocument),
+    );
+    store.finish(
+      overManaged.team.team_id,
+      overManaged.manager.agent_id,
+      {
+        schema: 1,
+        outcome: "succeeded",
+        summary: JSON.stringify(oversizedDocument),
+        plan_id: oversizedPlan.plan_id,
+      },
+      usage,
+    );
+    await assert.rejects(
+      executePlan(
+        store,
+        supervisor,
+        options,
+        overManaged.team.team_id,
+        oversizedPlan.plan_id,
+        oversizedPlan.digest,
+        2_000,
+      ),
+      /team_token_budget_exceeded/u,
+    );
+    assert.equal(store.status(overManaged.team.team_id).agents.length, 1);
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #145

## What changed
- adds the accepted closed `team-plan-v1` contract and digest-bound persisted proposal
- adds `plan.status` and idempotent `plan.execute`
- validates all profiles, agent slots and aggregate budgets before worker creation
- launches and awaits workers deterministically without another planning-manager turn
- runs one separately budgeted tool-free synthesis over bounded verified completions
- exposes plan state and receipts in team status and the conversation watcher
- updates the guide, RFC and threat model

## Why
Operational engage/await model turns spent tokens without adding reasoning. Control flow is now deterministic; model tokens are reserved for planning, useful worker execution and one explicit synthesis.

## Validation
- `npm test`: 259 tests passed
- `npm run build`
- `npm run typecheck`
- `npm run format:check`
- `git diff --check`

## Security and failure paths
Unknown plan fields, altered digests, unavailable models or skills, insufficient agent slots, aggregate over-allocation, worker failure, timeout and oversized synthesis input fail closed. Replay does not duplicate workers.