### PR TITLE
Add role profile policy for teams

### DIFF
--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -2,8 +2,12 @@ import { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
 import { TeamSupervisor } from "../../../packages/team-control/src/supervisor.js";
-import type { AgentRecord } from "../../../packages/team-control/src/store.js";
-import type { TeamExecutionPlanRecord } from "../../../packages/team-control/src/store.js";
+import type {
+  AgentRecord,
+  AgentRuntime,
+  ModelToolMode,
+  TeamExecutionPlanRecord,
+} from "../../../packages/team-control/src/store.js";
 
 const id = z.string().regex(/^team-[0-9a-f-]{36}$/u);
 
@@ -41,6 +45,25 @@ export interface TeamControlOptions {
   readonly dynamicExecution?: boolean;
 }
 
+export type TeamWorkProfile = "review" | "implementation" | "synthesis";
+
+export interface RoleProfilePolicy {
+  readonly schema: 1;
+  readonly role: string;
+  readonly work_profile: TeamWorkProfile;
+  readonly recommendation: {
+    readonly runtime: AgentRuntime;
+    readonly model: string;
+    readonly skills: readonly string[];
+    readonly token_budget: number;
+    readonly tool_mode: ModelToolMode;
+    readonly max_commands: number;
+    readonly runtime_timeout_ms: number;
+  };
+  readonly omitted_skills: readonly string[];
+  readonly rationale: string;
+}
+
 export function dynamicExecutionEnabled(options: TeamControlOptions): boolean {
   return options.dynamicExecution !== false;
 }
@@ -63,6 +86,100 @@ export function assertProfileAvailable(
   const availableSkills = options.skills?.[runtime] ?? new Set<string>();
   if (skills.some((skill) => !availableSkills.has(skill)))
     throw new Error("agent_skill_unavailable");
+}
+
+export function roleProfilePolicy(
+  options: TeamControlOptions,
+  role: string,
+  workProfile: TeamWorkProfile,
+  preferredRuntime?: AgentRuntime,
+): RoleProfilePolicy {
+  const runtime = selectRuntime(options, role, preferredRuntime);
+  const skills = selectSkills(options, runtime, role);
+  const budget = budgetFor(workProfile);
+  return {
+    schema: 1,
+    role,
+    work_profile: workProfile,
+    recommendation: {
+      runtime,
+      model: selectModel(options, runtime),
+      skills: skills.selected,
+      token_budget: budget.token_budget,
+      tool_mode: budget.tool_mode,
+      max_commands: budget.max_commands,
+      runtime_timeout_ms: budget.runtime_timeout_ms,
+    },
+    omitted_skills: skills.omitted,
+    rationale: rationaleFor(role, runtime, workProfile),
+  };
+}
+
+function selectRuntime(
+  options: TeamControlOptions,
+  role: string,
+  preferredRuntime?: AgentRuntime,
+): AgentRuntime {
+  if (preferredRuntime && hasRuntime(options, preferredRuntime)) return preferredRuntime;
+  const frontend = /\b(frontend|front-end|ui|ux|react|vite|web)\b/u.test(role);
+  if (frontend && hasRuntime(options, "copilot")) return "copilot";
+  if (hasRuntime(options, "codex")) return "codex";
+  return "copilot";
+}
+
+function hasRuntime(options: TeamControlOptions, runtime: AgentRuntime): boolean {
+  return (options.models?.[runtime].size ?? options.modelCatalog?.[runtime].models.length ?? 0) > 0;
+}
+
+function selectModel(options: TeamControlOptions, runtime: AgentRuntime): string {
+  const models = [...(options.models?.[runtime] ?? options.modelCatalog?.[runtime].models ?? [])];
+  return models.includes("default") ? "default" : (models[0] ?? "default");
+}
+
+function selectSkills(
+  options: TeamControlOptions,
+  runtime: AgentRuntime,
+  role: string,
+): { readonly selected: readonly string[]; readonly omitted: readonly string[] } {
+  const desired = desiredSkills(role);
+  const available = options.skills?.[runtime] ?? new Set<string>();
+  const selected = desired.filter((skill) => available.has(skill));
+  return {
+    selected,
+    omitted: desired.filter((skill) => !selected.includes(skill)),
+  };
+}
+
+function desiredSkills(role: string): readonly string[] {
+  if (/\b(frontend|front-end|ui|ux|react|vite|web)\b/u.test(role)) return ["frontend"];
+  if (/\b(qa|test|tester|quality)\b/u.test(role)) return ["testing"];
+  if (/\b(security|threat|audit)\b/u.test(role)) return ["security", "testing"];
+  if (/\b(doc|docs|documentation|site)\b/u.test(role)) return ["documentation"];
+  if (/\b(product|manager|pm|delivery)\b/u.test(role)) return ["product", "testing"];
+  if (/\b(backend|api|server|integration)\b/u.test(role)) return ["api-design", "testing"];
+  return ["testing"];
+}
+
+function budgetFor(workProfile: TeamWorkProfile): {
+  readonly token_budget: number;
+  readonly tool_mode: ModelToolMode;
+  readonly max_commands: number;
+  readonly runtime_timeout_ms: number;
+} {
+  if (workProfile === "review")
+    return { token_budget: 18_000, tool_mode: "none", max_commands: 0, runtime_timeout_ms: 60_000 };
+  if (workProfile === "synthesis")
+    return { token_budget: 16_000, tool_mode: "none", max_commands: 0, runtime_timeout_ms: 60_000 };
+  return {
+    token_budget: 50_000,
+    tool_mode: "team",
+    max_commands: 8,
+    runtime_timeout_ms: 300_000,
+  };
+}
+
+function rationaleFor(role: string, runtime: AgentRuntime, workProfile: TeamWorkProfile): string {
+  return `${role} mapped to ${runtime} with a ${workProfile} budget profile; unavailable skills are omitted rather than invented.`;
 }
 
 export async function awaitAgent(
@@ -270,8 +387,8 @@ export function createTeamControlServer(
           instructions: z.string().min(1).max(4_096),
           task: z.string().min(1).max(4_096),
           required_actions: z
-            .array(z.enum(["team.status", "agent.engage", "agent.await"]))
-            .max(3)
+            .array(z.enum(["policy.profile", "team.status", "agent.engage", "agent.await"]))
+            .max(4)
             .default([]),
           output_contract: z.enum(["summary", "team-plan-v1"]).default("summary"),
           max_agents: z.number().int().min(1).max(32).default(16),
@@ -478,6 +595,40 @@ export function createTeamControlServer(
           mission: manager_mission ?? goal,
         }),
       );
+    },
+  );
+
+  server.registerTool(
+    "policy.profile",
+    {
+      title: "Recommend a bounded specialist profile",
+      description:
+        "Map a role to an allowlisted runtime, model, skills and token budget before engaging a worker",
+      inputSchema: z
+        .object({
+          team_id: id.optional(),
+          role: z.string().regex(/^[a-z][a-z0-9-]{0,31}$/u),
+          work_profile: z.enum(["review", "implementation", "synthesis"]).default("implementation"),
+          preferred_runtime: z.enum(["codex", "copilot"]).optional(),
+        })
+        .strict(),
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    },
+    ({ team_id, role, work_profile, preferred_runtime }) => {
+      if (options.caller) {
+        if (!team_id || team_id !== options.caller.team_id)
+          throw new Error("agent_delegation_denied");
+        return result({
+          ...roleProfilePolicy(options, role, work_profile, preferred_runtime),
+          receipt: store.receipt(
+            team_id,
+            "policy.profile",
+            options.caller.agent_id,
+            options.caller.agent_id,
+          ),
+        });
+      }
+      return result(roleProfilePolicy(options, role, work_profile, preferred_runtime));
     },
   );
 

