### PR TITLE
Auto-bootstrap conversation agents

### DIFF
--- a/packages/conversation-coordinator/src/coordinator.ts
+++ b/packages/conversation-coordinator/src/coordinator.ts
@@ -22,12 +22,22 @@ export interface CoordinatorOptions {
 export interface CoordinatorEvent {
   readonly schema: 1;
   readonly event:
-    "agent_started" | "answer_verified" | "agent_completed_without_answer" | "agent_failed";
-  readonly agent: PreviewAgent;
-  readonly question_event_id: string;
-  readonly turn: number;
+    | "agent_started"
+    | "answer_verified"
+    | "agent_completed_without_answer"
+    | "agent_failed"
+    | "coordinator_coordination_failed";
+  readonly agent?: PreviewAgent;
+  readonly question_event_id?: string;
+  readonly turn?: number;
   readonly failure_code?:
-    "agent_spawn_failed" | "agent_timed_out" | "agent_exit_nonzero" | "agent_error";
+    | "agent_spawn_failed"
+    | "agent_timed_out"
+    | "agent_exit_nonzero"
+    | "agent_coordination_failed"
+    | "agent_error";
+  readonly coordination_action?: "bootstrap" | "join" | "replay";
+  readonly ykc_code?: string;
 }
 
 type RecordValue = { readonly event?: unknown };
@@ -38,7 +48,8 @@ type EventValue = {
 };
 
 function events(output: CoordinationOutput): EventValue[] {
-  if (output.status !== "ok" || !output.result || typeof output.result !== "object")
+  if (output.status === "error") throw new Error(`coordination_replay_failed:${output.code}`);
+  if (!output.result || typeof output.result !== "object")
     throw new Error("coordination_protocol_error");
   const records = (output.result as { records?: unknown }).records;
   if (!Array.isArray(records)) throw new Error("coordination_protocol_error");
@@ -107,12 +118,18 @@ export class ConversationCoordinator {
     this.#turns++;
     this.#observe("agent_started", agent, question.id);
     try {
+      await this.#prepare(agent);
       await this.#options.runner.run(
         agent,
         `Use yukh-coordination for communication. Bootstrap if required, join, replay, and find question event ${question.id}. Complete the requested work with the available local tools inside the current workspace, including files, shell, dependencies, and tests. Then answer through yukh-coordination preserving work_uri, correlation_id, and question_event_id. If another peer action is required, publish one directed follow-up question with the same work_uri.`,
       );
     } catch (error) {
-      const known = ["agent_spawn_failed", "agent_timed_out", "agent_exit_nonzero"];
+      const known = [
+        "agent_spawn_failed",
+        "agent_timed_out",
+        "agent_exit_nonzero",
+        "agent_coordination_failed",
+      ];
       const failure =
         error instanceof Error && known.includes(error.message)
           ? (error.message as CoordinatorEvent["failure_code"])
@@ -152,11 +169,51 @@ export class ConversationCoordinator {
     const launcher = this.#options.launchers[agent];
     if (!launcher) throw new Error("coordination_protocol_error");
     let output = await launcher.invoke("events replay");
-    if (output.status === "error" && output.code === "YKC-AUTH-001") {
+    if (output.status === "error" && output.code === "YKC-UNAVAILABLE-001")
+      throw new Error("coordination_unavailable");
+    if (output.status === "error") {
       const bootstrap = await launcher.invoke("session bootstrap");
-      if (bootstrap.status !== "ok") return bootstrap;
+      if (bootstrap.status !== "ok") {
+        this.#observeCoordinationFailure("bootstrap", bootstrap.code);
+        throw new Error("coordination_unavailable");
+      }
       output = await launcher.invoke("events replay");
     }
+    if (output.status === "error") {
+      this.#observeCoordinationFailure("replay", output.code);
+      throw new Error("coordination_unavailable");
+    }
     return output;
+  }
+
+  async #prepare(agent: PreviewAgent): Promise<void> {
+    const launcher = this.#options.launchers[agent];
+    if (!launcher) throw new Error("agent_coordination_failed");
+    const bootstrap = await launcher.invoke("session bootstrap");
+    if (bootstrap.status !== "ok") {
+      this.#observeCoordinationFailure("bootstrap", bootstrap.code);
+      throw new Error("agent_coordination_failed");
+    }
+    const join = await launcher.invoke("session join", {
+      capabilities: ["publish", "replay"],
+      session_label: agent,
+      status: "available",
+    });
+    if (join.status !== "ok") {
+      this.#observeCoordinationFailure("join", join.code);
+      throw new Error("agent_coordination_failed");
+    }
+  }
+
+  #observeCoordinationFailure(
+    action: NonNullable<CoordinatorEvent["coordination_action"]>,
+    code: string | undefined,
+  ) {
+    this.#options.observe?.({
+      schema: 1,
+      event: "coordinator_coordination_failed",
+      coordination_action: action,
+      ykc_code: code ?? "YKC-UNKNOWN-000",
+    });
   }
 }

