### PR TITLE
Enforce preemptive worker runtime bounds

### DIFF
--- a/.context/rfcs/RFC-0024-preemptive-agent-runtime-bounds.md
+++ b/.context/rfcs/RFC-0024-preemptive-agent-runtime-bounds.md
@@ -1,0 +1,65 @@
+# RFC-0024 — Preemptive agent runtime bounds
+
+- Status: Accepted
+- Authors: Nomed with Codex implementation support
+- Created: 2026-08-16
+- Accepted: 2026-08-16
+- Decider: project owner
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/149
+- Depends on: RFC-0020, RFC-0022 and RFC-0023
+
+## Evidence
+
+The first real deterministic self-hosting execution proved that post-turn token
+accounting is not an expense control. Planning completed at 14,717 of 20,000
+tokens. One worker then reported 344,007 tokens against a 45,000 allocation in
+one provider turn containing eleven command executions. Input was 340,832,
+including 295,936 cached. The synthesizer never launched and the team was
+stopped.
+
+## Decision
+
+Every new managed agent declares a server-validated maximum command count and
+wall-clock runtime. The wrapper counts structured `command_execution` start
+events and terminates the owned runtime process group immediately when a command
+beyond the declared count starts. It also terminates the process group when the runtime
+deadline expires. These are preemptive expense proxies; exact token accounting
+remains the post-turn evidence defined by RFC-0020.
+
+Deterministic plans also declare a model tool mode per agent: `none`,
+`coordination`, or `team`. `none` exposes no Yukh MCP, `coordination` exposes only
+Coordination, and `team` exposes the bounded team-control surface plus
+Coordination. Synthesis must use `none`. Independent workers should use `none`;
+communication or delegation is explicit plan data rather than an automatic
+worker default.
+
+The deterministic executor is restart-resumable. Re-execution of the same exact
+digest continues reserved, running, or synthesizing state by inspecting
+persistent agent states. It launches only defined agents, awaits already-running
+ones, converges terminal worker failure to failed plan state, and never duplicates
+a completed or running worker.
+
+## Outcomes and observation
+
+`command_budget_exceeded` and `runtime_deadline_exceeded` are distinct terminal
+agent outcomes. Status and the conversation watcher expose command and deadline
+bounds without retaining command text. A preemptively terminated runtime may not
+have exact token usage because the provider reports only at turn completion; it
+must never be reported as zero consumption.
+
+## Qualification
+
+- terminate on command N+1 start and exercise zero-command agents;
+- terminate at the wall-clock deadline and kill the owned process group;
+- prove tool modes produce exactly the intended MCP configuration;
+- require closed bounds in structured plans and reject unknown or excessive
+  values before worker creation;
+- resume reserved, running and synthesizing plans without duplicate launch;
+- converge a terminal failed worker to failed plan state without synthesis;
+- do not perform another real model qualification until all tests and CI pass.
+
+## Rollback
+
+Disable dynamic model execution. Removing preemptive bounds while retaining
+post-turn accounting is forbidden because the real qualification proved that it
+can incur unbounded cost before detection.

