### PR TITLE
Propagate dynamic team worker policy to managers

### DIFF
--- a/apps/team-worker/src/main.ts
+++ b/apps/team-worker/src/main.ts
@@ -101,7 +101,15 @@ const teamControlEnv = {
   YUKH_CALLER_TEAM_ID: agent.team_id,
   YUKH_CALLER_AGENT_ID: agent.agent_id,
   ...Object.fromEntries(
-    ["YUKH_CODEX_MODELS", "YUKH_COPILOT_MODELS", "YUKH_CODEX_SKILLS", "YUKH_COPILOT_SKILLS"]
+    [
+      "YUKH_CODEX_MODELS",
+      "YUKH_COPILOT_MODELS",
+      "YUKH_CODEX_MODEL_SOURCE",
+      "YUKH_COPILOT_MODEL_SOURCE",
+      "YUKH_CODEX_SKILLS",
+      "YUKH_COPILOT_SKILLS",
+      "YUKH_ENABLE_UNSAFE_DYNAMIC_WORKERS",
+    ]
       .filter((name) => process.env[name] !== undefined)
       .map((name) => [name, process.env[name]!] as const),
   ),

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -1209,6 +1209,7 @@ test("stopping a team makes its wrapper terminate the owned agent CLI", async ()
           YUKH_TEAM_CONTROL_MCP_MAIN: support,
           YUKH_CODEX_EXECUTABLE: executable,
           YUKH_COPILOT_EXECUTABLE: executable,
+          YUKH_ENABLE_UNSAFE_DYNAMIC_WORKERS: "1",
         },
       },
     );
@@ -1263,6 +1264,7 @@ test("worker fails closed before agent launch when Coordination cannot join", as
           YUKH_TEAM_CONTROL_MCP_MAIN: support,
           YUKH_CODEX_EXECUTABLE: executable,
           YUKH_COPILOT_EXECUTABLE: executable,
+          YUKH_ENABLE_UNSAFE_DYNAMIC_WORKERS: "1",
         },
       },
     );
@@ -1331,6 +1333,7 @@ printf '{"schema":1,"status":"ok","command":"test"}\\n'
           YUKH_TEAM_CONTROL_MCP_MAIN: support,
           YUKH_CODEX_EXECUTABLE: executable,
           YUKH_COPILOT_EXECUTABLE: executable,
+          YUKH_ENABLE_UNSAFE_DYNAMIC_WORKERS: "1",
         },
       },
     );
@@ -1455,6 +1458,7 @@ printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_inpu
           YUKH_TEAM_CONTROL_MCP_MAIN: support,
           YUKH_CODEX_EXECUTABLE: executable,
           YUKH_COPILOT_EXECUTABLE: executable,
+          YUKH_ENABLE_UNSAFE_DYNAMIC_WORKERS: "1",
         },
       },
     );
@@ -1468,6 +1472,10 @@ printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_inpu
     assert.match(
       runtimeArguments,
       /mcp_servers\.yukh-team-control\.enabled_tools=\["team\.status"\]/u,
+    );
+    assert.match(
+      runtimeArguments,
+      /mcp_servers\.yukh-team-control\.env\.YUKH_ENABLE_UNSAFE_DYNAMIC_WORKERS="1"/u,
     );
     assert.doesNotMatch(runtimeArguments, /mcp_servers\.yukh-coordination\.command/u);
   } finally {


### PR DESCRIPTION
## Summary
- propagate `YUKH_ENABLE_UNSAFE_DYNAMIC_WORKERS` into manager/worker Team Control MCP environments
- also propagate model catalog source env so nested Team Control status remains accurate
- add regression coverage for the generated Codex MCP configuration

Governing issue: #127

## Validation
- `npm run -s typecheck`
- `node --import tsx --test test/runtime/team-control.test.ts test/runtime/conversation-watch.test.ts`
- `npm run -s build`
- `npm run -s format:check`
- `git diff --check`

## Runtime evidence
- Real manager smoke before this fix reached `policy.profile` but `agent.engage` failed closed with `dynamic_worker_cost_boundary_unavailable`, proving the flag was not visible inside the manager MCP server.