--- a/packages/conversation-watch/src/watch.ts
+++ b/packages/conversation-watch/src/watch.ts
@@ -25,6 +25,8 @@ export interface LifecycleRecord {
   readonly question_event_id?: string;
   readonly turn?: number;
   readonly failure_code?: string;
+  readonly coordination_action?: string;
+  readonly ykc_code?: string;
 }
 
 export interface TeamSnapshot {
@@ -129,6 +131,7 @@ export function lifecycleRecords(raw: string, after: number): LifecycleRecord[] 
       "agent_failed",
       "coordinator_unavailable",
       "coordinator_recovered",
+      "coordinator_coordination_failed",
       "conversation_complete",
     ];
     if (
@@ -138,9 +141,16 @@ export function lifecycleRecords(raw: string, after: number): LifecycleRecord[] 
       (record.question_event_id !== undefined && !uuid.test(record.question_event_id)) ||
       (record.turn !== undefined && (!Number.isSafeInteger(record.turn) || record.turn < 1)) ||
       (record.failure_code !== undefined &&
-        !["agent_spawn_failed", "agent_timed_out", "agent_exit_nonzero", "agent_error"].includes(
-          record.failure_code,
-        ))
+        ![
+          "agent_spawn_failed",
+          "agent_timed_out",
+          "agent_exit_nonzero",
+          "agent_coordination_failed",
+          "agent_error",
+        ].includes(record.failure_code)) ||
+      (record.coordination_action !== undefined &&
+        !["bootstrap", "join", "replay"].includes(record.coordination_action)) ||
+      (record.ykc_code !== undefined && !/^YKC-[A-Z]+-[0-9]{3}$/u.test(record.ykc_code))
     )
       throw new Error("coordination_protocol_error");
     return record;
