### PR TITLE
Use Copilot SDK for model discovery

### DIFF
--- a/apps/team-control/src/main.ts
+++ b/apps/team-control/src/main.ts
@@ -4,6 +4,7 @@ import {
   discoverCodexModels,
   discoverCopilotModels,
   runtimeModels,
+  runtimeModelsAsync,
 } from "../../../packages/team-control/src/model-discovery.js";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
 import { TeamSupervisor } from "../../../packages/team-control/src/supervisor.js";
@@ -23,7 +24,7 @@ if ((callerTeamId && !callerAgentId) || (!callerTeamId && callerAgentId))
 const codexModels = runtimeModels(process.env.YUKH_CODEX_MODELS, ["default"], () =>
   discoverCodexModels(codex),
 );
-const copilotModels = runtimeModels(process.env.YUKH_COPILOT_MODELS, ["default"], () =>
+const copilotModels = await runtimeModelsAsync(process.env.YUKH_COPILOT_MODELS, ["default"], () =>
   discoverCopilotModels(copilot),
 );
 const profileEnvironment = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,13 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@github/copilot-sdk": "^1.0.11",
         "@modelcontextprotocol/server": "2.0.0",
         "ajv": "8.20.0",
         "zod": "4.4.3"
+      },
+      "bin": {
+        "yukh": "bin/yukh.mjs"
       },
       "devDependencies": {
         "@modelcontextprotocol/client": "2.0.0",
@@ -466,6 +470,411 @@
         "node": ">=18"
       }
     },
