### PR TITLE
Disable cost-unsafe dynamic execution by default

### DIFF
--- a/apps/team-control/src/main.ts
+++ b/apps/team-control/src/main.ts
@@ -40,6 +40,7 @@ const allowlist = (name: string, fallback: readonly string[] = []): ReadonlySet<
 serveStdio(
   () =>
     createTeamControlServer(store, supervisor, {
+      dynamicExecution: process.env.YUKH_ENABLE_UNSAFE_DYNAMIC_WORKERS === "1",
       models: {
         codex: allowlist("YUKH_CODEX_MODELS", ["default"]),
         copilot: allowlist("YUKH_COPILOT_MODELS", ["default"]),

--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -31,6 +31,11 @@ export interface TeamControlOptions {
   readonly caller?: { readonly team_id: string; readonly agent_id: string };
   readonly models?: Readonly<Record<"codex" | "copilot", ReadonlySet<string>>>;
   readonly skills?: Readonly<Record<"codex" | "copilot", ReadonlySet<string>>>;
+  readonly dynamicExecution?: boolean;
+}
+
+export function dynamicExecutionEnabled(options: TeamControlOptions): boolean {
+  return options.dynamicExecution !== false;
 }
 
 export function assertProfileAvailable(
@@ -335,6 +340,8 @@ export function createTeamControlServer(
     },
     async ({ team_id, plan_id, approved_digest, timeout_ms }) => {
       if (options.caller) throw new Error("agent_delegation_denied");
+      if (!dynamicExecutionEnabled(options))
+        return failure("dynamic_worker_cost_boundary_unavailable");
       try {
         return result(
           await executePlan(
@@ -454,6 +461,8 @@ export function createTeamControlServer(
     },
     (input) => {
       if (!options.caller) return failure("manager_runtime_required");
+      if (!dynamicExecutionEnabled(options))
+        return failure("dynamic_worker_cost_boundary_unavailable");
       try {
         assertProfileAvailable(options, input.runtime, input.model, input.skills);
       } catch (error) {
@@ -545,6 +554,8 @@ export function createTeamControlServer(
     },
     (input) => {
       if (!options.caller) return failure("manager_runtime_required");
+      if (!dynamicExecutionEnabled(options))
+        return failure("dynamic_worker_cost_boundary_unavailable");
       if (
         options.caller &&
         (input.team_id !== options.caller.team_id ||

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -94,6 +94,12 @@ trustworthy token counts. Copilot exposes credits and duration but not tokens, s
 token-strict Copilot worker terminates with `token_accounting_unavailable`
 rather than inventing a conversion.
 
+Real dynamic execution is temporarily fail-closed after issue #155 proved that a
+single provider turn can exceed its allocation before usage is reported. The
+server returns `dynamic_worker_cost_boundary_unavailable`. The escape hatch
+`YUKH_ENABLE_UNSAFE_DYNAMIC_WORKERS=1` is for isolated qualification only; it is
+not a cost-safe production profile.
+
 For Copilot, use the equivalent MCP server values in `copilot mcp add`. Then ask
 the manager:
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -881,3 +881,9 @@ the team surface; synthesis has no model-facing MCP. Executor replay resumes
 persistent state and cannot duplicate a running or completed worker. Residual
 risk remains that the provider can consume more tokens than allocated between
 two observable command boundaries or before the deadline fires.
+
+The real qualification for issue #155 confirmed this residual risk: one worker
+reported 61,740 tokens against a 12,000 allocation after one bounded read-only
+command. Dynamic worker execution is therefore disabled by default. An explicit
+unsafe qualification flag may enable it only in an isolated runtime; it is not a
+token-budget enforcement mechanism.

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -11,9 +11,16 @@ import { RuntimeOutput } from "../../packages/team-control/src/runtime-output.js
 import {
   assertProfileAvailable,
   awaitAgent,
+  dynamicExecutionEnabled,
   executePlan,
   readTeamStatus,
 } from "../../apps/team-control/src/server.js";
+
+test("real dynamic execution can fail closed without changing deterministic helpers", () => {
+  assert.equal(dynamicExecutionEnabled({ dynamicExecution: false }), false);
+  assert.equal(dynamicExecutionEnabled({ dynamicExecution: true }), true);
+  assert.equal(dynamicExecutionEnabled({}), true);
+});
 
 const usage = {
   schema: 1 as const,


### PR DESCRIPTION
Implements the immediate fail-closed portion of #155.

A real worker allocated 12,000 tokens used 61,740 in one provider turn after one bounded command. Yukh rejected the worker and suppressed synthesis, but post-turn accounting could not prevent cost. The real server now denies plan.execute, agent.engage and agent.spawn by default with dynamic_worker_cost_boundary_unavailable. An explicitly named unsafe environment flag exists only for isolated qualification.

Verified: typecheck, formatting, team-control runtime tests and diff check. No further model call was made.