### PR TITLE
Align team plans with Codex output schema

### DIFF
--- a/contracts/team-execution-plan-v1.schema.json
+++ b/contracts/team-execution-plan-v1.schema.json
@@ -1,24 +1,19 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://yukh.dev/contracts/team-execution-plan-v1.schema.json",
   "title": "Yukh deterministic team execution plan v1",
   "type": "object",
   "additionalProperties": false,
   "required": ["schema", "workers", "synthesis"],
   "properties": {
-    "schema": { "const": 1 },
+    "schema": { "type": "integer", "const": 1 },
     "workers": {
       "type": "array",
-      "minItems": 1,
-      "maxItems": 8,
       "items": { "$ref": "#/$defs/agent" }
     },
     "synthesis": { "$ref": "#/$defs/agent" }
   },
   "$defs": {
     "token": {
-      "type": "string",
-      "pattern": "^[a-z0-9][a-z0-9._:-]{0,63}$"
+      "type": "string"
     },
     "agent": {
       "type": "object",
@@ -34,23 +29,17 @@
         "token_budget"
       ],
       "properties": {
-        "runtime": { "enum": ["codex", "copilot"] },
-        "role": { "type": "string", "pattern": "^[a-z][a-z0-9-]{0,31}$" },
-        "mission": { "type": "string", "minLength": 1, "maxLength": 1024 },
+        "runtime": { "type": "string", "enum": ["codex", "copilot"] },
+        "role": { "type": "string" },
+        "mission": { "type": "string" },
         "model": { "$ref": "#/$defs/token" },
         "skills": {
           "type": "array",
-          "maxItems": 16,
-          "uniqueItems": true,
           "items": { "$ref": "#/$defs/token" }
         },
-        "instructions": { "type": "string", "minLength": 1, "maxLength": 4096 },
-        "task": { "type": "string", "minLength": 1, "maxLength": 4096 },
-        "token_budget": {
-          "type": "integer",
-          "minimum": 1000,
-          "maximum": 2000000
-        }
+        "instructions": { "type": "string" },
+        "task": { "type": "string" },
+        "token_budget": { "type": "integer" }
       }
     }
   }

--- a/packages/team-control/src/store.ts
+++ b/packages/team-control/src/store.ts
@@ -685,7 +685,11 @@ export class TeamStore {
         Number(candidate.token_budget) > 2_000_000
       )
         throw new TypeError("invalid team plan");
-      this.#validateProfile(profile as ComposedAgentProfile);
+      try {
+        this.#validateProfile(profile as ComposedAgentProfile);
+      } catch {
+        throw new TypeError("invalid team plan");
+      }
       return {
         runtime: candidate.runtime as AgentRuntime,
         role: candidate.role,

--- a/test/contracts/team-execution-plan-v1.test.mjs
+++ b/test/contracts/team-execution-plan-v1.test.mjs
@@ -21,7 +21,25 @@ const agent = {
   token_budget: 20_000,
 };
 
-test("team execution plan contract accepts a closed bounded proposal", () => {
+test("team execution plan response schema uses the supported closed subset", () => {
+  const unsupported = new Set([
+    "uniqueItems",
+    "pattern",
+    "minLength",
+    "maxLength",
+    "minimum",
+    "maximum",
+    "minItems",
+    "maxItems",
+  ]);
+  const visit = (value) => {
+    if (!value || typeof value !== "object") return;
+    for (const [key, child] of Object.entries(value)) {
+      assert.equal(unsupported.has(key), false, `unsupported response-schema keyword: ${key}`);
+      visit(child);
+    }
+  };
+  visit(schema);
   assert.equal(
     validate({
       schema: 1,
@@ -33,15 +51,14 @@ test("team execution plan contract accepts a closed bounded proposal", () => {
   );
 });
 
-test("team execution plan contract rejects unknown fields and unbounded allocations", () => {
+test("team execution plan response schema rejects unknown fields", () => {
   assert.equal(
     validate({
       schema: 1,
       workers: [{ ...agent, shell: "unrestricted" }],
-      synthesis: { ...agent, role: "delivery-synthesizer", token_budget: 2_000_001 },
+      synthesis: { ...agent, role: "delivery-synthesizer" },
     }),
     false,
   );
   assert.ok(validate.errors?.some((error) => error.keyword === "additionalProperties"));
-  assert.ok(validate.errors?.some((error) => error.keyword === "maximum"));
 });

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -1133,6 +1133,17 @@ test("deterministic executor fails before worker creation for malformed, stale a
         ),
       /invalid team plan/u,
     );
+    const duplicateSkills = planDocument();
+    (duplicateSkills.workers[0]!.skills as string[]).push("testing", "testing");
+    assert.throws(
+      () =>
+        store.proposePlan(
+          managed.team.team_id,
+          managed.manager.agent_id,
+          JSON.stringify(duplicateSkills),
+        ),
+      /invalid team plan/u,
+    );
     store.transition(managed.team.team_id, managed.manager.agent_id, "running");
     const unavailable = planDocument();
     unavailable.workers[0]!.model = "unavailable";


### PR DESCRIPTION
Closes #147

## What changed
- reduces the model-facing team-plan schema to the strict structured-output subset accepted by Codex
- keeps every semantic bound and duplicate-skill check in the server-side validator
- normalizes invalid composed profiles to the closed `invalid team plan` outcome
- adds response-schema compatibility and duplicate-skill regressions

## Root cause
The first real qualification was rejected before inference because Codex structured output does not accept `uniqueItems` and requires explicit property types.

## Real qualification evidence
After this fix the manager produced and persisted a valid digest-bound plan. Planning used 14,717 tokens within its 20,000 budget. The later worker run exposed a separate post-turn budget-enforcement defect tracked independently; synthesis was not launched and the team was stopped.

## Validation
- `npm test`: 259 tests passed
- `npm run typecheck`
- `npm run build`
- `npm run format:check`
- `git diff --check`