--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -71,19 +71,21 @@ export async function executePlan(
 ) {
   let plan = store.plan(teamId, planId);
   if (plan.digest !== digest) throw new Error("team_plan_digest_mismatch");
-  if (["running", "synthesizing", "completed", "failed", "reserved"].includes(plan.state))
-    return plan;
+  if (["completed", "failed"].includes(plan.state)) return plan;
   for (const profile of [...plan.document.workers, plan.document.synthesis])
     assertProfileAvailable(options, profile.runtime, profile.model, profile.skills);
-  plan = store.reservePlan(teamId, planId, digest);
+  if (plan.state === "proposed") plan = store.reservePlan(teamId, planId, digest);
   const deadline = Date.now() + timeoutMs;
   try {
-    for (const agentId of plan.worker_agent_ids) {
-      const agent = store.agent(teamId, agentId);
-      supervisor.launch(agent);
-      store.receipt(teamId, "plan.execute", undefined, agentId);
+    if (plan.state === "reserved") {
+      for (const agentId of plan.worker_agent_ids) {
+        const agent = store.agent(teamId, agentId);
+        if (agent.state !== "defined") continue;
+        supervisor.launch(agent);
+        store.receipt(teamId, "plan.execute", undefined, agentId);
+      }
+      plan = store.updatePlan(teamId, planId, { state: "running" });
     }
-    plan = store.updatePlan(teamId, planId, { state: "running" });
     const completed: AgentRecord[] = [];
     for (const agentId of plan.worker_agent_ids) {
       const terminal = await awaitAgent(store, teamId, agentId, Math.max(0, deadline - Date.now()));
@@ -108,11 +110,15 @@ export async function executePlan(
     const synthesisTask = `${synthesis.task}\n\nUse only these verified worker completion artifacts:\n${synthesisInput}`;
     if (Buffer.byteLength(synthesisTask, "utf8") > 4_096)
       throw new Error("team_plan_synthesis_input_too_large");
-    store.assign(teamId, synthesisAgentId, synthesisTask);
-    plan = store.updatePlan(teamId, planId, { state: "synthesizing" });
-    const synthesizer = store.agent(teamId, synthesisAgentId);
-    supervisor.launch(synthesizer);
-    store.receipt(teamId, "plan.synthesize", undefined, synthesizer.agent_id);
+    let synthesizer = store.agent(teamId, synthesisAgentId);
+    if (plan.state === "running") {
+      if (synthesizer.state !== "defined") throw new Error("team_plan_state_invalid");
+      store.assign(teamId, synthesisAgentId, synthesisTask);
+      plan = store.updatePlan(teamId, planId, { state: "synthesizing" });
+      synthesizer = store.agent(teamId, synthesisAgentId);
+      supervisor.launch(synthesizer);
+      store.receipt(teamId, "plan.synthesize", undefined, synthesizer.agent_id);
+    }
     const terminal = await awaitAgent(
       store,
       teamId,
@@ -151,6 +157,8 @@ export function readTeamStatus(
           readonly role: string;
           readonly state: "defined" | "running" | "completed" | "failed" | "stopped";
           readonly token_budget: number;
+          readonly max_commands: number;
+          readonly timeout_ms: number;
           readonly observed_tokens: number;
           readonly completion: string;
         }[];
@@ -176,6 +184,8 @@ export function readTeamStatus(
         role: agent.role,
         state: agent.state,
         token_budget: agent.token_budget,
+        max_commands: agent.max_commands ?? 8,
+        timeout_ms: agent.timeout_ms ?? 300_000,
         observed_tokens: agent.usage?.total_tokens ?? 0,
         completion: agent.completion?.outcome ?? "pending",
       })),
@@ -230,6 +240,8 @@ export function createTeamControlServer(
           max_depth: z.number().int().min(1).max(5).default(3),
           team_token_budget: z.number().int().min(1_000).max(10_000_000),
           manager_token_budget: z.number().int().min(1_000).max(2_000_000),
+          max_commands: z.number().int().min(0).max(32).default(8),
+          runtime_timeout_ms: z.number().int().min(5_000).max(900_000).default(300_000),
         })
         .strict(),
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
@@ -258,6 +270,8 @@ export function createTeamControlServer(
             token_budget: input.manager_token_budget,
             required_actions: input.required_actions,
             output_contract: input.output_contract,
+            max_commands: input.max_commands,
+            timeout_ms: input.runtime_timeout_ms,
           },
         );
         const runtime = supervisor.launch(managed.manager);
@@ -431,6 +445,9 @@ export function createTeamControlServer(
           task: z.string().min(1).max(4_096),
           can_spawn: z.boolean().default(false),
           token_budget: z.number().int().min(1_000).max(2_000_000),
+          tool_mode: z.enum(["none", "coordination", "team"]).default("team"),
+          max_commands: z.number().int().min(0).max(32).default(8),
+          runtime_timeout_ms: z.number().int().min(5_000).max(900_000).default(300_000),
         })
         .strict(),
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
@@ -472,6 +489,9 @@ export function createTeamControlServer(
           task: input.task,
           can_spawn: input.can_spawn,
           token_budget: input.token_budget,
+          model_tool_mode: input.tool_mode,
+          max_commands: input.max_commands,
+          timeout_ms: input.runtime_timeout_ms,
         });
         const runtime = supervisor.launch(agent);
         const receipt = store.receipt(
@@ -517,6 +537,8 @@ export function createTeamControlServer(
           task: z.string().min(1).max(4_096),
           can_spawn: z.boolean().default(false),
           token_budget: z.number().int().min(1_000).max(2_000_000),
+          max_commands: z.number().int().min(0).max(32).default(8),
+          runtime_timeout_ms: z.number().int().min(5_000).max(900_000).default(300_000),
         })
         .strict(),
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
@@ -541,6 +563,8 @@ export function createTeamControlServer(
         task: input.task,
         can_spawn: input.can_spawn,
         token_budget: input.token_budget,
+        max_commands: input.max_commands,
+        timeout_ms: input.runtime_timeout_ms,
       });
       const runtime = supervisor.launch(agent);
       return result({ agent, ...runtime });

--- a/apps/team-worker/src/main.ts
+++ b/apps/team-worker/src/main.ts
@@ -26,20 +26,26 @@ const mcpEnv = {
   YUKH_COORDINATION_LAUNCHER: launcher,
 };
 const profile = agent.profile;
-const modelToolsDisabled = agent.model_tool_mode === "none";
+const modelToolMode = agent.model_tool_mode ?? "default";
 const requiredActions = agent.required_actions.join(", ") || "none";
 const modelUsesCoordination =
-  !modelToolsDisabled &&
-  (agent.kind === "worker" || agent.required_actions.some((action) => action !== "team.status"));
+  modelToolMode === "coordination" ||
+  modelToolMode === "team" ||
+  (modelToolMode === "default" &&
+    (agent.kind === "worker" || agent.required_actions.some((action) => action !== "team.status")));
 const modelTeamTools = [
   ...new Set(
-    modelToolsDisabled
+    modelToolMode === "none" || modelToolMode === "coordination"
       ? []
-      : agent.kind === "manager"
-        ? agent.required_actions
-        : agent.can_spawn
+      : modelToolMode === "team"
+        ? agent.can_spawn
           ? ["team.status", "agent.status", "agent.engage", "agent.await"]
-          : ["team.status", "agent.status"],
+          : ["team.status", "agent.status"]
+        : agent.kind === "manager"
+          ? agent.required_actions
+          : agent.can_spawn
+            ? ["team.status", "agent.status", "agent.engage", "agent.await"]
+            : ["team.status", "agent.status"],
   ),
 ];
 const modelUsesTeamControl = modelTeamTools.length > 0;
@@ -53,7 +59,7 @@ const outputInstruction =
   agent.output_contract === "team-plan-v1"
     ? "Return only the JSON team execution plan required by the supplied output schema. Include the minimum specialists needed and one concise delivery synthesizer. Do not wrap JSON in Markdown."
     : "End with one concise public-safe completion summary of at most 4096 UTF-8 bytes; the wrapper persists that final response.";
