### PR TITLE
Add team token budget preflight

### DIFF
--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -86,6 +86,8 @@ export async function executePlan(
   let plan = store.plan(teamId, planId);
   if (plan.digest !== digest) throw new Error("team_plan_digest_mismatch");
   if (["completed", "failed"].includes(plan.state)) return plan;
+  const preflight = store.planTokenBudgetPreflight(teamId, planId);
+  if (preflight.outcome !== "accepted") throw new Error("team_token_budget_exceeded");
   for (const profile of [...plan.document.workers, plan.document.synthesis])
     assertProfileAvailable(options, profile.runtime, profile.model, profile.skills);
   if (plan.state === "proposed") plan = store.reservePlan(teamId, planId, digest);
@@ -341,6 +343,34 @@ export function createTeamControlServer(
   );
 
   server.registerTool(
+    "plan.preflight",
+    {
+      title: "Preflight a deterministic team plan token budget",
+      description:
+        "Read the exact per-role token allocation, total, ceiling and remaining headroom before execution",
+      inputSchema: z
+        .object({
+          team_id: id,
+          plan_id: z.string().regex(/^plan-[0-9a-f-]{36}$/u),
+        })
+        .strict(),
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    },
+    ({ team_id, plan_id }) => {
+      if (options.caller) throw new Error("agent_delegation_denied");
+      try {
+        return result(store.planTokenBudgetPreflight(team_id, plan_id));
+      } catch (error) {
+        return stableFailure(
+          error,
+          new Set(["team_plan_token_budget_invalid"]),
+          "team_plan_preflight_failed",
+        );
+      }
+    },
+  );
+
+  server.registerTool(
     "plan.execute",
     {
       title: "Execute an approved deterministic team plan",
@@ -383,6 +413,7 @@ export function createTeamControlServer(
             "team_plan_manager_incomplete",
             "agent_model_unavailable",
             "agent_skill_unavailable",
+            "team_plan_token_budget_invalid",
             "team_agent_limit",
             "team_token_budget_exceeded",
             "team_plan_wait_timeout",

--- a/packages/team-control/src/store.ts
+++ b/packages/team-control/src/store.ts
@@ -145,6 +145,25 @@ export interface TeamExecutionPlanRecord {
   readonly failure_code?: string;
 }
 
+export interface TeamTokenBudgetPreflightAllocation {
+  readonly role: string;
+  readonly kind: "existing" | "worker" | "synthesis";
+  readonly token_budget: number;
+}
+
+export interface TeamTokenBudgetPreflight {
+  readonly schema: 1;
+  readonly team_id: string;
+  readonly plan_id: string;
+  readonly ceiling: number;
+  readonly existing_allocated: number;
+  readonly planned_allocated: number;
+  readonly total_allocated: number;
+  readonly remaining_headroom: number;
+  readonly outcome: "accepted" | "exceeded";
+  readonly allocations: readonly TeamTokenBudgetPreflightAllocation[];
+}
+
 export interface TeamActionReceipt {
   readonly schema: 1;
   readonly receipt_id: string;
@@ -500,18 +519,10 @@ export class TeamStore {
       manager.completion.plan_id !== planId
     )
       throw new Error("team_plan_manager_incomplete");
-    const status = this.status(id);
-    const allocations = [
-      ...plan.document.workers.map((worker) => worker.token_budget),
-      plan.document.synthesis.token_budget,
-    ];
-    if (status.agents.length + allocations.length > status.team.max_agents)
+    const preflight = this.planTokenBudgetPreflight(id, planId);
+    if (preflight.allocations.length > this.status(id).team.max_agents)
       throw new Error("team_agent_limit");
-    if (
-      status.tokens.allocated + allocations.reduce((total, value) => total + value, 0) >
-      status.team.token_budget
-    )
-      throw new Error("team_token_budget_exceeded");
+    if (preflight.outcome !== "accepted") throw new Error("team_token_budget_exceeded");
     const workers = plan.document.workers.map((worker) =>
       this.spawn(id, {
         parent_agent_id: plan.manager_agent_id,
@@ -555,6 +566,60 @@ export class TeamStore {
       worker_agent_ids: workers.map((worker) => worker.agent_id),
       synthesis_agent_id: synthesizer.agent_id,
     });
+  }
+
+  planTokenBudgetPreflight(id: string, planId: string): TeamTokenBudgetPreflight {
+    const team = this.#readTeam(id);
+    const agents = this.#readAgents(id);
+    const plan = this.plan(id, planId);
+    const existing = agents.map((agent) => ({
+      role: agent.role,
+      kind: "existing" as const,
+      token_budget: agent.token_budget,
+    }));
+    const planned = [
+      ...plan.document.workers.map((worker) => ({
+        role: worker.role,
+        kind: "worker" as const,
+        token_budget: worker.token_budget,
+      })),
+      {
+        role: plan.document.synthesis.role,
+        kind: "synthesis" as const,
+        token_budget: plan.document.synthesis.token_budget,
+      },
+    ];
+    const allocations = [...existing, ...planned];
+    if (
+      !Number.isSafeInteger(team.token_budget) ||
+      team.token_budget < 1_000 ||
+      allocations.some(
+        (allocation) =>
+          !Number.isSafeInteger(allocation.token_budget) || allocation.token_budget < 1_000,
+      )
+    )
+      throw new Error("team_plan_token_budget_invalid");
+    const existingAllocated = existing.reduce(
+      (total, allocation) => total + allocation.token_budget,
+      0,
+    );
+    const plannedAllocated = planned.reduce(
+      (total, allocation) => total + allocation.token_budget,
+      0,
+    );
+    const totalAllocated = existingAllocated + plannedAllocated;
+    return {
+      schema: 1,
+      team_id: id,
+      plan_id: planId,
+      ceiling: team.token_budget,
+      existing_allocated: existingAllocated,
+      planned_allocated: plannedAllocated,
+      total_allocated: totalAllocated,
+      remaining_headroom: Math.max(0, team.token_budget - totalAllocated),
+      outcome: totalAllocated <= team.token_budget ? "accepted" : "exceeded",
+      allocations,
+    };
   }
 
   updatePlan(

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -445,6 +445,231 @@ test("structured planning contract rejects model-facing manager actions", async 
   }
 });
 
+test("plan token preflight reports deterministic boundaries before worker creation", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-plan-token-preflight-")));
+  try {
+    const store = new TeamStore(root);
+    const managed = store.createManaged("Preflight exact budget", "codex", 3, 1, 90_000, {
+      role: "delivery-manager",
+      profile: {
+        schema: 1,
+        mission: "Return one structured plan",
+        model: "default",
+        skills: [],
+        instructions: "Declare exact token allocations.",
+      },
+      task: "Plan",
+      token_budget: 1_000,
+      required_actions: [],
+      output_contract: "team-plan-v1",
+    });
+    const accepted = store.proposePlan(
+      managed.team.team_id,
+      managed.manager.agent_id,
+      JSON.stringify(planDocument(86_999, 2_000)),
+    );
+    const acceptedPreflight = store.planTokenBudgetPreflight(
+      managed.team.team_id,
+      accepted.plan_id,
+    );
+    assert.deepEqual(
+      acceptedPreflight.allocations.map((allocation) => [
+        allocation.kind,
+        allocation.role,
+        allocation.token_budget,
+      ]),
+      [
+        ["existing", "delivery-manager", 1_000],
+        ["worker", "backend-developer", 86_999],
+        ["synthesis", "delivery-synthesizer", 2_000],
+      ],
+    );
+    assert.equal(acceptedPreflight.total_allocated, 89_999);
+    assert.equal(acceptedPreflight.remaining_headroom, 1);
+    assert.equal(acceptedPreflight.outcome, "accepted");
+
+    const exact = store.createManaged("Preflight exact ceiling", "codex", 3, 1, 90_000, {
+      role: "delivery-manager",
+      profile: {
+        schema: 1,
+        mission: "Return one structured plan",
+        model: "default",
+        skills: [],
+        instructions: "Declare exact token allocations.",
+      },
+      task: "Plan",
+      token_budget: 1_000,
+      required_actions: [],
+      output_contract: "team-plan-v1",
+    });
+    const exactPlan = store.proposePlan(
+      exact.team.team_id,
+      exact.manager.agent_id,
+      JSON.stringify(planDocument(87_000, 2_000)),
+    );
+    assert.equal(
+      store.planTokenBudgetPreflight(exact.team.team_id, exactPlan.plan_id).outcome,
+      "accepted",
+    );
+    assert.equal(
+      store.planTokenBudgetPreflight(exact.team.team_id, exactPlan.plan_id).remaining_headroom,
+      0,
+    );
+
+    const exceeded = store.createManaged("Preflight over ceiling", "codex", 3, 1, 90_000, {
+      role: "delivery-manager",
+      profile: {
+        schema: 1,
+        mission: "Return one structured plan",
+        model: "default",
+        skills: [],
+        instructions: "Declare exact token allocations.",
+      },
+      task: "Plan",
+      token_budget: 1_000,
+      required_actions: [],
+      output_contract: "team-plan-v1",
+    });
+    const exceededPlan = store.proposePlan(
+      exceeded.team.team_id,
+      exceeded.manager.agent_id,
+      JSON.stringify(planDocument(87_001, 2_000)),
+    );
+    const exceededPreflight = store.planTokenBudgetPreflight(
+      exceeded.team.team_id,
+      exceededPlan.plan_id,
+    );
+    assert.equal(exceededPreflight.total_allocated, 90_001);
+    assert.equal(exceededPreflight.remaining_headroom, 0);
+    assert.equal(exceededPreflight.outcome, "exceeded");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("plan execution blocks over-budget proposals before creating workers", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-plan-token-block-")));
+  try {
+    const store = new TeamStore(root);
+    const managed = store.createManaged("Block expensive plan", "codex", 3, 1, 90_000, {
+      role: "delivery-manager",
+      profile: {
+        schema: 1,
+        mission: "Return one structured plan",
+        model: "default",
+        skills: [],
+        instructions: "Declare exact token allocations.",
+      },
+      task: "Plan",
+      token_budget: 1_000,
+      required_actions: [],
+      output_contract: "team-plan-v1",
+    });
+    const plan = store.proposePlan(
+      managed.team.team_id,
+      managed.manager.agent_id,
+      JSON.stringify(planDocument(87_001, 2_000)),
+    );
+    store.transition(managed.team.team_id, managed.manager.agent_id, "running");
+    store.finish(
+      managed.team.team_id,
+      managed.manager.agent_id,
+      { schema: 1, outcome: "succeeded", summary: "Approved plan", plan_id: plan.plan_id },
+      usage,
+    );
+    let launches = 0;
+    await assert.rejects(
+      () =>
+        executePlan(
+          store,
+          {
+            launch: () => {
+              launches += 1;
+              return { pid: 1, log: "unused" };
+            },
+          },
+          { models: { codex: new Set(["default"]), copilot: new Set(["default"]) } },
+          managed.team.team_id,
+          plan.plan_id,
+          plan.digest,
+          1_000,
+        ),
+      /team_token_budget_exceeded/u,
+    );
+    assert.equal(launches, 0);
+    assert.equal(store.status(managed.team.team_id).agents.length, 1);
+    assert.equal(store.plan(managed.team.team_id, plan.plan_id).state, "proposed");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("plan token preflight rejects malformed persisted allocations fail closed", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-plan-token-invalid-")));
+  try {
+    const store = new TeamStore(root);
+    const managed = store.createManaged("Reject malformed budget", "codex", 3, 1, 90_000, {
+      role: "delivery-manager",
+      profile: {
+        schema: 1,
+        mission: "Return one structured plan",
+        model: "default",
+        skills: [],
+        instructions: "Declare exact token allocations.",
+      },
+      task: "Plan",
+      token_budget: 1_000,
+      required_actions: [],
+      output_contract: "team-plan-v1",
+    });
+    const plan = store.proposePlan(
+      managed.team.team_id,
+      managed.manager.agent_id,
+      JSON.stringify(planDocument(10_000, 2_000)),
+    );
+    const planPath = join(
+      root,
+      ".yukh",
+      "teams",
+      managed.team.team_id,
+      "plans",
+      `${plan.plan_id}.json`,
+    );
+    const raw = JSON.parse(await readFile(planPath, "utf8")) as {
+      document: { workers: { token_budget?: unknown }[] };
+    };
+    raw.document.workers[0]!.token_budget = "10000";
+    await writeFile(planPath, `${JSON.stringify(raw)}\n`);
+    assert.throws(
+      () => store.planTokenBudgetPreflight(managed.team.team_id, plan.plan_id),
+      /team_plan_token_budget_invalid/u,
+    );
+    store.transition(managed.team.team_id, managed.manager.agent_id, "running");
+    store.finish(
+      managed.team.team_id,
+      managed.manager.agent_id,
+      { schema: 1, outcome: "succeeded", summary: "Malformed plan", plan_id: plan.plan_id },
+      usage,
+    );
+    await assert.rejects(
+      () =>
+        executePlan(
+          store,
+          { launch: () => ({ pid: 1, log: "unused" }) },
+          { models: { codex: new Set(["default"]), copilot: new Set(["default"]) } },
+          managed.team.team_id,
+          plan.plan_id,
+          plan.digest,
+          1_000,
+        ),
+      /team_plan_token_budget_invalid/u,
+    );
+    assert.equal(store.status(managed.team.team_id).agents.length, 1);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("accounted manager receives the exact persisted team status receipt", async () => {
   const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-manager-status-receipt-")));
   try {


### PR DESCRIPTION
## Summary

Adds a deterministic token-budget preflight for team execution plans.

## What changed

- Adds `plan.preflight` as a read-only Team Control tool.
- Reports existing allocation, planned allocation, total, ceiling, headroom, outcome and per-role entries.
- Makes `plan.execute` fail closed before worker creation when the plan exceeds the team ceiling.
- Reuses the same preflight check during plan reservation.
- Adds tests for 89,999 / 90,000 / 90,001 boundaries, malformed persisted allocations, and no-worker-created over-budget rejection.

## Validation

- `npm run -s typecheck`
- `node --import tsx --test test/runtime/team-control.test.ts`
- `npm run -s build`
- `npm run -s format:check`
- `git diff --check`

## Notes

The full `npm test` run still has unrelated runtime preview/gateway failures in this worktree; `test/runtime/team-control.test.ts` passes both focused and inside the full run.
