### PR TITLE
Silence non-blocking bootstrap warnings

### DIFF
--- a/packages/conversation-coordinator/src/coordinator.ts
+++ b/packages/conversation-coordinator/src/coordinator.ts
@@ -189,8 +189,7 @@ export class ConversationCoordinator {
   async #prepare(agent: PreviewAgent): Promise<void> {
     const launcher = this.#options.launchers[agent];
     if (!launcher) throw new Error("agent_coordination_failed");
-    const bootstrap = await launcher.invoke("session bootstrap");
-    if (bootstrap.status !== "ok") this.#observeCoordinationFailure("bootstrap", bootstrap.code);
+    await launcher.invoke("session bootstrap");
     const join = await launcher.invoke("session join", {
       capabilities: ["publish", "replay"],
       session_label: agent,

--- a/test/runtime/conversation-coordinator.test.ts
+++ b/test/runtime/conversation-coordinator.test.ts
@@ -176,12 +176,6 @@ test("coordinator treats target bootstrap as best effort when join succeeds", as
     },
     {
       schema: 1,
-      event: "coordinator_coordination_failed",
-      coordination_action: "bootstrap",
-      ykc_code: "YKC-UNAVAILABLE-001",
-    },
-    {
-      schema: 1,
       event: "agent_completed_without_answer",
       agent: "agent-b",
       question_event_id: questionId,
@@ -213,12 +207,6 @@ test("coordinator fails the agent before launch when target join is unavailable"
       agent: "agent-b",
       question_event_id: questionId,
       turn: 1,
-    },
-    {
-      schema: 1,
-      event: "coordinator_coordination_failed",
-      coordination_action: "bootstrap",
-      ykc_code: "YKC-CUSTODY-001",
     },
     {
       schema: 1,


### PR DESCRIPTION
## What changed

- Suppresses non-blocking `session bootstrap` failures during conversation agent preparation.
- `session join` remains authoritative:
  - if join succeeds, the agent launches without noisy bootstrap lifecycle warnings;
  - if join fails, the coordinator still records the exact `YKC-*` join failure and blocks the launch.

## Why

On the local preview runtime, `session bootstrap` can return `YKC-UNAVAILABLE-001` while `session join`, `events replay` and `answer` all work. Showing that as:

```text
COORDINATOR  COORDINATION BOOTSTRAP FAILED ... — RETRYING
```

made the healthy path look broken.

## Validation

- `node --import tsx --test test/runtime/conversation-coordinator.test.ts test/runtime/conversation-watch.test.ts`
- `npm run -s typecheck`
- `npm run -s build`
- `npm run -s format:check`