-const prompt = `You are ${agent.role}, ${agent.kind} ${agent.agent_id} in team ${agent.team_id}.${profile ? ` Mission: ${profile.mission}\nOperating instructions: ${profile.instructions}\nRequired skills: ${profile.skills.length > 0 ? profile.skills.join(", ") : "none"}.` : ""}\nComplete this task: ${agent.task}\nToken budget: ${agent.token_budget} total input plus output tokens. Keep inspection and tool output bounded. The team already exists: do not call team.create. ${teamControlInstruction} When engaging a child, use the returned coordination_participant exactly and never add another agent: prefix. Wait for each child with agent.await and inspect its completion before synthesizing. ${coordinationInstruction} ${outputInstruction} You may create a bounded child only when explicitly delegated.`;
+const prompt = `You are ${agent.role}, ${agent.kind} ${agent.agent_id} in team ${agent.team_id}.${profile ? ` Mission: ${profile.mission}\nOperating instructions: ${profile.instructions}\nRequired skills: ${profile.skills.length > 0 ? profile.skills.join(", ") : "none"}.` : ""}\nComplete this task: ${agent.task}\nToken budget: ${agent.token_budget} total input plus output tokens. Runtime bounds: at most ${agent.max_commands ?? 8} command executions and ${agent.timeout_ms ?? 300_000} milliseconds. Keep inspection and tool output bounded. The team already exists: do not call team.create. ${teamControlInstruction} When engaging a child, use the returned coordination_participant exactly and never add another agent: prefix. Wait for each child with agent.await and inspect its completion before synthesizing. ${coordinationInstruction} ${outputInstruction} You may create a bounded child only when explicitly delegated.`;
 const planSchema = fileURLToPath(
   new URL("../../../contracts/team-execution-plan-v1.schema.json", import.meta.url),
 );
@@ -222,11 +228,13 @@ const outcome = !joined
   : await new Promise<{
       readonly exitCode: number;
       readonly stopped: boolean;
+      readonly bound?: "commands" | "deadline";
       readonly output: RuntimeOutput;
     }>((resolve) => {
       const output = new RuntimeOutput(agent.runtime);
       const child = spawn(command, args, {
         cwd: workspace,
+        detached: process.platform !== "win32",
         shell: false,
         stdio: ["ignore", "pipe", "pipe"],
         env: { HOME: process.env.HOME ?? "", PATH: process.env.PATH ?? "/usr/bin:/bin" },
@@ -237,18 +245,48 @@ const outcome = !joined
       const lines = createInterface({ input: child.stdout, crlfDelay: Infinity });
       lines.on("line", (line) => output.line(line));
       let stopped = false;
+      let bound: "commands" | "deadline" | undefined;
+      let terminating = false;
       let killTimer: NodeJS.Timeout | undefined;
+      const terminate = (): void => {
+        if (terminating || !child.pid) return;
+        terminating = true;
+        try {
+          if (process.platform !== "win32") process.kill(-child.pid, "SIGTERM");
+          else child.kill("SIGTERM");
+        } catch {
+          child.kill("SIGTERM");
+        }
+        killTimer = setTimeout(() => {
+          try {
+            if (child.pid && process.platform !== "win32") process.kill(-child.pid, "SIGKILL");
+            else child.kill("SIGKILL");
+          } catch {
+            child.kill("SIGKILL");
+          }
+        }, 5_000);
+      };
+      lines.on("line", () => {
+        if (bound || output.commandsStarted() <= (agent.max_commands ?? 8)) return;
+        bound = "commands";
+        terminate();
+      });
+      const deadlineTimer = setTimeout(() => {
+        if (bound) return;
+        bound = "deadline";
+        terminate();
+      }, agent.timeout_ms ?? 300_000);
       const monitor = setInterval(() => {
         if (stopped || store.status(teamID).team.state !== "stopped") return;
         stopped = true;
-        child.kill("SIGTERM");
-        killTimer = setTimeout(() => child.kill("SIGKILL"), 5_000);
+        terminate();
       }, 500);
       const finish = (exitCode: number): void => {
         clearInterval(monitor);
+        clearTimeout(deadlineTimer);
         if (killTimer) clearTimeout(killTimer);
         lines.close();
-        resolve({ exitCode, stopped, output });
+        resolve({ exitCode, stopped, ...(bound ? { bound } : {}), output });
       };
       child.once("error", () => finish(1));
       child.once("close", (code) => finish(code ?? 1));
@@ -277,32 +315,36 @@ if (joined && "output" in outcome) {
       }
     }
     const completion =
-      outcome.exitCode !== 0
-        ? { schema: 1 as const, outcome: "agent_exit_nonzero" as const, summary }
-        : !usage
-          ? { schema: 1 as const, outcome: "token_accounting_unavailable" as const, summary }
-          : usage.budget_outcome === "exceeded"
-            ? { schema: 1 as const, outcome: "token_budget_exceeded" as const, summary }
-            : missingActions.length > 0
-              ? {
-                  schema: 1 as const,
-                  outcome: "required_action_missing" as const,
-                  summary: `Missing required action receipts: ${missingActions.join(", ")}`,
-                }
-              : !summary
-                ? { schema: 1 as const, outcome: "completion_missing" as const, summary: "" }
-                : planInvalid
+      outcome.bound === "commands"
+        ? { schema: 1 as const, outcome: "command_budget_exceeded" as const, summary }
+        : outcome.bound === "deadline"
+          ? { schema: 1 as const, outcome: "runtime_deadline_exceeded" as const, summary }
+          : outcome.exitCode !== 0
+            ? { schema: 1 as const, outcome: "agent_exit_nonzero" as const, summary }
+            : !usage
+              ? { schema: 1 as const, outcome: "token_accounting_unavailable" as const, summary }
+              : usage.budget_outcome === "exceeded"
+                ? { schema: 1 as const, outcome: "token_budget_exceeded" as const, summary }
+                : missingActions.length > 0
                   ? {
                       schema: 1 as const,
-                      outcome: "team_plan_invalid" as const,
-                      summary: "Structured team plan validation failed",
+                      outcome: "required_action_missing" as const,
+                      summary: `Missing required action receipts: ${missingActions.join(", ")}`,
                     }
-                  : {
-                      schema: 1 as const,
-                      outcome: "succeeded" as const,
-                      summary,
-                      ...(proposedPlan ? { plan_id: proposedPlan.plan_id } : {}),
-                    };
+                  : !summary
+                    ? { schema: 1 as const, outcome: "completion_missing" as const, summary: "" }
+                    : planInvalid
+                      ? {
+                          schema: 1 as const,
+                          outcome: "team_plan_invalid" as const,
+                          summary: "Structured team plan validation failed",
+                        }
+                      : {
+                          schema: 1 as const,
+                          outcome: "succeeded" as const,
+                          summary,
+                          ...(proposedPlan ? { plan_id: proposedPlan.plan_id } : {}),
+                        };
     store.finish(teamID, agentID, completion, usage);
     if (completion.outcome !== "succeeded") wrapperExitCode = 1;
   }

--- a/contracts/team-execution-plan-v1.schema.json
+++ b/contracts/team-execution-plan-v1.schema.json
@@ -26,6 +26,9 @@
         "skills",
         "instructions",
         "task",
+        "tool_mode",
+        "max_commands",
+        "timeout_ms",
         "token_budget"
       ],
       "properties": {
@@ -39,6 +42,9 @@
         },
         "instructions": { "type": "string" },
         "task": { "type": "string" },
+        "tool_mode": { "type": "string", "enum": ["none", "coordination", "team"] },
+        "max_commands": { "type": "integer" },
+        "timeout_ms": { "type": "integer" },
         "token_budget": { "type": "integer" }
       }
     }

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -76,12 +76,14 @@ session to retrieve its terminal completion. For efficient automatic work, set
 without tools. Read its plan ID and digest from status, then call `plan.execute`
 with that exact digest. Model and skill values outside these allowlists fail
 before process launch. The
