### PR TITLE
Treat conversation bootstrap as best effort

### DIFF
--- a/packages/conversation-coordinator/src/coordinator.ts
+++ b/packages/conversation-coordinator/src/coordinator.ts
@@ -190,10 +190,7 @@ export class ConversationCoordinator {
     const launcher = this.#options.launchers[agent];
     if (!launcher) throw new Error("agent_coordination_failed");
     const bootstrap = await launcher.invoke("session bootstrap");
-    if (bootstrap.status !== "ok") {
-      this.#observeCoordinationFailure("bootstrap", bootstrap.code);
-      throw new Error("agent_coordination_failed");
-    }
+    if (bootstrap.status !== "ok") this.#observeCoordinationFailure("bootstrap", bootstrap.code);
     const join = await launcher.invoke("session join", {
       capabilities: ["publish", "replay"],
       session_label: agent,

--- a/test/runtime/conversation-coordinator.test.ts
+++ b/test/runtime/conversation-coordinator.test.ts
@@ -134,7 +134,63 @@ test("coordinator records replay bootstrap failures with the Yukh code", async (
   ]);
 });
 
-test("coordinator fails the agent before launch when target bootstrap is unavailable", async () => {
+test("coordinator treats target bootstrap as best effort when join succeeds", async () => {
+  const lifecycle: unknown[] = [];
+  const commands: string[] = [];
+  const launcher: CoordinationLauncher = {
+    invoke: async (command) => {
+      commands.push(command);
+      if (command === "events replay") return replay(false);
+      if (command === "session bootstrap")
+        return { schema: 1, status: "error", command, code: "YKC-UNAVAILABLE-001" };
+      return { schema: 1, status: "ok", command, result: { event_id: answerId } };
+    },
+  };
+  let launched = false;
+  const coordinator = new ConversationCoordinator({
+    launchers: { "agent-a": launcher, "agent-b": launcher },
+    runner: {
+      run: async () => {
+        launched = true;
+      },
+    },
+    maxTurns: 1,
+    lifetimeMs: 10_000,
+    observe: (event) => lifecycle.push(event),
+  });
+  assert.equal(await coordinator.tick(), "handled");
+  assert.equal(launched, true);
+  assert.deepEqual(commands, [
+    "events replay",
+    "session bootstrap",
+    "session join",
+    "events replay",
+  ]);
+  assert.deepEqual(lifecycle, [
+    {
+      schema: 1,
+      event: "agent_started",
+      agent: "agent-b",
+      question_event_id: questionId,
+      turn: 1,
+    },
+    {
+      schema: 1,
+      event: "coordinator_coordination_failed",
+      coordination_action: "bootstrap",
+      ykc_code: "YKC-UNAVAILABLE-001",
+    },
+    {
+      schema: 1,
+      event: "agent_completed_without_answer",
+      agent: "agent-b",
+      question_event_id: questionId,
+      turn: 1,
+    },
+  ]);
+});
+
+test("coordinator fails the agent before launch when target join is unavailable", async () => {
   const lifecycle: unknown[] = [];
   const launcher: CoordinationLauncher = {
     invoke: async (command) =>
@@ -162,6 +218,12 @@ test("coordinator fails the agent before launch when target bootstrap is unavail
       schema: 1,
       event: "coordinator_coordination_failed",
       coordination_action: "bootstrap",
+      ykc_code: "YKC-CUSTODY-001",
+    },
+    {
+      schema: 1,
+      event: "coordinator_coordination_failed",
+      coordination_action: "join",
       ykc_code: "YKC-CUSTODY-001",
     },
     {


### PR DESCRIPTION
## What changed

- Conversation agent preparation now treats `session bootstrap` as best-effort.
- The coordinator still records the exact bootstrap `YKC-*` failure for the watcher.
- It proceeds to `session join`; if join succeeds, the agent is launched.
- If join fails, the agent turn fails before launching Codex/Copilot.

## Why

The local preview can return `YKC-UNAVAILABLE-001` for `session bootstrap` even when an existing custody/session can still `join` and `replay` successfully. The previous coordinator behavior was too strict and blocked a usable `agent-b` turn.

## Validation

- `node --import tsx --test test/runtime/conversation-coordinator.test.ts test/runtime/conversation-watch.test.ts`
- `npm run -s typecheck`
- `npm run -s build`
- `npm run -s format:check`