--- a/apps/team-worker/src/main.ts
+++ b/apps/team-worker/src/main.ts
@@ -40,7 +40,7 @@ const modelTeamTools = [
       ? []
       : modelToolMode === "team"
         ? agent.can_spawn
-          ? ["team.status", "agent.status", "agent.engage", "agent.await"]
+          ? ["policy.profile", "team.status", "agent.status", "agent.engage", "agent.await"]
           : ["team.status", "agent.status"]
         : agent.kind === "manager"
           ? agent.required_actions

--- a/packages/team-control/src/store.ts
+++ b/packages/team-control/src/store.ts
@@ -105,6 +105,7 @@ export interface ContextPackDocument extends ContextPackMetadata {
 
 export type TeamAction =
   | "manager.start"
+  | "policy.profile"
   | "team.status"
   | "agent.engage"
   | "agent.await"
@@ -273,12 +274,13 @@ export class TeamStore {
       manager.token_budget < 1_000 ||
       manager.token_budget > 2_000_000 ||
       manager.token_budget > tokenBudget ||
-      manager.required_actions.length > 3 ||
+      manager.required_actions.length > 4 ||
       new Set(manager.required_actions).size !== manager.required_actions.length ||
       (manager.output_contract === "team-plan-v1" && manager.required_actions.length > 0) ||
       !this.#validRuntimeBounds(manager.max_commands ?? 8, manager.timeout_ms ?? 300_000) ||
       manager.required_actions.some(
-        (action) => !["team.status", "agent.engage", "agent.await"].includes(action),
+        (action) =>
+          !["policy.profile", "team.status", "agent.engage", "agent.await"].includes(action),
       )
     )
       throw new TypeError("invalid manager definition");
@@ -692,6 +694,7 @@ export class TeamStore {
     if (
       ![
         "manager.start",
+        "policy.profile",
         "team.status",
         "agent.engage",
         "agent.await",

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -25,6 +25,7 @@ import {
   dynamicExecutionEnabled,
   executePlan,
   readTeamStatus,
+  roleProfilePolicy,
 } from "../../apps/team-control/src/server.js";
 
 test("real dynamic execution can fail closed without changing deterministic helpers", () => {
@@ -109,6 +110,43 @@ test("composed profiles require allowlisted runtime models and skills", () => {
     () => assertProfileAvailable(options, "copilot", "fast-model", ["api-design"]),
     /agent_skill_unavailable/u,
   );
+});
+
+test("role profile policy maps specialists to allowlisted runtime models skills and budgets", () => {
+  const options = {
+    models: {
+      codex: new Set(["default", "gpt-5.6-sol"]),
+      copilot: new Set(["default", "claude-sonnet-5"]),
+    },
+    skills: {
+      codex: new Set(["api-design", "testing", "product"]),
+      copilot: new Set(["frontend"]),
+    },
+  };
+  assert.deepEqual(
+    roleProfilePolicy(options, "frontend-developer", "implementation").recommendation,
+    {
+      runtime: "copilot",
+      model: "default",
+      skills: ["frontend"],
+      token_budget: 50_000,
+      tool_mode: "team",
+      max_commands: 8,
+      runtime_timeout_ms: 300_000,
+    },
+  );
+  assert.deepEqual(roleProfilePolicy(options, "backend-developer", "review").recommendation, {
+    runtime: "codex",
+    model: "default",
+    skills: ["api-design", "testing"],
+    token_budget: 18_000,
+    tool_mode: "none",
+    max_commands: 0,
+    runtime_timeout_ms: 60_000,
+  });
+  assert.deepEqual(roleProfilePolicy(options, "security-reviewer", "review").omitted_skills, [
+    "security",
+  ]);
 });
 
 test("runtime model discovery parses CLI catalogs and keeps explicit env authoritative", () => {
@@ -492,6 +530,52 @@ test("managed team rejects a manager budget above the team budget", async () => 
         }),
       /invalid manager definition/u,
     );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("managed teams can require a role policy receipt before completion", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-policy-receipt-")));
+  try {
+    const store = new TeamStore(root);
+    const managed = store.createManaged("Choose a bounded frontend worker", "codex", 2, 1, 50_000, {
+      role: "delivery-manager",
+      profile: {
+        schema: 1,
+        mission: "Inspect policy before engaging specialists",
+        model: "default",
+        skills: [],
+        instructions: "Use policy.profile before claiming completion.",
+      },
+      task: "Resolve a worker profile",
+      token_budget: 20_000,
+      required_actions: ["policy.profile"],
+    });
+    store.transition(managed.team.team_id, managed.manager.agent_id, "running");
+    assert.throws(
+      () =>
+        store.finish(
+          managed.team.team_id,
+          managed.manager.agent_id,
+          { schema: 1, outcome: "succeeded", summary: "Skipped policy lookup" },
+          usage,
+        ),
+      /required_action_missing/u,
+    );
+    store.receipt(
+      managed.team.team_id,
+      "policy.profile",
+      managed.manager.agent_id,
+      managed.manager.agent_id,
+    );
+    const completed = store.finish(
+      managed.team.team_id,
+      managed.manager.agent_id,
+      { schema: 1, outcome: "succeeded", summary: "Policy checked" },
+      usage,
+    );
+    assert.equal(completed.state, "completed");
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- add a read-only `policy.profile` Team Control tool that maps a role to an allowlisted runtime/model/skill set and bounded token profile
- make `policy.profile` a receipt-backed manager action so managers can prove they checked profile policy before completion
- expose the tool to manager workers that can spawn children, without granting shell or automatic worker creation

Governing issue: #127

## Validation
- `npm run -s typecheck`
- `node --import tsx --test test/runtime/team-control.test.ts test/runtime/conversation-watch.test.ts`
- `npm run -s build`
- `npm run -s format:check`
- `git diff --check`
