### PR TITLE
Discover agent models before team planning

### DIFF
--- a/apps/team-control/src/main.ts
+++ b/apps/team-control/src/main.ts
@@ -1,5 +1,10 @@
 import { serveStdio } from "@modelcontextprotocol/server/stdio";
 import { fileURLToPath } from "node:url";
+import {
+  discoverCodexModels,
+  discoverCopilotModels,
+  runtimeModels,
+} from "../../../packages/team-control/src/model-discovery.js";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
 import { TeamSupervisor } from "../../../packages/team-control/src/supervisor.js";
 import { createTeamControlServer } from "./server.js";
@@ -15,6 +20,21 @@ const callerTeamId = process.env.YUKH_CALLER_TEAM_ID;
 const callerAgentId = process.env.YUKH_CALLER_AGENT_ID;
 if ((callerTeamId && !callerAgentId) || (!callerTeamId && callerAgentId))
   throw new TypeError("invalid team control caller");
+const codexModels = runtimeModels(process.env.YUKH_CODEX_MODELS, ["default"], () =>
+  discoverCodexModels(codex),
+);
+const copilotModels = runtimeModels(process.env.YUKH_COPILOT_MODELS, ["default"], () =>
+  discoverCopilotModels(copilot),
+);
+const profileEnvironment = {
+  YUKH_CODEX_MODELS: codexModels.join(","),
+  YUKH_COPILOT_MODELS: copilotModels.join(","),
+  ...Object.fromEntries(
+    ["YUKH_CODEX_SKILLS", "YUKH_COPILOT_SKILLS"]
+      .filter((name) => process.env[name] !== undefined)
+      .map((name) => [name, process.env[name]!] as const),
+  ),
+};
 const supervisor = new TeamSupervisor({
   node: process.execPath,
   worker: fileURLToPath(new URL("../../team-worker/src/main.js", import.meta.url)),
@@ -26,11 +46,7 @@ const supervisor = new TeamSupervisor({
   codex,
   copilot,
   workspace,
-  profileEnvironment: Object.fromEntries(
-    ["YUKH_CODEX_MODELS", "YUKH_COPILOT_MODELS", "YUKH_CODEX_SKILLS", "YUKH_COPILOT_SKILLS"]
-      .filter((name) => process.env[name] !== undefined)
-      .map((name) => [name, process.env[name]!] as const),
-  ),
+  profileEnvironment,
 });
 const allowlist = (name: string, fallback: readonly string[] = []): ReadonlySet<string> => {
   const raw = process.env[name];
@@ -42,8 +58,8 @@ serveStdio(
     createTeamControlServer(store, supervisor, {
       dynamicExecution: process.env.YUKH_ENABLE_UNSAFE_DYNAMIC_WORKERS === "1",
       models: {
-        codex: allowlist("YUKH_CODEX_MODELS", ["default"]),
-        copilot: allowlist("YUKH_COPILOT_MODELS", ["default"]),
+        codex: new Set(codexModels),
+        copilot: new Set(copilotModels),
       },
       skills: {
         codex: allowlist("YUKH_CODEX_SKILLS"),

--- a/apps/team-worker/src/main.ts
+++ b/apps/team-worker/src/main.ts
@@ -60,6 +60,14 @@ const delegationInstruction =
   agent.can_spawn && modelUsesTeamControl
     ? "When engaging a child, use the returned coordination_participant exactly and never add another agent: prefix. Wait for each child with agent.await and inspect its completion before synthesizing. You may create a bounded child only when explicitly delegated."
     : "";
+const allowlist = (name: string, fallback: readonly string[]): readonly string[] => {
+  const raw = process.env[name];
+  return raw ? raw.split(",").filter(Boolean) : fallback;
+};
+const planConstraintInstruction =
+  agent.output_contract === "team-plan-v1"
+    ? `Plan constraints: use only allowlisted models. Codex models: ${allowlist("YUKH_CODEX_MODELS", ["default"]).join(", ")}. Copilot models: ${allowlist("YUKH_COPILOT_MODELS", ["default"]).join(", ")}. Prefer model "default" unless the task explicitly requires another allowlisted model. Do not invent model names. Worker context_paths must name repository-relative regular UTF-8 files, at most four per worker, each file at most 4096 bytes and each worker pack at most 12288 bytes total. If a requested or attractive file may exceed 4096 bytes, omit it or choose a smaller file; never rely on a large document being accepted at execution time. Synthesis must use no context_paths.`
+    : "";
 const outputInstruction =
   agent.output_contract === "team-plan-v1"
     ? "Return only the JSON team execution plan required by the supplied output schema. Include the minimum specialists needed and one concise delivery synthesizer. Every role must be a lowercase slug matching ^[a-z][a-z0-9-]{0,31}$, for example token-efficiency-auditor; spaces are invalid. Select at most four small repository-relative context_paths per worker and none for synthesis. Do not wrap JSON in Markdown."
@@ -77,6 +85,7 @@ const prompt = [
   teamControlInstruction,
   delegationInstruction,
   coordinationInstruction,
+  planConstraintInstruction,
   outputInstruction,
 ]
   .filter(Boolean)

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -62,7 +62,10 @@ enabled_tools = ["manager.start", "team.status", "plan.status", "plan.execute", 
 default_tools_approval_mode = "writes"
 ```
 
-Add comma-separated local allowlists when using composed profiles:
+At startup, `yukh-team-control` discovers callable model IDs from the configured
+agent CLIs. Codex uses `codex debug models`; Copilot currently exposes its local
+catalog through `copilot help config`. Set model environment variables only to
+override or narrow that discovered list. Skills remain explicit local policy:
 
 ```toml
 env = { YUKH_CODEX_MODELS = "default,approved-codex-model", YUKH_COPILOT_MODELS = "default,approved-copilot-model", YUKH_CODEX_SKILLS = "api-design,testing,review", YUKH_COPILOT_SKILLS = "frontend,testing,product" }
@@ -74,8 +77,9 @@ server receipt plus the manager agent ID. Use `agent.await` from the controlling
 session to retrieve its terminal completion. For efficient automatic work, set
 `output_contract` to `team-plan-v1`: the manager returns one structured proposal
 without tools. Read its plan ID and digest from status, then call `plan.execute`
-with that exact digest. Model and skill values outside these allowlists fail
-before process launch. The
+with that exact digest. Model values outside the discovered or overridden model
+set fail before process launch; skill values outside the explicit skill
+allowlists fail the same way. The
 worker must bootstrap and join Coordination before its agent CLI starts. Set
 explicit token, command and runtime bounds: `team_token_budget`,
 `manager_token_budget`, `max_commands` and `runtime_timeout_ms`. Every planned

--- a/packages/team-control/src/model-discovery.ts
+++ b/packages/team-control/src/model-discovery.ts
@@ -1,0 +1,69 @@
+import { execFileSync } from "node:child_process";
+
+const token = /^[a-z0-9][a-z0-9._:-]{0,63}$/u;
+
+export function parseCodexModelCatalog(output: string): readonly string[] {
+  const line = output
+    .split(/\r?\n/u)
+    .map((value) => value.trim())
+    .findLast((value) => value.startsWith("{"));
+  if (!line) return [];
+  const parsed = JSON.parse(line) as { readonly models?: readonly { readonly slug?: unknown }[] };
+  return unique(
+    (parsed.models ?? [])
+      .map((model) => model.slug)
+      .filter((slug): slug is string => typeof slug === "string" && token.test(slug)),
+  );
+}
+
+export function parseCopilotConfigModels(output: string): readonly string[] {
+  const lines = output.split(/\r?\n/u);
+  const start = lines.findIndex((line) => line.includes("`model`: AI model"));
+  if (start < 0) return [];
+  const end = lines.findIndex((line, index) => index > start && line.includes("`contextTier`:"));
+  return unique(
+    lines
+      .slice(start, end < 0 ? undefined : end)
+      .map((line) => line.match(/^\s+-\s+"([^"]+)"/u)?.[1])
+      .filter((model): model is string => typeof model === "string" && token.test(model)),
+  );
+}
+
+export function runtimeModels(
+  explicit: string | undefined,
+  fallback: readonly string[],
+  discover: () => readonly string[],
+): readonly string[] {
+  if (explicit !== undefined) return unique(explicit.split(",").filter(Boolean));
+  let discovered: readonly string[] = [];
+  try {
+    discovered = discover();
+  } catch {
+    discovered = [];
+  }
+  return unique(["default", ...(discovered.length > 0 ? discovered : fallback)]);
+}
+
+export function discoverCodexModels(executable: string): readonly string[] {
+  return parseCodexModelCatalog(
+    execFileSync(executable, ["debug", "models"], {
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+    }),
+  );
+}
+
+export function discoverCopilotModels(executable: string): readonly string[] {
+  return parseCopilotConfigModels(
+    execFileSync(executable, ["help", "config"], {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+    }),
+  );
+}
+
+function unique(values: readonly string[]): readonly string[] {
+  return [...new Set(values.filter((value) => token.test(value)))];
+}

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -9,6 +9,11 @@ import { TeamStore } from "../../packages/team-control/src/store.js";
 import { TeamSupervisor } from "../../packages/team-control/src/supervisor.js";
 import { RuntimeOutput } from "../../packages/team-control/src/runtime-output.js";
 import {
+  parseCodexModelCatalog,
+  parseCopilotConfigModels,
+  runtimeModels,
+} from "../../packages/team-control/src/model-discovery.js";
+import {
   assertProfileAvailable,
   awaitAgent,
   costSafeDeterministicPlan,
@@ -98,6 +103,35 @@ test("composed profiles require allowlisted runtime models and skills", () => {
   assert.throws(
     () => assertProfileAvailable(options, "copilot", "fast-model", ["api-design"]),
     /agent_skill_unavailable/u,
+  );
+});
+
+test("runtime model discovery parses CLI catalogs and keeps explicit env authoritative", () => {
+  assert.deepEqual(
+    parseCodexModelCatalog(
+      'warning\n{"models":[{"slug":"gpt-5.6-sol"},{"slug":"bad value"},{"slug":"gpt-5.6-terra"}]}\n',
+    ),
+    ["gpt-5.6-sol", "gpt-5.6-terra"],
+  );
+  assert.deepEqual(
+    parseCopilotConfigModels(`
+  \`model\`: AI model to use for Copilot CLI.
+    - "claude-sonnet-5"
+    - "gpt-5.6-sol"
+
+  \`contextTier\`: context window tier
+`),
+    ["claude-sonnet-5", "gpt-5.6-sol"],
+  );
+  assert.deepEqual(
+    runtimeModels("default,approved-model", ["fallback"], () => ["ignored"]),
+    ["default", "approved-model"],
+  );
+  assert.deepEqual(
+    runtimeModels(undefined, ["fallback-model"], () => {
+      throw new Error("missing cli");
+    }),
+    ["default", "fallback-model"],
   );
 });
 
@@ -1120,6 +1154,8 @@ printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_inpu
           YUKH_TEAM_CONTROL_MCP_MAIN: support,
           YUKH_CODEX_EXECUTABLE: executable,
           YUKH_COPILOT_EXECUTABLE: executable,
+          YUKH_CODEX_MODELS: "default,reasoning-approved",
+          YUKH_COPILOT_MODELS: "default",
         },
       },
     );
@@ -1134,6 +1170,10 @@ printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_inpu
     assert.match(runtimeArguments, /--output-schema/u);
     assert.match(runtimeArguments, /Every role must be a lowercase slug/u);
     assert.match(runtimeArguments, /token-efficiency-auditor/u);
+    assert.match(runtimeArguments, /Codex models: default, reasoning-approved/u);
+    assert.match(runtimeArguments, /Prefer model "default"/u);
+    assert.match(runtimeArguments, /each file at most 4096 bytes/u);
+    assert.match(runtimeArguments, /worker pack at most 12288 bytes/u);
     assert.doesNotMatch(runtimeArguments, /When engaging a child/u);
     assert.doesNotMatch(runtimeArguments, /Coordination model tools are omitted/u);
     assert.doesNotMatch(runtimeArguments, /mcp_servers\.yukh-team-control/u);


### PR DESCRIPTION
## Summary

- discovers callable model IDs from configured agent CLIs at yukh-team-control startup
- uses Codex `codex debug models` and Copilot `copilot help config` parsing, with explicit env overrides still authoritative
- passes discovered model allowlists to workers and injects them into team-plan manager prompts
- keeps context-pack feasibility constraints visible before plan JSON generation: max 4 KiB per file, 12 KiB per worker pack, no synthesis context

## Why

The first real Yukh self-development manager test succeeded within budget, but proposed a plan that was not execution-ready: it selected a model outside the server allowlist and included a 9.5 KiB context file. The manager should see the concrete models and context limits before it proposes workers.

## Validation

- node --import tsx --test --test-name-pattern "runtime model discovery|structured planning manager persists" test/runtime/team-control.test.ts
- npm run -s typecheck
- npm run -s format:check
- npm run -s build
