### PR TITLE
Admit only zero-command deterministic plans by default

### DIFF
--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
 import { TeamSupervisor } from "../../../packages/team-control/src/supervisor.js";
 import type { AgentRecord } from "../../../packages/team-control/src/store.js";
+import type { TeamExecutionPlanRecord } from "../../../packages/team-control/src/store.js";
 
 const id = z.string().regex(/^team-[0-9a-f-]{36}$/u);
 
@@ -36,6 +37,14 @@ export interface TeamControlOptions {
 
 export function dynamicExecutionEnabled(options: TeamControlOptions): boolean {
   return options.dynamicExecution !== false;
+}
+
+export function costSafeDeterministicPlan(
+  plan: Pick<TeamExecutionPlanRecord, "document">,
+): boolean {
+  return [...plan.document.workers, plan.document.synthesis].every(
+    (agent) => agent.tool_mode === "none" && agent.max_commands === 0,
+  );
 }
 
 export function assertProfileAvailable(
@@ -340,7 +349,10 @@ export function createTeamControlServer(
     },
     async ({ team_id, plan_id, approved_digest, timeout_ms }) => {
       if (options.caller) throw new Error("agent_delegation_denied");
-      if (!dynamicExecutionEnabled(options))
+      if (
+        !dynamicExecutionEnabled(options) &&
+        !costSafeDeterministicPlan(store.plan(team_id, plan_id))
+      )
         return failure("dynamic_worker_cost_boundary_unavailable");
       try {
         return result(

--- a/apps/team-worker/src/main.ts
+++ b/apps/team-worker/src/main.ts
@@ -51,15 +51,32 @@ const modelTeamTools = [
 const modelUsesTeamControl = modelTeamTools.length > 0;
 const coordinationInstruction = modelUsesCoordination
   ? "Your Coordination session is already bootstrapped and joined. Use yukh-coordination only for necessary team communication."
-  : "Coordination model tools are omitted for this bounded turn because no communication action is required.";
+  : "";
 const teamControlInstruction = modelUsesTeamControl
   ? `Required receipt-backed actions before success: ${requiredActions}. A textual claim is not evidence; invoke each required yukh-team-control tool successfully.`
-  : "No model-facing team-control tools are required or exposed for this single-pass turn; the controller verifies manager.start and terminal state.";
+  : "";
+const delegationInstruction =
+  agent.can_spawn && modelUsesTeamControl
+    ? "When engaging a child, use the returned coordination_participant exactly and never add another agent: prefix. Wait for each child with agent.await and inspect its completion before synthesizing. You may create a bounded child only when explicitly delegated."
+    : "";
 const outputInstruction =
   agent.output_contract === "team-plan-v1"
     ? "Return only the JSON team execution plan required by the supplied output schema. Include the minimum specialists needed and one concise delivery synthesizer. Every role must be a lowercase slug matching ^[a-z][a-z0-9-]{0,31}$, for example token-efficiency-auditor; spaces are invalid. Do not wrap JSON in Markdown."
     : "End with one concise public-safe completion summary of at most 4096 UTF-8 bytes; the wrapper persists that final response.";
-const prompt = `You are ${agent.role}, ${agent.kind} ${agent.agent_id} in team ${agent.team_id}.${profile ? ` Mission: ${profile.mission}\nOperating instructions: ${profile.instructions}\nRequired skills: ${profile.skills.length > 0 ? profile.skills.join(", ") : "none"}.` : ""}\nComplete this task: ${agent.task}\nToken budget: ${agent.token_budget} total input plus output tokens. Runtime bounds: at most ${agent.max_commands ?? 8} command executions and ${agent.timeout_ms ?? 300_000} milliseconds. Keep inspection and tool output bounded. The team already exists: do not call team.create. ${teamControlInstruction} When engaging a child, use the returned coordination_participant exactly and never add another agent: prefix. Wait for each child with agent.await and inspect its completion before synthesizing. ${coordinationInstruction} ${outputInstruction} You may create a bounded child only when explicitly delegated.`;
+const prompt = [
+  `You are ${agent.role}, ${agent.kind} ${agent.agent_id} in team ${agent.team_id}.`,
+  profile
+    ? `Mission: ${profile.mission}\nOperating instructions: ${profile.instructions}\nRequired skills: ${profile.skills.length > 0 ? profile.skills.join(", ") : "none"}.`
+    : "",
+  `Complete this task: ${agent.task}`,
+  `Token budget: ${agent.token_budget} total input plus output tokens. Runtime bounds: at most ${agent.max_commands ?? 8} command executions and ${agent.timeout_ms ?? 300_000} milliseconds. Keep inspection and tool output bounded.`,
+  teamControlInstruction,
+  delegationInstruction,
+  coordinationInstruction,
+  outputInstruction,
+]
+  .filter(Boolean)
+  .join(" ");
 const planSchema = fileURLToPath(
   new URL("../../../contracts/team-execution-plan-v1.schema.json", import.meta.url),
 );

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -94,11 +94,13 @@ trustworthy token counts. Copilot exposes credits and duration but not tokens, s
 token-strict Copilot worker terminates with `token_accounting_unavailable`
 rather than inventing a conversion.
 
-Real dynamic execution is temporarily fail-closed after issue #155 proved that a
-single provider turn can exceed its allocation before usage is reported. The
-server returns `dynamic_worker_cost_boundary_unavailable`. The escape hatch
-`YUKH_ENABLE_UNSAFE_DYNAMIC_WORKERS=1` is for isolated qualification only; it is
-not a cost-safe production profile.
+Issue #155 proved that a single provider turn can exceed its allocation before
+usage is reported. Deterministic plans therefore run by default only when every
+worker and the synthesizer use `tool_mode: none` and `max_commands: 0`; they
+receive only the closed server-built prompt and cannot feed shell output into a
+follow-up inference. Other dynamic execution returns
+`dynamic_worker_cost_boundary_unavailable`. The escape hatch
+`YUKH_ENABLE_UNSAFE_DYNAMIC_WORKERS=1` is for isolated qualification only.
 
 For Copilot, use the equivalent MCP server values in `copilot mcp add`. Then ask
 the manager:
@@ -108,9 +110,9 @@ Use yukh-team-control. Call manager.start with a 120000-token team budget and a
 20000-token Codex planning-manager budget, max_commands 2, runtime_timeout_ms
 120000, no required actions and
 output_contract team-plan-v1. Ask for the minimum specialists needed, explicit
-token, command, timeout and tool-mode bounds, plus one small tool-free synthesis
-budget. Show me the proposed plan and digest. After I approve that exact digest,
-call plan.execute once and report terminal state and exact usage.
+token and timeout bounds, `tool_mode: none` and `max_commands: 0` for every
+worker and synthesis. Show me the proposed plan and digest. After I approve that
+exact digest, call plan.execute once and report terminal state and exact usage.
 Do not use team.create and do not engage a runtime that cannot provide token
 accounting.
 ```

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -884,6 +884,8 @@ two observable command boundaries or before the deadline fires.
 
 The real qualification for issue #155 confirmed this residual risk: one worker
 reported 61,740 tokens against a 12,000 allocation after one bounded read-only
-command. Dynamic worker execution is therefore disabled by default. An explicit
-unsafe qualification flag may enable it only in an isolated runtime; it is not a
-token-budget enforcement mechanism.
+command. Default deterministic execution therefore admits only agents with no
+model-facing MCP and a zero-command limit. Their server-built prompt is the only
+task context, so shell output cannot trigger another inference. Other dynamic
+execution remains disabled. An explicit unsafe qualification flag may enable it
+only in an isolated runtime; it is not a token-budget enforcement mechanism.

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -11,6 +11,7 @@ import { RuntimeOutput } from "../../packages/team-control/src/runtime-output.js
 import {
   assertProfileAvailable,
   awaitAgent,
+  costSafeDeterministicPlan,
   dynamicExecutionEnabled,
   executePlan,
   readTeamStatus,
@@ -20,6 +21,18 @@ test("real dynamic execution can fail closed without changing deterministic help
   assert.equal(dynamicExecutionEnabled({ dynamicExecution: false }), false);
   assert.equal(dynamicExecutionEnabled({ dynamicExecution: true }), true);
   assert.equal(dynamicExecutionEnabled({}), true);
+});
+
+test("only zero-command tool-free deterministic plans satisfy the default cost profile", () => {
+  const safe = structuredClone(planDocument());
+  const record = { document: safe } as unknown as Parameters<typeof costSafeDeterministicPlan>[0];
+  safe.workers[0]!.max_commands = 0;
+  assert.equal(costSafeDeterministicPlan(record), true);
+  safe.workers[0]!.max_commands = 1;
+  assert.equal(costSafeDeterministicPlan(record), false);
+  safe.workers[0]!.max_commands = 0;
+  (safe.workers[0] as { tool_mode: string }).tool_mode = "coordination";
+  assert.equal(costSafeDeterministicPlan(record), false);
 });
 
 const usage = {
@@ -1024,6 +1037,8 @@ printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_inpu
     assert.match(runtimeArguments, /--output-schema/u);
     assert.match(runtimeArguments, /Every role must be a lowercase slug/u);
     assert.match(runtimeArguments, /token-efficiency-auditor/u);
+    assert.doesNotMatch(runtimeArguments, /When engaging a child/u);
+    assert.doesNotMatch(runtimeArguments, /Coordination model tools are omitted/u);
     assert.doesNotMatch(runtimeArguments, /mcp_servers\.yukh-team-control/u);
   } finally {
     await rm(root, { recursive: true, force: true });


### PR DESCRIPTION
Advances #155.

Default plan execution is admitted only when every worker and synthesis agent has tool_mode none and max_commands 0. This prevents shell output from feeding a second provider inference. Direct agent.engage and agent.spawn remain fail-closed. The worker prompt now omits Coordination, team-control and delegation prose when those capabilities are absent, implementing the bounded finding from the failed qualification.

Verified: typecheck, formatting, team-control runtime tests and diff check. No model calls were made.