### PR TITLE
Expose reviewable over-budget worker summaries

### DIFF
--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -175,6 +175,7 @@ export function readTeamStatus(
           readonly timeout_ms: number;
           readonly observed_tokens: number;
           readonly completion: string;
+          readonly review_summary_available: boolean;
         }[];
         readonly tokens: ReturnType<TeamStore["status"]>["tokens"];
       };
@@ -202,11 +203,19 @@ export function readTeamStatus(
         timeout_ms: agent.timeout_ms ?? 300_000,
         observed_tokens: agent.usage?.total_tokens ?? 0,
         completion: agent.completion?.outcome ?? "pending",
+        review_summary_available: reviewSummaryAvailable(agent),
       })),
       tokens: status.tokens,
     },
     receipt,
   };
+}
+
+function reviewSummaryAvailable(agent: AgentRecord): boolean {
+  return (
+    agent.completion?.outcome === "token_budget_exceeded" &&
+    agent.completion.summary.trim().length > 0
+  );
 }
 
 export function createTeamControlServer(

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -125,10 +125,17 @@ more context.
 
 The tool-free planning profile measured 14,382 total tokens: 13,735 input,
 including 9,984 cached, and 647 output. The 20,000-token allocation provides a
-bounded margin; it is not a universal estimate. Every operational tool call is
-a separate context round and needs its own justified budget. Deterministic plan
-execution adds no manager context rounds; only useful workers and the explicit
-final synthesis consume additional model tokens.
+bounded margin; it is not a universal estimate. A zero-command worker using two
+small context files measured 15,652 total tokens against an 8,000-token
+allocation and failed closed after preserving its summary for review. Use at
+least an 18,000-token worker budget for similar review/planning workers and at
+least a 10,000-token synthesis budget unless fresh qualification evidence
+justifies less. Every operational tool call is a separate context round and
+needs its own justified budget. Deterministic plan execution adds no manager
+context rounds; only useful workers and the explicit final synthesis consume
+additional model tokens. If a worker returns useful text but exceeds budget, the
+plan fails before synthesis; inspect the worker summary as a review artifact and
+approve a fresh plan rather than retrying blindly.
 
 Codex managers run without inherited user configuration. Yukh injects only the
 tools required by the manager record; a pure planning turn receives no

--- a/packages/conversation-watch/src/watch.ts
+++ b/packages/conversation-watch/src/watch.ts
@@ -176,8 +176,13 @@ export function renderTeamChanges(
       const value = `${agent.state}:${agent.task}:${agent.max_commands ?? 8}:${agent.timeout_ms ?? 300_000}:${agent.usage?.total_tokens ?? "pending"}:${agent.completion?.outcome ?? "pending"}`;
       if (previous.get(key) === value) continue;
       previous.set(key, value);
+      const review =
+        agent.completion?.outcome === "token_budget_exceeded" &&
+        agent.completion.summary.trim().length > 0
+          ? " review=summary_available"
+          : "";
       lines.push(
-        `${agent.kind === "manager" ? "MANAGER" : "WORKER"}  ${agent.role}  ${agent.state.toUpperCase()}  runtime=${agent.runtime}${agent.profile ? ` model=${agent.profile.model}` : ""}\n        task=${compact(agent.task, 180)}${agent.profile ? `\n        mission=${compact(agent.profile.mission, 160)} skills=${agent.profile.skills.join(",") || "none"}` : ""}\n        bounds=commands:${agent.max_commands ?? 8} timeout_ms:${agent.timeout_ms ?? 300_000} tools=${agent.model_tool_mode ?? "default"}\n        tokens=${agent.usage?.total_tokens ?? "pending"}/${agent.token_budget} input=${agent.usage?.input_tokens ?? "pending"} cached=${agent.usage?.cached_input_tokens ?? "pending"} output=${agent.usage?.output_tokens ?? "pending"} reasoning=${agent.usage?.reasoning_output_tokens ?? "pending"} accounting=${agent.usage?.source ?? "pending"} completion=${agent.completion?.outcome ?? "pending"}\n        required=${agent.required_actions.join(",") || "none"} receipts=${
+        `${agent.kind === "manager" ? "MANAGER" : "WORKER"}  ${agent.role}  ${agent.state.toUpperCase()}  runtime=${agent.runtime}${agent.profile ? ` model=${agent.profile.model}` : ""}\n        task=${compact(agent.task, 180)}${agent.profile ? `\n        mission=${compact(agent.profile.mission, 160)} skills=${agent.profile.skills.join(",") || "none"}` : ""}\n        bounds=commands:${agent.max_commands ?? 8} timeout_ms:${agent.timeout_ms ?? 300_000} tools=${agent.model_tool_mode ?? "default"}\n        tokens=${agent.usage?.total_tokens ?? "pending"}/${agent.token_budget} input=${agent.usage?.input_tokens ?? "pending"} cached=${agent.usage?.cached_input_tokens ?? "pending"} output=${agent.usage?.output_tokens ?? "pending"} reasoning=${agent.usage?.reasoning_output_tokens ?? "pending"} accounting=${agent.usage?.source ?? "pending"} completion=${agent.completion?.outcome ?? "pending"}${review}\n        required=${agent.required_actions.join(",") || "none"} receipts=${
           snapshot.receipts
             .filter((receipt) => receipt.actor_agent_id === agent.agent_id)
             .map((receipt) => receipt.action)

--- a/test/runtime/conversation-watch.test.ts
+++ b/test/runtime/conversation-watch.test.ts
@@ -225,6 +225,74 @@ test("watch exposes manager accounting and receipt-backed actions", () => {
   assert.match(changes, /workers=1 synthesis=worker-4dc1c6d1/u);
 });
 
+test("watch marks over-budget summaries as reviewable", () => {
+  const changes = renderTeamChanges(
+    [
+      {
+        team: {
+          schema: 1,
+          team_id: "team-0eae0789-0d76-493a-9d89-2f44c9f819cd",
+          goal: "Review over-budget output",
+          workspace: "/tmp/project",
+          manager_runtime: "codex",
+          manager_role: "delivery-manager",
+          manager_mission: "Keep useful failed output visible",
+          max_agents: 2,
+          max_depth: 1,
+          token_budget: 20_000,
+          state: "active",
+        },
+        agents: [
+          {
+            schema: 1,
+            agent_id: "worker-3dc1c6d1-ac73-4f39-9d48-301123385534",
+            kind: "worker",
+            coordination_agent: "agent-suite-planner-61e1f378",
+            coordination_participant: "agent:suite-planner-61e1f378",
+            team_id: "team-0eae0789-0d76-493a-9d89-2f44c9f819cd",
+            runtime: "codex",
+            role: "suite-planner",
+            task: "Return a concise proposal",
+            depth: 1,
+            can_spawn: false,
+            token_budget: 8_000,
+            required_actions: [],
+            usage: {
+              schema: 1,
+              source: "codex-json-v1",
+              input_tokens: 14_869,
+              cached_input_tokens: 9_984,
+              output_tokens: 783,
+              reasoning_output_tokens: 143,
+              total_tokens: 15_652,
+              budget_outcome: "exceeded",
+            },
+            completion: {
+              schema: 1,
+              outcome: "token_budget_exceeded",
+              summary: "Useful proposal preserved for review",
+            },
+            state: "failed",
+          },
+        ],
+        receipts: [],
+        plans: [],
+        tokens: {
+          budget: 20_000,
+          allocated: 8_000,
+          observed: 15_652,
+          remaining: 4_348,
+          pending_agents: 0,
+          unaccounted_agents: 0,
+          exceeded_agents: 1,
+        },
+      },
+    ],
+    new Map(),
+  ).join("\n");
+  assert.match(changes, /completion=token_budget_exceeded review=summary_available/u);
+});
+
 test("watch accepts bounded dynamic team identities", () => {
   const dynamic = structuredClone(output);
   dynamic.result.records[0]!.event.participant.id = "agent:frontend-developer-a1b2c3d4";

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -449,6 +449,61 @@ test("accounted manager receives the exact persisted team status receipt", async
   }
 });
 
+test("compact status marks over-budget summaries as reviewable", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-reviewable-overbudget-")));
+  try {
+    const store = new TeamStore(root);
+    const managed = store.createManaged("Inspect review artifact", "codex", 2, 1, 50_000, {
+      role: "delivery-manager",
+      profile: {
+        schema: 1,
+        mission: "Inspect one team",
+        model: "default",
+        skills: [],
+        instructions: "Read compact status.",
+      },
+      task: "Call team.status",
+      token_budget: 20_000,
+      required_actions: [],
+    });
+    const worker = store.spawn(managed.team.team_id, {
+      parent_agent_id: managed.manager.agent_id,
+      runtime: "codex",
+      role: "reviewable-worker",
+      task: "Return useful output but exceed budget",
+      token_budget: 2_000,
+    });
+    store.transition(managed.team.team_id, worker.agent_id, "running");
+    store.finish(
+      managed.team.team_id,
+      worker.agent_id,
+      { schema: 1, outcome: "token_budget_exceeded", summary: "Useful review artifact" },
+      {
+        schema: 1,
+        source: "codex-json-v1",
+        input_tokens: 2_500,
+        cached_input_tokens: 1_000,
+        output_tokens: 200,
+        reasoning_output_tokens: 50,
+        total_tokens: 2_700,
+        budget_outcome: "exceeded",
+      },
+    );
+    const accounted = readTeamStatus(store, managed.team.team_id, {
+      team_id: managed.team.team_id,
+      agent_id: managed.manager.agent_id,
+    });
+    if (!("status" in accounted)) throw new Error("missing accounted status");
+    const compactWorker = accounted.status.agents.find(
+      (agent) => agent.agent_id === worker.agent_id,
+    );
+    assert.equal(compactWorker?.completion, "token_budget_exceeded");
+    assert.equal(compactWorker?.review_summary_available, true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("runtime output extracts Codex completion and refuses invented Copilot token usage", () => {
   const codex = new RuntimeOutput("codex");
   codex.line(
@@ -1346,11 +1401,25 @@ test("deterministic executor resumes reserved state and suppresses synthesis aft
     const reserved = store.reservePlan(managed.team.team_id, proposed.plan_id, proposed.digest);
     const failedWorker = reserved.worker_agent_ids[0]!;
     store.transition(managed.team.team_id, failedWorker, "running");
+    const overrunUsage = {
+      schema: 1 as const,
+      source: "codex-json-v1" as const,
+      input_tokens: 2_500,
+      cached_input_tokens: 1_000,
+      output_tokens: 200,
+      reasoning_output_tokens: 50,
+      total_tokens: 2_700,
+      budget_outcome: "exceeded" as const,
+    };
     store.finish(
       managed.team.team_id,
       failedWorker,
-      { schema: 1, outcome: "command_budget_exceeded", summary: "bounded" },
-      undefined,
+      {
+        schema: 1,
+        outcome: "token_budget_exceeded",
+        summary: "Useful but over-budget worker proposal",
+      },
+      overrunUsage,
     );
     const launches: string[] = [];
     const options = {
@@ -1373,6 +1442,10 @@ test("deterministic executor resumes reserved state and suppresses synthesis aft
     assert.equal(failed.state, "failed");
     assert.equal(failed.failure_code, "team_plan_worker_failed");
     assert.deepEqual(launches, []);
+    const reviewable = store.agent(managed.team.team_id, failedWorker);
+    assert.equal(reviewable.completion?.outcome, "token_budget_exceeded");
+    assert.equal(reviewable.completion?.summary, "Useful but over-budget worker proposal");
+    assert.equal(reviewable.usage?.total_tokens, 2_700);
     assert.equal(
       store.agent(managed.team.team_id, failed.synthesis_agent_id ?? "invalid").state,
       "defined",


### PR DESCRIPTION
## Summary

- marks over-budget worker summaries as reviewable in compact team status
- shows review=summary_available in conversation watch output
- documents measured worker/synthesis budget guidance from the zero-command Yukh suite trial

## Why

The first real manager → worker zero-command trial produced useful worker output but exceeded the worker budget. The plan correctly failed closed before synthesis, but the UI/status path made the useful preserved summary too easy to miss.

## Validation

- node --import tsx --test --test-name-pattern "over-budget|deterministic executor resumes reserved state" test/runtime/team-control.test.ts
- node --import tsx --test test/runtime/conversation-watch.test.ts
- npm run -s typecheck
- npm run -s build
- npm run -s format:check