+    "node_modules/@github/copilot": {
+      "version": "1.0.80",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.80.tgz",
+      "integrity": "sha512-6tf93ZF56KOiTTAjK/UhLZkl1W543IzaTQly288kockJZFswpRTnQEI00Yvacpb39DTvTYu3/ha9SeKpo/pgZQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "detect-libc": "^2.1.2"
+      },
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.80",
+        "@github/copilot-darwin-x64": "1.0.80",
+        "@github/copilot-linux-arm64": "1.0.80",
+        "@github/copilot-linux-x64": "1.0.80",
+        "@github/copilot-linuxmusl-arm64": "1.0.80",
+        "@github/copilot-linuxmusl-x64": "1.0.80",
+        "@github/copilot-win32-arm64": "1.0.80",
+        "@github/copilot-win32-x64": "1.0.80"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.80",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.80.tgz",
+      "integrity": "sha512-fzn4PnSx3+O/a3ip72KVsjnzORsEygK+0i21bFAnFBYS+0Wi1Pk+o/CmNsJ7aRbf1enSJrcH8UDVkyc9pMGEBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.80",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.80.tgz",
+      "integrity": "sha512-PKsyGk5DccNzR3bYXcYTGB9N6sHzhzGqEwq/2t1qBwqPbrC98Zo2dOT2G40/QYpJ4XdrGmTmdmfPJQ9PJknlIQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.80",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.80.tgz",
+      "integrity": "sha512-8oXwN2luyHEjIoSk8AkATBjXDhRoQtuiUvC93GpfQKFHI+I1eoOVwIsAq5fKP8jNCF2rOrYFIcTjwmRt38kCcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.80",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.80.tgz",
+      "integrity": "sha512-qv1ytVNwA3IDK7kcQow+fAikD67t42+AQ8X42bK/7oudNiv4frVZMO0yh1DYIebVRcmEhmPvbVPY/ptVUK3cbA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-arm64": {
+      "version": "1.0.80",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.80.tgz",
+      "integrity": "sha512-Qjyi+OlVnPC4Lkuy7blDMMwMUQI/yELl7gDnqQlaN8TEbhZqZueuf3p0a+kEjXcNsw4XtNYQc0eMJqSIYy/Pjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-x64": {
+      "version": "1.0.80",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.80.tgz",
+      "integrity": "sha512-rBg8pugf+5FhiZxi2zkOr+rlcOVF6Xg63j1FvryfwPT4DJ2w5Na7O3lpS4sgu8QmsP5H+dAqjlXYLYsvSoVQ0g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.11.tgz",
+      "integrity": "sha512-ngrnfa9052fLTOMoY0iiQS2B6pFDYJpWNj3syCdjzdje0R5mWoij9b8exJZciLvX7BbJjKz2/lIdwo24av3e3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot": "^1.0.79",
+        "koffi": "^3.1.0",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.80",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.80.tgz",
+      "integrity": "sha512-+f7Vkd3vt2DYOxRnS8dStvYu3DY638N/AuLuIjxZp1F9GgwCUZK69wspqIxg2L59PmRRQcH4AGTrRDR60ENIZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.80",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.80.tgz",
+      "integrity": "sha512-PO0kPqhRTWQfsqGaj4UN3cj8ttkcJYy4wmXiArtFm+03AIFu8xTvuhQDPn2xEOsUome7m7t2XomKoavcrCcRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-arm64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.1.5.tgz",
+      "integrity": "sha512-IpqITl2fJi3QN9bTtNnygWPdK7ScSjw3xtGu8e6feYGvimCysu+spgI5KyeslY2jTnqxGS9xr8pLAbLhGJ8edA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-x64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.1.5.tgz",
+      "integrity": "sha512-4Tia4BS5EV/+vN9eIrdToanVe+U/2VqTZCBgOzoUbPKjgky51eqM+3J4qdRUvmYJohcJNPob5/hsxeItUZrl1g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-arm64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.1.5.tgz",
+      "integrity": "sha512-bP94uzseFO79NG3flpU3WxfyvltD+jzC/kN8FDZLi8J0VUZNW1Wmu8yq87KEzjX1qT9KyX4Y+elVbGqHXHTv2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-ia32": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.1.5.tgz",
+      "integrity": "sha512-raFXXAPHzvCQWhaoMUF+Cc2ZWgg2UBU0RVoowHZhaw9nQYPC1pERcPRH+JA+SNIN6g4d2GFW6uPFc+QbUhsagA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-x64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.1.5.tgz",
+      "integrity": "sha512-h6RyBZmPMBIDWTABkJIhzDdYwSnYAJvTacHpEjbT55Arkmw1H15Rl7CFtXuEuBrqh+uivoCrRgA6vszl9CsJ9g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-arm64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.1.5.tgz",
+      "integrity": "sha512-u0vCmKPu4yQDhl/ri1J6U3vDnvYtYjoZaIWb+oMbRXhVZeiqdE53MGPb+q2A7Dj2n9IbYloAfEICQbL6l0pmiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-ia32": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.1.5.tgz",
+      "integrity": "sha512-Xa5JbumWglwPVZgrJcLhqyC1wCWlfm7+C00p3FuOTNGp0qoYuf2/tOoAh0/q7+taVm30cMopu/6lRHwdmF6I/w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-loong64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.1.5.tgz",
+      "integrity": "sha512-F3i2CeTcqVBUQiSRUBSEzX1VgtXmLLiZb/ouZtXHkWpTLhJNd9TH7s3CizTofci0VRqlKdexGUYhK5vzPDAAHA==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-riscv64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.1.5.tgz",
+      "integrity": "sha512-2TgQuzy+4PfDg+rw3kOmN6lywEWdzKT3eaLPbOp0b/9DaN7CLBJ/QIR5GhGsMNpeI30zU0YzFeYFxoVoJ/LqFw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-x64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.1.5.tgz",
+      "integrity": "sha512-2yaIg/1V0m4CiAUMzG4CIlWmq1WJ+QBMlFfaGr9su+OH5fuIqC7V3BbMiB03IwIl1VofIZO5JA4Db4lID8tpbw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-ia32": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.1.5.tgz",
+      "integrity": "sha512-8/OXd+u9omMooykhvdJPEP7u6FFzzrrFo9gOmSHc9/DPt3XkVYOtSsE97PDk6zYaAzwIYHSKjHvIXsfFwFc7sg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-x64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.1.5.tgz",
+      "integrity": "sha512-SpeqldKkuDk2aTj5PVWumy7eq6Tr2GtBPAOI1NiDHhg8xe433KraxrA9V9UjEd+1+kSGJQGR04nQByN3MPA9PQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-arm64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.1.5.tgz",
+      "integrity": "sha512-uej3YAEKAhlfVPoIo5sOwtxhTLRVJ01LgtWrKGpnnAQU3C+Ilmaxdh+Oc2xc1G3NK30N5eCVJpyO9r3pjKC6Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-ia32": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.1.5.tgz",
+      "integrity": "sha512-d42jv2f4PwtJGNJS19Xfn/BRtGsBNNVkw0O0K5tkIGI+yNq4MnPTSUsaGbDIkCLNsCgk/LFqAaE8BExyCdrujA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-x64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.1.5.tgz",
+      "integrity": "sha512-Pyo1WEHEP6Ek2NEn2pquwJzSPLOdY4vymoPSz0an1DgvFWSkOyBYYkGVoxL1ajfj5I1pPdXysYqixtVTzAtOfQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
     "node_modules/@modelcontextprotocol/client": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
@@ -891,6 +1300,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -1028,6 +1446,33 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/koffi": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-3.1.5.tgz",
+      "integrity": "sha512-XVwwrxg0Ca6IEUQF4YtGIU4XN0LSselFYpYvgfhh8wafCunhEEx5hPr7LZhp5QyeFA/LcRsKHTqncCdjWjWAlg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      },
+      "optionalDependencies": {
+        "@koromix/koffi-darwin-arm64": "3.1.5",
+        "@koromix/koffi-darwin-x64": "3.1.5",
+        "@koromix/koffi-freebsd-arm64": "3.1.5",
+        "@koromix/koffi-freebsd-ia32": "3.1.5",
+        "@koromix/koffi-freebsd-x64": "3.1.5",
+        "@koromix/koffi-linux-arm64": "3.1.5",
+        "@koromix/koffi-linux-ia32": "3.1.5",
+        "@koromix/koffi-linux-loong64": "3.1.5",
+        "@koromix/koffi-linux-riscv64": "3.1.5",
+        "@koromix/koffi-linux-x64": "3.1.5",
+        "@koromix/koffi-openbsd-ia32": "3.1.5",
+        "@koromix/koffi-openbsd-x64": "3.1.5",
+        "@koromix/koffi-win32-arm64": "3.1.5",
+        "@koromix/koffi-win32-ia32": "3.1.5",
+        "@koromix/koffi-win32-x64": "3.1.5"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -1168,6 +1613,15 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "typecheck": "tsc --project tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@github/copilot-sdk": "^1.0.11",
     "@modelcontextprotocol/server": "2.0.0",
     "ajv": "8.20.0",
     "zod": "4.4.3"

--- a/packages/team-control/src/model-discovery.ts
+++ b/packages/team-control/src/model-discovery.ts
@@ -2,6 +2,35 @@ import { execFileSync } from "node:child_process";
 
 const token = /^[a-z0-9][a-z0-9._:-]{0,63}$/u;
 
+export interface CopilotSdkModelInfo {
+  readonly id: string;
+  readonly [key: string]: unknown;
+}
+
+interface CopilotSdkClient {
+  start(): Promise<void>;
+  stop(): Promise<unknown>;
+  forceStop(): Promise<void>;
+  listModels(): Promise<readonly CopilotSdkModelInfo[]>;
+}
+
+interface CopilotSdkModule {
+  readonly CopilotClient: new (options: {
+    readonly connection: unknown;
+    readonly logLevel: "none";
+  }) => CopilotSdkClient;
+  readonly RuntimeConnection: {
+    readonly forStdio: (options: {
+      readonly path: string;
+      readonly env: Record<string, string>;
+    }) => unknown;
+  };
+}
+
+const importModule = new Function("specifier", "return import(specifier)") as (
+  specifier: string,
+) => Promise<unknown>;
+
 export function parseCodexModelCatalog(output: string): readonly string[] {
   const line = output
     .split(/\r?\n/u)
@@ -44,6 +73,21 @@ export function runtimeModels(
   return unique(["default", ...(discovered.length > 0 ? discovered : fallback)]);
 }
 
+export async function runtimeModelsAsync(
+  explicit: string | undefined,
+  fallback: readonly string[],
+  discover: () => Promise<readonly string[]>,
+): Promise<readonly string[]> {
+  if (explicit !== undefined) return unique(explicit.split(",").filter(Boolean));
+  let discovered: readonly string[] = [];
+  try {
+    discovered = await discover();
+  } catch {
+    discovered = [];
+  }
+  return unique(["default", ...(discovered.length > 0 ? discovered : fallback)]);
+}
+
 export function discoverCodexModels(executable: string): readonly string[] {
   return parseCodexModelCatalog(
     execFileSync(executable, ["debug", "models"], {
@@ -54,7 +98,47 @@ export function discoverCodexModels(executable: string): readonly string[] {
   );
 }
 
-export function discoverCopilotModels(executable: string): readonly string[] {
+export async function discoverCopilotModels(executable: string): Promise<readonly string[]> {
+  const sdk = await discoverCopilotModelsWithSdk(executable);
+  if (sdk.length > 0) return sdk;
+  return discoverCopilotModelsFromCliHelp(executable);
+}
+
+export async function discoverCopilotModelsWithSdk(
+  executable: string,
+  timeoutMs = 15_000,
+): Promise<readonly string[]> {
+  const sdk = (await importModule("@github/copilot-sdk")) as CopilotSdkModule;
+  const client = new sdk.CopilotClient({
+    connection: sdk.RuntimeConnection.forStdio({
+      path: executable,
+      env: {
+        HOME: process.env.HOME ?? "",
+        PATH: process.env.PATH ?? "/usr/bin:/bin",
+      },
+    }),
+    logLevel: "none",
+  });
+  try {
+    await withTimeout(client.start(), timeoutMs, "copilot_sdk_start_timeout");
+    const models = await withTimeout(client.listModels(), timeoutMs, "copilot_sdk_models_timeout");
+    return parseCopilotSdkModels(models);
+  } finally {
+    try {
+      await client.stop();
+    } catch {
+      try {
+        await client.forceStop();
+      } catch {}
+    }
+  }
+}
+
+export function parseCopilotSdkModels(models: readonly CopilotSdkModelInfo[]): readonly string[] {
+  return unique(models.map((model) => model.id).filter((id) => token.test(id)));
+}
+
+export function discoverCopilotModelsFromCliHelp(executable: string): readonly string[] {
   return parseCopilotConfigModels(
     execFileSync(executable, ["help", "config"], {
       encoding: "utf8",
@@ -62,6 +146,20 @@ export function discoverCopilotModels(executable: string): readonly string[] {
       stdio: ["ignore", "pipe", "pipe"],
     }),
   );
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 function unique(values: readonly string[]): readonly string[] {

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -11,7 +11,9 @@ import { RuntimeOutput } from "../../packages/team-control/src/runtime-output.js
 import {
   parseCodexModelCatalog,
   parseCopilotConfigModels,
+  parseCopilotSdkModels,
   runtimeModels,
+  runtimeModelsAsync,
 } from "../../packages/team-control/src/model-discovery.js";
 import {
   assertProfileAvailable,
@@ -132,6 +134,56 @@ test("runtime model discovery parses CLI catalogs and keeps explicit env authori
       throw new Error("missing cli");
     }),
     ["default", "fallback-model"],
+  );
+});
+
+test("runtime model discovery accepts Copilot SDK model metadata", () => {
+  assert.deepEqual(
+    parseCopilotSdkModels([
+      {
+        id: "claude-sonnet-5",
+        name: "Claude Sonnet 5",
+        capabilities: {},
+      },
+      {
+        id: "bad value",
+        name: "Rejected",
+        capabilities: {},
+      },
+      {
+        id: "gpt-5.6-sol",
+        name: "GPT 5.6 Sol",
+        capabilities: {},
+      },
+      {
+        id: "claude-sonnet-5",
+        name: "Duplicate",
+        capabilities: {},
+      },
+    ]),
+    ["claude-sonnet-5", "gpt-5.6-sol"],
+  );
+});
+
+test("async runtime model discovery keeps env authoritative and falls back safely", async () => {
+  assert.deepEqual(
+    await runtimeModelsAsync("default,approved-model", ["fallback"], async () => {
+      throw new Error("must not discover");
+    }),
+    ["default", "approved-model"],
+  );
+  assert.deepEqual(
+    await runtimeModelsAsync(undefined, ["fallback-model"], async () => {
+      throw new Error("sdk unavailable");
+    }),
+    ["default", "fallback-model"],
+  );
+  assert.deepEqual(
+    await runtimeModelsAsync(undefined, ["fallback-model"], async () => [
+      "claude-sonnet-5",
+      "bad value",
+    ]),
+    ["default", "claude-sonnet-5"],
   );
 });
 


### PR DESCRIPTION
## Summary

Uses the official GitHub Copilot SDK for Copilot model discovery, with the existing CLI-help parser retained as fallback.

## What changed

- Adds `@github/copilot-sdk` as a runtime dependency.
- Adds SDK-first Copilot model discovery via `CopilotClient.listModels()`.
- Keeps explicit `YUKH_COPILOT_MODELS` authoritative.
- Keeps the legacy `copilot help config` parser as fallback if SDK discovery fails or returns no models.
- Avoids compile-time SDK type imports because the repo uses `skipLibCheck: false` and the SDK dependency currently exposes declaration issues under this TypeScript setup.
- Updates Team Control bootstrap to await Copilot discovery.
- Adds deterministic tests for SDK model metadata parsing and async fallback behavior.

## Validation

- `npm run -s typecheck`
- `node --import tsx --test test/runtime/team-control.test.ts`
- `npm run -s build`
- `npm run -s format:check`
- SDK runtime probe on rufy-worker: discovered 13 Copilot models via SDK, including `gpt-5.6-sol` and `gpt-5.6-terra`.
- `git diff --check`

## Notes

The SDK documentation states the SDK exposes `listModels()` for available runtime models. This PR uses that path first and keeps the old CLI parser only as resilience fallback.