-worker must bootstrap and join Coordination before its agent CLI starts. Set an
-explicit `team_token_budget` and `manager_token_budget` in `manager.start`, then
-a smaller `token_budget` for every planned worker and for synthesis. All
-allocations are validated together before a worker starts. Teams created by an older
-preview remain readable but an external unaccounted session cannot engage
-workers. Stop and recreate them with `manager.start`.
+worker must bootstrap and join Coordination before its agent CLI starts. Set
+explicit token, command and runtime bounds: `team_token_budget`,
+`manager_token_budget`, `max_commands` and `runtime_timeout_ms`. Every planned
+agent must also declare `token_budget`, `max_commands`, `timeout_ms` and
+`tool_mode`; use `none` unless Coordination or delegation is necessary.
+Allocations are validated before launch. Older preview teams remain readable,
+but an external unaccounted session cannot engage workers; recreate them with
+`manager.start`.
 
 `plan.execute` reserves every worker plus one synthesizer, starts and awaits the
 workers without another manager model turn, then gives their bounded completion
@@ -97,11 +99,12 @@ the manager:
 
 ```text
 Use yukh-team-control. Call manager.start with a 120000-token team budget and a
-20000-token Codex planning-manager budget, no required actions and
+20000-token Codex planning-manager budget, max_commands 2, runtime_timeout_ms
+120000, no required actions and
 output_contract team-plan-v1. Ask for the minimum specialists needed, explicit
-worker budgets and one small synthesis budget. Show me the proposed plan and its
-digest. After I approve that exact digest, call plan.execute once and report its
-terminal state and exact usage.
+token, command, timeout and tool-mode bounds, plus one small tool-free synthesis
+budget. Show me the proposed plan and digest. After I approve that exact digest,
+call plan.execute once and report terminal state and exact usage.
 Do not use team.create and do not engage a runtime that cannot provide token
 accounting.
 ```

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -66,6 +66,12 @@ is single-use and deterministic: it launches and awaits reserved workers without
 calling the planning model again. Final synthesis is a separate tool-free,
 budgeted runtime over bounded public completion artifacts. Mismatch, replay,
 worker failure or incomplete accounting fails closed and remains observable.
+Post-turn token evidence alone is not an expense control: the real qualification
+for issue #149 observed 344,007 tokens against a 45,000 worker allocation before
+the provider reported usage. New agents therefore carry preemptive command-count
+and wall-clock bounds enforced by the wrapper process, and model-facing Yukh tools
+are exposed only through an explicit plan mode. Exact token evidence remains
+post-turn and preemptive termination may leave usage unknown rather than zero.
 
 ### Prompt and content injection
 
@@ -861,3 +867,17 @@ its own token allocation. Digest substitution, replay, unavailable profiles,
 over-allocation, worker failure and incomplete accounting fail closed. The
 remaining cost risk is the provider's post-turn usage boundary described by
 RFC-0020.
+
+## Accepted preemptive agent runtime bounds — 2026-08-16
+
+- Governing issue: #149
+- Accepted architecture: RFC-0024
+
+Real qualification proved a worker can consume hundreds of thousands of tokens
+inside one provider turn before post-turn accounting detects an overrun. Every
+new agent now has a bounded command count and runtime deadline enforced by its
+wrapper. Planned agents explicitly select no Yukh tools, Coordination only, or
+the team surface; synthesis has no model-facing MCP. Executor replay resumes
+persistent state and cannot duplicate a running or completed worker. Residual
+risk remains that the provider can consume more tokens than allocated between
+two observable command boundaries or before the deadline fires.

