### PR TITLE
Add zero-token team engage preflight

### DIFF
--- a/apps/team-preflight/src/main.ts
+++ b/apps/team-preflight/src/main.ts
@@ -1,0 +1,85 @@
+import type { AgentRuntime } from "../../../packages/team-control/src/store.js";
+import type { TeamWorkProfile } from "../../team-control/src/server.js";
+import { runEngagePreflight } from "./preflight.js";
+
+interface Arguments {
+  readonly workspace?: string;
+  readonly goal: string;
+  readonly role: string;
+  readonly workProfile: TeamWorkProfile;
+  readonly preferredRuntime?: AgentRuntime;
+  readonly teamBudget: number;
+  readonly managerBudget: number;
+  readonly codexModels: readonly string[];
+  readonly copilotModels: readonly string[];
+  readonly codexSkills: readonly string[];
+  readonly copilotSkills: readonly string[];
+}
+
+function list(value: string | undefined, fallback: readonly string[]): readonly string[] {
+  return value ? value.split(",").filter(Boolean) : fallback;
+}
+
+function integer(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) throw new TypeError("invalid integer argument");
+  return parsed;
+}
+
+function parseArguments(argv: readonly string[]): Arguments {
+  const values = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!name?.startsWith("--") || value === undefined || value.startsWith("--"))
+      throw new TypeError("invalid team preflight arguments");
+    values.set(name.slice(2), value);
+  }
+  const preferredRuntime = values.get("preferred-runtime");
+  if (preferredRuntime !== undefined && !["codex", "copilot"].includes(preferredRuntime))
+    throw new TypeError("invalid preferred runtime");
+  const workProfile = values.get("work-profile") ?? "implementation";
+  if (!["review", "implementation", "synthesis"].includes(workProfile))
+    throw new TypeError("invalid work profile");
+  const workspace = values.get("workspace");
+  return {
+    ...(workspace ? { workspace } : {}),
+    goal: values.get("goal") ?? "Preflight one dynamic Yukh worker engagement.",
+    role: values.get("role") ?? "backend-reviewer",
+    workProfile: workProfile as TeamWorkProfile,
+    ...(preferredRuntime ? { preferredRuntime: preferredRuntime as AgentRuntime } : {}),
+    teamBudget: integer(values.get("team-budget"), 260_000),
+    managerBudget: integer(values.get("manager-budget"), 180_000),
+    codexModels: list(values.get("codex-models") ?? process.env.YUKH_CODEX_MODELS, ["default"]),
+    copilotModels: list(values.get("copilot-models") ?? process.env.YUKH_COPILOT_MODELS, [
+      "default",
+    ]),
+    codexSkills: list(values.get("codex-skills") ?? process.env.YUKH_CODEX_SKILLS, [
+      "api-design",
+      "testing",
+      "product",
+      "documentation",
+      "security",
+    ]),
+    copilotSkills: list(values.get("copilot-skills") ?? process.env.YUKH_COPILOT_SKILLS, [
+      "frontend",
+      "testing",
+    ]),
+  };
+}
+
+try {
+  const output = runEngagePreflight(parseArguments(process.argv.slice(2)));
+  process.stdout.write(`${JSON.stringify(output)}\n`);
+} catch (error) {
+  process.stdout.write(
+    `${JSON.stringify({
+      schema: 1,
+      status: "error",
+      command: "team preflight-engage",
+      code: error instanceof Error ? error.message : "team_preflight_failed",
+    })}\n`,
+  );
+  process.exitCode = 1;
+}