@@ -152,6 +162,8 @@ export function renderLifecycle(record: LifecycleRecord): string {
   if (record.event === "coordinator_unavailable")
     return "COORDINATOR  COORDINATION TEMPORARILY UNAVAILABLE — RETRYING";
   if (record.event === "coordinator_recovered") return "COORDINATOR  COORDINATION RECOVERED";
+  if (record.event === "coordinator_coordination_failed")
+    return `COORDINATOR  COORDINATION ${record.coordination_action?.toUpperCase() ?? "ACTION"} FAILED code=${record.ykc_code ?? "unknown"} — RETRYING`;
   const label = record.event.replaceAll("_", " ").toUpperCase();
   const failure = record.failure_code ? ` failure=${record.failure_code}` : "";
   return `COORDINATOR  ${record.agent ?? "agent"}  ${label}  turn=${record.turn ?? "?"} question=${record.question_event_id ?? "?"}${failure}`;

--- a/test/runtime/conversation-coordinator.test.ts
+++ b/test/runtime/conversation-coordinator.test.ts
@@ -48,9 +48,15 @@ function replay(answered = false) {
 
 test("coordinator wakes the addressed agent once and excludes answered work", async () => {
   const prompts: string[] = [];
+  const commands: string[] = [];
   const lifecycle: string[] = [];
   let output = replay();
-  const launcher: CoordinationLauncher = { invoke: async () => output };
+  const launcher: CoordinationLauncher = {
+    invoke: async (command) => {
+      commands.push(command);
+      return output;
+    },
+  };
   const coordinator = new ConversationCoordinator({
     launchers: { "agent-a": launcher, "agent-b": launcher },
     runner: {
@@ -68,6 +74,13 @@ test("coordinator wakes the addressed agent once and excludes answered work", as
   assert.equal(await coordinator.tick(), "handled");
   assert.equal(await coordinator.tick(), "idle");
   assert.equal(prompts.length, 1);
+  assert.deepEqual(commands, [
+    "events replay",
+    "session bootstrap",
+    "session join",
+    "events replay",
+    "events replay",
+  ]);
   assert.match(prompts[0] ?? "", new RegExp(questionId));
   assert.match(prompts[0] ?? "", /Complete the requested work/u);
   assert.deepEqual(lifecycle, ["agent_started", "answer_verified"]);
@@ -93,6 +106,73 @@ test("coordinator explicitly recovers replay authentication without retrying pub
   });
   assert.equal(await coordinator.tick(), "idle");
   assert.deepEqual(commands, ["events replay", "session bootstrap", "events replay"]);
+});
+
+test("coordinator records replay bootstrap failures with the Yukh code", async () => {
+  const lifecycle: unknown[] = [];
+  const launcher: CoordinationLauncher = {
+    invoke: async (command) =>
+      command === "session bootstrap"
+        ? { schema: 1, status: "error", command, code: "YKC-CUSTODY-001" }
+        : { schema: 1, status: "error", command, code: "YKC-AUTH-001" },
+  };
+  const coordinator = new ConversationCoordinator({
+    launchers: { "agent-a": launcher, "agent-b": launcher },
+    runner: { run: async () => assert.fail() },
+    maxTurns: 1,
+    lifetimeMs: 10_000,
+    observe: (event) => lifecycle.push(event),
+  });
+  await assert.rejects(coordinator.tick(), /coordination_unavailable/u);
+  assert.deepEqual(lifecycle, [
+    {
+      schema: 1,
+      event: "coordinator_coordination_failed",
+      coordination_action: "bootstrap",
+      ykc_code: "YKC-CUSTODY-001",
+    },
+  ]);
+});
+
+test("coordinator fails the agent before launch when target bootstrap is unavailable", async () => {
+  const lifecycle: unknown[] = [];
+  const launcher: CoordinationLauncher = {
+    invoke: async (command) =>
+      command === "events replay"
+        ? replay(false)
+        : { schema: 1, status: "error", command, code: "YKC-CUSTODY-001" },
+  };
+  const coordinator = new ConversationCoordinator({
+    launchers: { "agent-a": launcher, "agent-b": launcher },
+    runner: { run: async () => assert.fail("agent must not launch without Coordination") },
+    maxTurns: 1,
+    lifetimeMs: 10_000,
+    observe: (event) => lifecycle.push(event),
+  });
+  assert.equal(await coordinator.tick(), "handled");
+  assert.deepEqual(lifecycle, [
+    {
+      schema: 1,
+      event: "agent_started",
+      agent: "agent-b",
+      question_event_id: questionId,
+      turn: 1,
+    },
+    {
+      schema: 1,
+      event: "coordinator_coordination_failed",
+      coordination_action: "bootstrap",
+      ykc_code: "YKC-CUSTODY-001",
+    },
+    {
+      schema: 1,
+      event: "agent_failed",
+      agent: "agent-b",
+      question_event_id: questionId,
+      turn: 1,
+      failure_code: "agent_coordination_failed",
+    },
+  ]);
 });
 
 test("coordinator fails closed on malformed transcript and enforces lifetime", async () => {

--- a/test/runtime/conversation-watch.test.ts
+++ b/test/runtime/conversation-watch.test.ts
@@ -368,4 +368,13 @@ test("watch renders closed coordinator lifecycle without message content", () =>
     renderLifecycle(lifecycleRecords('{"schema":1,"event":"coordinator_recovered"}\n', 0)[0]!),
     "COORDINATOR  COORDINATION RECOVERED",
   );
+  assert.equal(
+    renderLifecycle(
+      lifecycleRecords(
+        '{"schema":1,"event":"coordinator_coordination_failed","coordination_action":"bootstrap","ykc_code":"YKC-CUSTODY-001"}\n',
+        0,
+      )[0]!,
+    ),
+    "COORDINATOR  COORDINATION BOOTSTRAP FAILED code=YKC-CUSTODY-001 — RETRYING",
+  );
 });


### PR DESCRIPTION
## What changed

- The conversation coordinator now prepares the target Coordination identity before launching the agent:
  - `session bootstrap`
  - `session join`
- Replay recovery no longer collapses Yukh errors into a generic `coordination_protocol_error`.
- The lifecycle stream records the failed Coordination action and exact `YKC-*` code.
- The watcher renders that as a readable line, for example:
  - `COORDINATOR  COORDINATION BOOTSTRAP FAILED code=YKC-CUSTODY-001 — RETRYING`
- If the target agent cannot be prepared, the coordinator fails that agent turn before launching Codex/Copilot.

## Why

The user should not have to run:

```sh
.github/scripts/yukh-local-agent.py agent-a session bootstrap
.github/scripts/yukh-local-agent.py agent-b session bootstrap
```

Those are preview/runtime details. The coordinator should own them and the viewer should explain failures.

## Validation

- `node --import tsx --test test/runtime/conversation-coordinator.test.ts test/runtime/conversation-watch.test.ts`
- `npm run -s typecheck`
- `npm run -s build`
- `npm run -s format:check`