--- a/packages/conversation-watch/src/watch.ts
+++ b/packages/conversation-watch/src/watch.ts
@@ -173,11 +173,11 @@ export function renderTeamChanges(
     }
     for (const agent of snapshot.agents) {
       const key = `agent:${agent.agent_id}`;
-      const value = `${agent.state}:${agent.task}:${agent.usage?.total_tokens ?? "pending"}:${agent.completion?.outcome ?? "pending"}`;
+      const value = `${agent.state}:${agent.task}:${agent.max_commands ?? 8}:${agent.timeout_ms ?? 300_000}:${agent.usage?.total_tokens ?? "pending"}:${agent.completion?.outcome ?? "pending"}`;
       if (previous.get(key) === value) continue;
       previous.set(key, value);
       lines.push(
-        `${agent.kind === "manager" ? "MANAGER" : "WORKER"}  ${agent.role}  ${agent.state.toUpperCase()}  runtime=${agent.runtime}${agent.profile ? ` model=${agent.profile.model}` : ""}\n        task=${compact(agent.task, 180)}${agent.profile ? `\n        mission=${compact(agent.profile.mission, 160)} skills=${agent.profile.skills.join(",") || "none"}` : ""}\n        tokens=${agent.usage?.total_tokens ?? "pending"}/${agent.token_budget} input=${agent.usage?.input_tokens ?? "pending"} cached=${agent.usage?.cached_input_tokens ?? "pending"} output=${agent.usage?.output_tokens ?? "pending"} reasoning=${agent.usage?.reasoning_output_tokens ?? "pending"} accounting=${agent.usage?.source ?? "pending"} completion=${agent.completion?.outcome ?? "pending"}\n        required=${agent.required_actions.join(",") || "none"} receipts=${
+        `${agent.kind === "manager" ? "MANAGER" : "WORKER"}  ${agent.role}  ${agent.state.toUpperCase()}  runtime=${agent.runtime}${agent.profile ? ` model=${agent.profile.model}` : ""}\n        task=${compact(agent.task, 180)}${agent.profile ? `\n        mission=${compact(agent.profile.mission, 160)} skills=${agent.profile.skills.join(",") || "none"}` : ""}\n        bounds=commands:${agent.max_commands ?? 8} timeout_ms:${agent.timeout_ms ?? 300_000} tools=${agent.model_tool_mode ?? "default"}\n        tokens=${agent.usage?.total_tokens ?? "pending"}/${agent.token_budget} input=${agent.usage?.input_tokens ?? "pending"} cached=${agent.usage?.cached_input_tokens ?? "pending"} output=${agent.usage?.output_tokens ?? "pending"} reasoning=${agent.usage?.reasoning_output_tokens ?? "pending"} accounting=${agent.usage?.source ?? "pending"} completion=${agent.completion?.outcome ?? "pending"}\n        required=${agent.required_actions.join(",") || "none"} receipts=${
           snapshot.receipts
             .filter((receipt) => receipt.actor_agent_id === agent.agent_id)
             .map((receipt) => receipt.action)

--- a/packages/team-control/src/runtime-output.ts
+++ b/packages/team-control/src/runtime-output.ts
@@ -17,6 +17,7 @@ export class RuntimeOutput {
     reasoning_output_tokens: 0,
   };
   #usageObserved = false;
+  #commandsStarted = 0;
 
   constructor(runtime: "codex" | "copilot") {
     this.#runtime = runtime;
@@ -41,6 +42,10 @@ export class RuntimeOutput {
     return Buffer.byteLength(normalized, "utf8") <= 4_096 ? normalized : "";
   }
 
+  commandsStarted(): number {
+    return this.#commandsStarted;
+  }
+
   usage(budget: number): AgentUsage | undefined {
     if (!this.#usageObserved) return undefined;
     const total = this.#usage.input_tokens + this.#usage.output_tokens;
@@ -54,6 +59,12 @@ export class RuntimeOutput {
   }
 
   #codex(event: Record<string, unknown>): void {
+    if (
+      event.type === "item.started" &&
+      object(event.item) &&
+      event.item.type === "command_execution"
+    )
+      this.#commandsStarted += 1;
     if (event.type === "item.completed" && object(event.item)) {
       const item = event.item;
       if (item.type === "agent_message" && typeof item.text === "string") this.#summary = item.text;

--- a/packages/team-control/src/store.ts
+++ b/packages/team-control/src/store.ts
@@ -13,6 +13,7 @@ import { isAbsolute, join } from "node:path";
 export type AgentRuntime = "codex" | "copilot";
 export type AgentKind = "manager" | "worker";
 export type ManagerOutputContract = "summary" | "team-plan-v1";
+export type ModelToolMode = "none" | "coordination" | "team";
 export type TeamState = "active" | "stopped";
 export type AgentState = "defined" | "running" | "completed" | "failed" | "stopped";
 
@@ -34,6 +35,8 @@ export interface AgentCompletion {
     | "agent_exit_nonzero"
     | "completion_missing"
     | "team_plan_invalid"
+    | "command_budget_exceeded"
+    | "runtime_deadline_exceeded"
     | "required_action_missing"
     | "token_accounting_unavailable"
     | "token_budget_exceeded";
@@ -80,7 +83,9 @@ export interface AgentRecord {
   readonly token_budget: number;
   readonly required_actions: readonly TeamAction[];
   readonly output_contract?: ManagerOutputContract;
-  readonly model_tool_mode?: "default" | "none";
+  readonly model_tool_mode?: "default" | ModelToolMode;
+  readonly max_commands?: number;
+  readonly timeout_ms?: number;
   readonly usage?: AgentUsage;
   readonly completion?: AgentCompletion;
   readonly state: AgentState;
@@ -102,6 +107,9 @@ export interface PlannedAgent {
   readonly skills: readonly string[];
   readonly instructions: string;
   readonly task: string;
+  readonly tool_mode: ModelToolMode;
+  readonly max_commands: number;
+  readonly timeout_ms: number;
   readonly token_budget: number;
 }
 
@@ -219,6 +227,8 @@ export class TeamStore {
       readonly token_budget: number;
       readonly required_actions: readonly TeamAction[];
       readonly output_contract?: ManagerOutputContract;
+      readonly max_commands?: number;
+      readonly timeout_ms?: number;
     },
   ): {
     readonly team: TeamRecord;
@@ -232,6 +242,7 @@ export class TeamStore {
       manager.required_actions.length > 3 ||
       new Set(manager.required_actions).size !== manager.required_actions.length ||
       (manager.output_contract === "team-plan-v1" && manager.required_actions.length > 0) ||
+      !this.#validRuntimeBounds(manager.max_commands ?? 8, manager.timeout_ms ?? 300_000) ||
       manager.required_actions.some(
         (action) => !["team.status", "agent.engage", "agent.await"].includes(action),
       )
@@ -260,6 +271,8 @@ export class TeamStore {
       token_budget: manager.token_budget,
       required_actions: manager.required_actions,
       output_contract: manager.output_contract ?? "summary",
+      max_commands: manager.max_commands ?? 8,
+      timeout_ms: manager.timeout_ms ?? 300_000,
       state: "defined",
     };
     this.#write(
@@ -280,7 +293,9 @@ export class TeamStore {
       readonly task: string;
       readonly can_spawn?: boolean;
       readonly token_budget: number;
-      readonly model_tool_mode?: "default" | "none";
+      readonly model_tool_mode?: "default" | ModelToolMode;
+      readonly max_commands?: number;
+      readonly timeout_ms?: number;
     },
   ): AgentRecord {
     const team = this.#readTeam(id);
@@ -294,7 +309,8 @@ export class TeamStore {
       input.task.length > 4_096 ||
       !Number.isSafeInteger(input.token_budget) ||
       input.token_budget < 1_000 ||
-      input.token_budget > 2_000_000
+      input.token_budget > 2_000_000 ||
+      !this.#validRuntimeBounds(input.max_commands ?? 8, input.timeout_ms ?? 300_000)
     )
       throw new TypeError("invalid agent definition");
     if (input.profile) this.#validateProfile(input.profile);
@@ -333,6 +349,8 @@ export class TeamStore {
       token_budget: input.token_budget,
       required_actions: [],
       model_tool_mode: input.model_tool_mode ?? "default",
+      max_commands: input.max_commands ?? 8,
+      timeout_ms: input.timeout_ms ?? 300_000,
       state: "defined",
     };
     this.#write(join(this.#teamDirectory(id), "agents", `${record.agent_id}.json`), record, true);
@@ -468,6 +486,9 @@ export class TeamStore {
         },
         task: worker.task,
         token_budget: worker.token_budget,
+        model_tool_mode: worker.tool_mode,
+        max_commands: worker.max_commands,
+        timeout_ms: worker.timeout_ms,
       }),
     );
     const synthesis = plan.document.synthesis;
@@ -485,6 +506,8 @@ export class TeamStore {
       task: "Awaiting deterministic worker completion artifacts.",
       token_budget: synthesis.token_budget,
       model_tool_mode: "none",
+      max_commands: synthesis.max_commands,
+      timeout_ms: synthesis.timeout_ms,
     });
     return this.updatePlan(id, planId, {
       state: "reserved",
@@ -629,6 +652,8 @@ export class TeamStore {
         "agent_exit_nonzero",
         "completion_missing",
         "team_plan_invalid",
+        "command_budget_exceeded",
+        "runtime_deadline_exceeded",
         "required_action_missing",
         "token_accounting_unavailable",
         "token_budget_exceeded",
@@ -662,6 +687,9 @@ export class TeamStore {
         "skills",
         "instructions",
         "task",
+        "tool_mode",
+        "max_commands",
+        "timeout_ms",
         "token_budget",
       ];
       if (!exact(candidate, keys)) throw new TypeError("invalid team plan");
@@ -680,6 +708,8 @@ export class TeamStore {
         candidate.task.trim() !== candidate.task ||
         candidate.task.length < 1 ||
         candidate.task.length > 4_096 ||
+        !["none", "coordination", "team"].includes(String(candidate.tool_mode)) ||
+        !this.#validRuntimeBounds(Number(candidate.max_commands), Number(candidate.timeout_ms)) ||
         !Number.isSafeInteger(candidate.token_budget) ||
         Number(candidate.token_budget) < 1_000 ||
         Number(candidate.token_budget) > 2_000_000
@@ -698,13 +728,29 @@ export class TeamStore {
         skills: candidate.skills as readonly string[],
         instructions: candidate.instructions as string,
         task: candidate.task,
+        tool_mode: candidate.tool_mode as ModelToolMode,
+        max_commands: candidate.max_commands as number,
+        timeout_ms: candidate.timeout_ms as number,
         token_budget: candidate.token_budget as number,
       };
     };
     const workers = value.workers.map(normalize);
     if (new Set(workers.map((worker) => worker.role)).size !== workers.length)
       throw new TypeError("invalid team plan");
-    return { schema: 1, workers, synthesis: normalize(value.synthesis) };
+    const synthesis = normalize(value.synthesis);
+    if (synthesis.tool_mode !== "none") throw new TypeError("invalid team plan");
+    return { schema: 1, workers, synthesis };
+  }
+
+  #validRuntimeBounds(maxCommands: number, timeoutMs: number): boolean {
+    return (
+      Number.isSafeInteger(maxCommands) &&
+      maxCommands >= 0 &&
+      maxCommands <= 32 &&
+      Number.isSafeInteger(timeoutMs) &&
+      timeoutMs >= 5_000 &&
+      timeoutMs <= 900_000
+    );
   }
 
   #validateUsage(agent: AgentRecord, usage: AgentUsage): void {
@@ -743,6 +789,14 @@ export class TeamStore {
       ...value,
       kind: value.kind ?? "worker",
       required_actions: Array.isArray(value.required_actions) ? value.required_actions : [],
+      max_commands:
+        typeof value.max_commands === "number" && Number.isSafeInteger(value.max_commands)
+          ? value.max_commands
+          : 8,
+      timeout_ms:
+        typeof value.timeout_ms === "number" && Number.isSafeInteger(value.timeout_ms)
+          ? value.timeout_ms
+          : 300_000,
       ...(Number.isSafeInteger(value.token_budget) ? {} : { token_budget: 0 }),
       ...(value.coordination_participant
         ? {}

--- a/test/contracts/team-execution-plan-v1.test.mjs
+++ b/test/contracts/team-execution-plan-v1.test.mjs
@@ -18,6 +18,9 @@ const agent = {
   skills: ["testing"],
   instructions: "Inspect relevant files, implement and test.",
   task: "Deliver the increment.",
+  tool_mode: "none",
+  max_commands: 4,
+  timeout_ms: 60_000,
   token_budget: 20_000,
 };
 

--- a/test/runtime/conversation-watch.test.ts
+++ b/test/runtime/conversation-watch.test.ts
@@ -75,6 +75,8 @@ test("watch explains team and worker activity in work-oriented language", () => 
             depth: 1,
             can_spawn: true,
             token_budget: 50_000,
+            max_commands: 6,
+            timeout_ms: 120_000,
             required_actions: [],
             state: "running",
           },
@@ -96,6 +98,7 @@ test("watch explains team and worker activity in work-oriented language", () => 
   assert.match(changes.join("\n"), /manager=manager runtime=codex goal=Build a task board/u);
   assert.match(changes.join("\n"), /WORKER  backend-lead  RUNNING/u);
   assert.match(changes.join("\n"), /task=Define and implement the API/u);
+  assert.match(changes.join("\n"), /bounds=commands:6 timeout_ms:120000 tools=default/u);
 });
 
 test("watch exposes manager accounting and receipt-backed actions", () => {
@@ -175,6 +178,9 @@ test("watch exposes manager accounting and receipt-backed actions", () => {
                   skills: [],
                   instructions: "Implement and test.",
                   task: "Deliver one increment.",
+                  tool_mode: "none",
+                  max_commands: 4,
+                  timeout_ms: 60_000,
                   token_budget: 20_000,
                 },
               ],
@@ -186,6 +192,9 @@ test("watch exposes manager accounting and receipt-backed actions", () => {
                 skills: [],
                 instructions: "Use verified evidence.",
                 task: "Summarize the delivery.",
+                tool_mode: "none",
+                max_commands: 0,
+                timeout_ms: 60_000,
                 token_budget: 5_000,
               },
             },

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -37,6 +37,9 @@ const planDocument = (workerBudget = 2_000, synthesisBudget = 2_000) => ({
       skills: [],
       instructions: "Inspect only relevant files, implement and test the requested increment.",
       task: "Implement and verify the backend increment.",
+      tool_mode: "none" as const,
+      max_commands: 4,
+      timeout_ms: 60_000,
       token_budget: workerBudget,
     },
   ],
@@ -48,6 +51,9 @@ const planDocument = (workerBudget = 2_000, synthesisBudget = 2_000) => ({
     skills: [],
     instructions: "Use only supplied verified completion artifacts and remain concise.",
     task: "Synthesize outcome, remaining gaps and the next action.",
+    tool_mode: "none" as const,
+    max_commands: 0,
+    timeout_ms: 60_000,
     token_budget: synthesisBudget,
   },
 });
@@ -384,6 +390,9 @@ test("accounted manager receives the exact persisted team status receipt", async
 test("runtime output extracts Codex completion and refuses invented Copilot token usage", () => {
   const codex = new RuntimeOutput("codex");
   codex.line(
+    JSON.stringify({ type: "item.started", item: { type: "command_execution", command: "pwd" } }),
+  );
+  codex.line(
     JSON.stringify({
       type: "item.completed",
       item: { type: "agent_message", text: "Concise completion" },
@@ -401,6 +410,7 @@ test("runtime output extracts Codex completion and refuses invented Copilot toke
     }),
   );
   assert.equal(codex.summary(), "Concise completion");
+  assert.equal(codex.commandsStarted(), 1);
   assert.deepEqual(codex.usage(10_000), {
     schema: 1,
     source: "codex-json-v1",
@@ -1011,6 +1021,72 @@ printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_inpu
   }
 });
 
+test("worker preempts the provider when its command budget is exceeded", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-command-bound-")));
+  try {
+    const executable = join(root, "agent-cli");
+    const launcher = join(root, "launcher");
+    const support = join(root, "support.mjs");
+    await writeFile(
+      executable,
+      `#!/bin/sh
+printf '%s\n' '{"type":"item.started","item":{"type":"command_execution","command":"sleep 30"}}'
+sleep 30
+`,
+      { mode: 0o700 },
+    );
+    await writeFile(
+      launcher,
+      '#!/bin/sh\ncat >/dev/null\nprintf \'{"schema":1,"status":"ok","command":"test"}\\n\'\n',
+      { mode: 0o700 },
+    );
+    await writeFile(support, "", { mode: 0o600 });
+    const store = new TeamStore(root);
+    const managed = store.createManaged("Bound commands", "codex", 2, 1, 5_000, {
+      role: "delivery-manager",
+      profile: {
+        schema: 1,
+        mission: "Prove command preemption",
+        model: "default",
+        skills: [],
+        instructions: "Stay bounded.",
+      },
+      task: "Attempt one command",
+      token_budget: 2_000,
+      required_actions: [],
+      max_commands: 0,
+      timeout_ms: 60_000,
+    });
+    const started = Date.now();
+    const child = spawn(
+      process.execPath,
+      ["--import", tsxLoader, workerMain, managed.team.team_id, managed.manager.agent_id],
+      {
+        cwd: root,
+        stdio: "ignore",
+        env: {
+          HOME: process.env.HOME ?? "",
+          PATH: process.env.PATH ?? "/usr/bin:/bin",
+          YUKH_TEAM_WORKSPACE: root,
+          YUKH_COORDINATION_LAUNCHER: launcher,
+          YUKH_COORDINATION_MCP_MAIN: support,
+          YUKH_TEAM_CONTROL_MCP_MAIN: support,
+          YUKH_CODEX_EXECUTABLE: executable,
+          YUKH_COPILOT_EXECUTABLE: executable,
+        },
+      },
+    );
+    assert.notEqual(await new Promise<number | null>((resolve) => child.once("close", resolve)), 0);
+    assert.ok(Date.now() - started < 10_000);
+    assert.equal(
+      store.agent(managed.team.team_id, managed.manager.agent_id).completion?.outcome,
+      "command_budget_exceeded",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("deterministic executor reserves, runs, awaits and synthesizes without manager relaunch", async () => {
   const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-plan-executor-")));
   try {
@@ -1106,6 +1182,80 @@ test("deterministic executor reserves, runs, awaits and synthesizes without mana
   }
 });
 
+test("deterministic executor resumes reserved state and suppresses synthesis after worker failure", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-plan-resume-failure-")));
+  try {
+    const store = new TeamStore(root);
+    const managed = store.createManaged("Resume failed work", "codex", 4, 1, 10_000, {
+      role: "delivery-manager",
+      profile: {
+        schema: 1,
+        mission: "Plan one bounded increment",
+        model: "default",
+        skills: [],
+        instructions: "Return a closed plan.",
+      },
+      task: "Plan",
+      token_budget: 2_000,
+      required_actions: [],
+      output_contract: "team-plan-v1",
+    });
+    store.transition(managed.team.team_id, managed.manager.agent_id, "running");
+    const proposed = store.proposePlan(
+      managed.team.team_id,
+      managed.manager.agent_id,
+      JSON.stringify(planDocument()),
+    );
+    store.finish(
+      managed.team.team_id,
+      managed.manager.agent_id,
+      {
+        schema: 1,
+        outcome: "succeeded",
+        summary: JSON.stringify(planDocument()),
+        plan_id: proposed.plan_id,
+      },
+      usage,
+    );
+    const reserved = store.reservePlan(managed.team.team_id, proposed.plan_id, proposed.digest);
+    const failedWorker = reserved.worker_agent_ids[0]!;
+    store.transition(managed.team.team_id, failedWorker, "running");
+    store.finish(
+      managed.team.team_id,
+      failedWorker,
+      { schema: 1, outcome: "command_budget_exceeded", summary: "bounded" },
+      undefined,
+    );
+    const launches: string[] = [];
+    const options = {
+      models: { codex: new Set(["default"]), copilot: new Set(["default"]) },
+      skills: { codex: new Set<string>(), copilot: new Set<string>() },
+    };
+    await assert.rejects(
+      executePlan(
+        store,
+        { launch: (agent) => (launches.push(agent.agent_id), { pid: 1, log: "test" }) },
+        options,
+        managed.team.team_id,
+        proposed.plan_id,
+        proposed.digest,
+        2_000,
+      ),
+      /team_plan_worker_failed/u,
+    );
+    const failed = store.plan(managed.team.team_id, proposed.plan_id);
+    assert.equal(failed.state, "failed");
+    assert.equal(failed.failure_code, "team_plan_worker_failed");
+    assert.deepEqual(launches, []);
+    assert.equal(
+      store.agent(managed.team.team_id, failed.synthesis_agent_id ?? "invalid").state,
+      "defined",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("deterministic executor fails before worker creation for malformed, stale and unavailable plans", async () => {
   const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-plan-denials-")));
   try {
@@ -1141,6 +1291,28 @@ test("deterministic executor fails before worker creation for malformed, stale a
           managed.team.team_id,
           managed.manager.agent_id,
           JSON.stringify(duplicateSkills),
+        ),
+      /invalid team plan/u,
+    );
+    const unbounded = planDocument();
+    unbounded.workers[0]!.max_commands = 33;
+    assert.throws(
+      () =>
+        store.proposePlan(
+          managed.team.team_id,
+          managed.manager.agent_id,
+          JSON.stringify(unbounded),
+        ),
+      /invalid team plan/u,
+    );
+    const toolUsingSynthesis = planDocument();
+    (toolUsingSynthesis.synthesis as { tool_mode: string }).tool_mode = "coordination";
+    assert.throws(
+      () =>
+        store.proposePlan(
+          managed.team.team_id,
+          managed.manager.agent_id,
+          JSON.stringify(toolUsingSynthesis),
         ),
       /invalid team plan/u,
     );


### PR DESCRIPTION
Closes #149.

Adds closed command, wall-clock and tool-mode bounds to managed agents and deterministic plans. The worker terminates its owned process group on a bound, records distinct outcomes, and the executor resumes persisted running/synthesizing state without launching completed work or synthesizing after worker failure. Status and conversation watch expose the bounds.

Qualification:
- npm test
- npm run build
- npm run format:check
- npm run typecheck
- git diff --check

No real model call was made after the overrun.