--- a/apps/team-preflight/src/preflight.ts
+++ b/apps/team-preflight/src/preflight.ts
@@ -1,0 +1,97 @@
+import { mkdtempSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { roleProfilePolicy } from "../../team-control/src/server.js";
+import { TeamStore } from "../../../packages/team-control/src/store.js";
+import type { AgentRuntime } from "../../../packages/team-control/src/store.js";
+import type { TeamWorkProfile } from "../../team-control/src/server.js";
+
+export interface EngagePreflightArguments {
+  readonly workspace?: string;
+  readonly goal: string;
+  readonly role: string;
+  readonly workProfile: TeamWorkProfile;
+  readonly preferredRuntime?: AgentRuntime;
+  readonly teamBudget: number;
+  readonly managerBudget: number;
+  readonly codexModels: readonly string[];
+  readonly copilotModels: readonly string[];
+  readonly codexSkills: readonly string[];
+  readonly copilotSkills: readonly string[];
+}
+
+function runtimeSet(values: readonly string[]): ReadonlySet<string> {
+  return new Set(values);
+}
+
+export function runEngagePreflight(args: EngagePreflightArguments) {
+  const workspace = realpathSync(args.workspace ?? mkdtempSync(join(tmpdir(), "yukh-preflight-")));
+  const store = new TeamStore(workspace);
+  const managed = store.createManaged(args.goal, "codex", 3, 2, args.teamBudget, {
+    role: "delivery-manager",
+    profile: {
+      schema: 1,
+      mission: "Preflight dynamic worker engagement without launching a provider runtime.",
+      model: "default",
+      skills: ["testing"],
+      instructions:
+        "Compute policy, reserve budget, and prove the worker can be composed without launching Codex or Copilot.",
+    },
+    task: "Preflight policy.profile then agent.engage without provider execution.",
+    token_budget: args.managerBudget,
+    required_actions: ["policy.profile", "agent.engage"],
+    max_commands: 0,
+    timeout_ms: 60_000,
+  });
+  const policy = roleProfilePolicy(
+    {
+      models: {
+        codex: runtimeSet(args.codexModels),
+        copilot: runtimeSet(args.copilotModels),
+      },
+      skills: {
+        codex: runtimeSet(args.codexSkills),
+        copilot: runtimeSet(args.copilotSkills),
+      },
+      dynamicExecution: true,
+    },
+    args.role,
+    args.workProfile,
+    args.preferredRuntime,
+  );
+  const worker = store.spawn(managed.team.team_id, {
+    parent_agent_id: managed.manager.agent_id,
+    runtime: policy.recommendation.runtime,
+    role: policy.role,
+    profile: {
+      schema: 1,
+      mission: `Preflighted ${policy.role}`,
+      model: policy.recommendation.model,
+      skills: policy.recommendation.skills,
+      instructions:
+        "This worker was composed by preflight only. A real run must be launched separately.",
+    },
+    task: "Preflight only: no provider runtime launched.",
+    can_spawn: false,
+    token_budget: policy.recommendation.token_budget,
+    model_tool_mode: policy.recommendation.tool_mode,
+    max_commands: policy.recommendation.max_commands,
+    timeout_ms: policy.recommendation.runtime_timeout_ms,
+  });
+  const budget = store.status(managed.team.team_id).tokens;
+  return {
+    schema: 1 as const,
+    status: "ok" as const,
+    command: "team preflight-engage" as const,
+    workspace,
+    provider_tokens_observed: 0,
+    provider_runtime_launched: false,
+    team: managed.team,
+    manager: managed.manager,
+    policy,
+    planned_worker: worker,
+    budget,
+    next_real_action:
+      "Run a managed manager or agent.engage from Team Control only after approving this policy and budget.",
+  };
+}

--- a/bin/yukh.mjs
+++ b/bin/yukh.mjs
@@ -6,9 +6,12 @@ if (process.argv[2] === "conversation" && process.argv[3] === "watch") {
 } else if (process.argv[2] === "team" && process.argv[3] === "serve") {
   process.argv.splice(2, 2);
   await import("../dist/apps/team-control/src/main.js");
+} else if (process.argv[2] === "team" && process.argv[3] === "preflight-engage") {
+  process.argv.splice(2, 2);
+  await import("../dist/apps/team-preflight/src/main.js");
 } else {
   process.stderr.write(
-    "usage: yukh conversation watch [--full] [--verbose]\n       yukh team serve\n",
+    "usage: yukh conversation watch [--full] [--verbose]\n       yukh team serve\n       yukh team preflight-engage [--role backend-reviewer] [--work-profile implementation]\n",
   );
   process.exitCode = 2;
 }

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -8,6 +8,7 @@ import test from "node:test";
 import { TeamStore } from "../../packages/team-control/src/store.js";
 import { TeamSupervisor } from "../../packages/team-control/src/supervisor.js";
 import { RuntimeOutput } from "../../packages/team-control/src/runtime-output.js";
+import { runEngagePreflight } from "../../apps/team-preflight/src/preflight.js";
 import {
   copilotModelCatalogFromDiscoveries,
   parseCodexModelCatalog,
@@ -147,6 +148,38 @@ test("role profile policy maps specialists to allowlisted runtime models skills 
   assert.deepEqual(roleProfilePolicy(options, "security-reviewer", "review").omitted_skills, [
     "security",
   ]);
+});
+
+test("engage preflight composes a worker without launching a provider runtime", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-engage-preflight-")));
+  try {
+    const output = runEngagePreflight({
+      workspace: root,
+      goal: "Preflight frontend worker",
+      role: "frontend-developer",
+      workProfile: "implementation",
+      preferredRuntime: "copilot",
+      teamBudget: 260_000,
+      managerBudget: 180_000,
+      codexModels: ["default"],
+      copilotModels: ["default", "claude-sonnet-5"],
+      codexSkills: ["api-design", "testing"],
+      copilotSkills: ["frontend", "testing"],
+    });
+    assert.equal(output.status, "ok");
+    assert.equal(output.provider_runtime_launched, false);
+    assert.equal(output.provider_tokens_observed, 0);
+    assert.equal(output.policy.recommendation.runtime, "copilot");
+    assert.equal(output.policy.recommendation.model, "default");
+    assert.deepEqual(output.policy.recommendation.skills, ["frontend"]);
+    assert.equal(output.planned_worker.state, "defined");
+    assert.equal(output.planned_worker.parent_agent_id, output.manager.agent_id);
+    assert.equal(output.budget.allocated, 230_000);
+    assert.equal(output.budget.observed, 0);
+    assert.equal(output.budget.pending_agents, 2);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 test("runtime model discovery parses CLI catalogs and keeps explicit env authoritative", () => {


### PR DESCRIPTION
## Summary
- add `yukh team preflight-engage` for deterministic manager→worker policy/budget validation
- compose the planned worker without launching Codex/Copilot, keeping provider token usage at zero
- default to a temporary workspace so the target repo is not dirtied
- add runtime test coverage for frontend→Copilot policy and budget allocation

## Validation
- `npm run -s typecheck`
- `node --import tsx --test test/runtime/team-control.test.ts`
- `npm run -s build`
- `npm run -s format:check`
- `git diff --check`
- `./bin/yukh.mjs team preflight-engage --role frontend-developer --preferred-runtime copilot`

## Token evidence
- `provider_runtime_launched=false`
- `provider_tokens_observed=0`
