### PR TITLE
Add approved team preflight runner

### DIFF
--- a/apps/team-preflight/src/approved-run.ts
+++ b/apps/team-preflight/src/approved-run.ts
@@ -1,0 +1,115 @@
+import { readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { TeamStore } from "../../../packages/team-control/src/store.js";
+import { TeamSupervisor } from "../../../packages/team-control/src/supervisor.js";
+import type { AgentRecord } from "../../../packages/team-control/src/store.js";
+import { preflightApprovalDigest, type EngagePreflightOutput } from "./preflight.js";
+
+const runtimeExtension = fileURLToPath(import.meta.url).endsWith(".ts") ? "ts" : "js";
+
+export interface ApprovedRunArguments {
+  readonly preflightPath: string;
+  readonly approvedDigest: string;
+  readonly launcher: string;
+  readonly codex: string;
+  readonly copilot: string;
+  readonly waitMs: number;
+  readonly codexModels?: string;
+  readonly copilotModels?: string;
+  readonly codexSkills?: string;
+  readonly copilotSkills?: string;
+}
+
+async function awaitAgent(
+  store: TeamStore,
+  teamId: string,
+  agentId: string,
+  timeoutMs: number,
+): Promise<AgentRecord | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const agent = store.agent(teamId, agentId);
+    if (["completed", "failed", "stopped"].includes(agent.state)) return agent;
+    if (Date.now() >= deadline) return undefined;
+    await new Promise((resolve) => setTimeout(resolve, Math.min(250, deadline - Date.now())));
+  }
+}
+
+function loadPreflight(path: string): EngagePreflightOutput {
+  const value = JSON.parse(readFileSync(path, "utf8")) as EngagePreflightOutput;
+  if (
+    value.schema !== 1 ||
+    value.status !== "ok" ||
+    value.command !== "team preflight-engage" ||
+    value.provider_runtime_launched !== false ||
+    value.provider_tokens_observed !== 0
+  )
+    throw new TypeError("invalid preflight document");
+  return value;
+}
+
+function profileEnvironment(args: ApprovedRunArguments): Readonly<Record<string, string>> {
+  const env: Record<string, string> = { YUKH_ENABLE_UNSAFE_DYNAMIC_WORKERS: "1" };
+  if (args.codexModels) env.YUKH_CODEX_MODELS = args.codexModels;
+  if (args.copilotModels) env.YUKH_COPILOT_MODELS = args.copilotModels;
+  if (args.codexSkills) env.YUKH_CODEX_SKILLS = args.codexSkills;
+  if (args.copilotSkills) env.YUKH_COPILOT_SKILLS = args.copilotSkills;
+  return env;
+}
+
+export async function runApprovedPreflight(args: ApprovedRunArguments) {
+  const preflight = loadPreflight(args.preflightPath);
+  const digest = preflightApprovalDigest(preflight);
+  if (digest !== preflight.approval_digest || digest !== args.approvedDigest)
+    throw new Error("approval_digest_mismatch");
+
+  const workspace = realpathSync(preflight.workspace);
+  const store = new TeamStore(workspace);
+  const team = store.status(preflight.team.team_id).team;
+  const worker = store.agent(preflight.team.team_id, preflight.planned_worker.agent_id);
+  if (team.state !== "active") throw new Error("team_not_active");
+  if (worker.state !== "defined") throw new Error("worker_not_defined");
+
+  const supervisor = new TeamSupervisor({
+    node: process.execPath,
+    worker: fileURLToPath(
+      new URL(`../../team-worker/src/main.${runtimeExtension}`, import.meta.url),
+    ),
+    coordinationMcp: fileURLToPath(
+      new URL(`../../coordination-preview/src/main.${runtimeExtension}`, import.meta.url),
+    ),
+    teamControlMcp: fileURLToPath(
+      new URL(`../../team-control/src/main.${runtimeExtension}`, import.meta.url),
+    ),
+    launcher: realpathSync(args.launcher),
+    codex: realpathSync(args.codex),
+    copilot: realpathSync(args.copilot),
+    workspace,
+    profileEnvironment: profileEnvironment(args),
+  });
+
+  const runtime = supervisor.launch(worker);
+  const receipt = store.receipt(
+    preflight.team.team_id,
+    "agent.engage",
+    preflight.manager.agent_id,
+    worker.agent_id,
+  );
+  const terminal =
+    args.waitMs > 0
+      ? await awaitAgent(store, preflight.team.team_id, worker.agent_id, args.waitMs)
+      : undefined;
+  const status = store.status(preflight.team.team_id);
+  return {
+    schema: 1 as const,
+    status: "ok" as const,
+    command: "team run-approved" as const,
+    approval_digest: digest,
+    provider_runtime_launched: true,
+    launched_worker: worker.agent_id,
+    receipt,
+    runtime,
+    terminal_agent: terminal,
+    tokens: status.tokens,
+  };
+}

--- a/apps/team-preflight/src/preflight.ts
+++ b/apps/team-preflight/src/preflight.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { mkdtempSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -20,11 +21,76 @@ export interface EngagePreflightArguments {
   readonly copilotSkills: readonly string[];
 }
 
+export interface EngagePreflightOutput {
+  readonly schema: 1;
+  readonly status: "ok";
+  readonly command: "team preflight-engage";
+  readonly workspace: string;
+  readonly provider_tokens_observed: 0;
+  readonly provider_runtime_launched: false;
+  readonly approval_digest: `sha-256:${string}`;
+  readonly team: ReturnType<TeamStore["createManaged"]>["team"];
+  readonly manager: ReturnType<TeamStore["createManaged"]>["manager"];
+  readonly policy: ReturnType<typeof roleProfilePolicy>;
+  readonly planned_worker: ReturnType<TeamStore["spawn"]>;
+  readonly budget: ReturnType<TeamStore["status"]>["tokens"];
+  readonly next_real_action: string;
+}
+
 function runtimeSet(values: readonly string[]): ReadonlySet<string> {
   return new Set(values);
 }
 
-export function runEngagePreflight(args: EngagePreflightArguments) {
+export function approvalDigest(input: {
+  readonly team_id: string;
+  readonly manager_agent_id: string;
+  readonly worker_agent_id: string;
+  readonly runtime: string;
+  readonly role: string;
+  readonly model: string;
+  readonly skills: readonly string[];
+  readonly token_budget: number;
+  readonly tool_mode?: string;
+  readonly max_commands?: number;
+  readonly timeout_ms?: number;
+}): `sha-256:${string}` {
+  const stable = {
+    schema: 1,
+    team_id: input.team_id,
+    manager_agent_id: input.manager_agent_id,
+    worker_agent_id: input.worker_agent_id,
+    runtime: input.runtime,
+    role: input.role,
+    model: input.model,
+    skills: [...input.skills].sort(),
+    token_budget: input.token_budget,
+    tool_mode: input.tool_mode ?? "default",
+    max_commands: input.max_commands ?? 8,
+    timeout_ms: input.timeout_ms ?? 300_000,
+  };
+  return `sha-256:${createHash("sha256").update(JSON.stringify(stable)).digest("hex")}`;
+}
+
+export function preflightApprovalDigest(
+  output: Pick<EngagePreflightOutput, "team" | "manager" | "planned_worker">,
+): `sha-256:${string}` {
+  const worker = output.planned_worker;
+  return approvalDigest({
+    team_id: output.team.team_id,
+    manager_agent_id: output.manager.agent_id,
+    worker_agent_id: worker.agent_id,
+    runtime: worker.runtime,
+    role: worker.role,
+    model: worker.profile?.model ?? "default",
+    skills: worker.profile?.skills ?? [],
+    token_budget: worker.token_budget,
+    ...(worker.model_tool_mode ? { tool_mode: worker.model_tool_mode } : {}),
+    ...(worker.max_commands !== undefined ? { max_commands: worker.max_commands } : {}),
+    ...(worker.timeout_ms !== undefined ? { timeout_ms: worker.timeout_ms } : {}),
+  });
+}
+
+export function runEngagePreflight(args: EngagePreflightArguments): EngagePreflightOutput {
   const workspace = realpathSync(args.workspace ?? mkdtempSync(join(tmpdir(), "yukh-preflight-")));
   const store = new TeamStore(workspace);
   const managed = store.createManaged(args.goal, "codex", 3, 2, args.teamBudget, {
@@ -79,13 +145,14 @@ export function runEngagePreflight(args: EngagePreflightArguments) {
     timeout_ms: policy.recommendation.runtime_timeout_ms,
   });
   const budget = store.status(managed.team.team_id).tokens;
-  return {
+  const output = {
     schema: 1 as const,
     status: "ok" as const,
     command: "team preflight-engage" as const,
     workspace,
-    provider_tokens_observed: 0,
-    provider_runtime_launched: false,
+    provider_tokens_observed: 0 as const,
+    provider_runtime_launched: false as const,
+    approval_digest: "sha-256:" as `sha-256:${string}`,
     team: managed.team,
     manager: managed.manager,
     policy,
@@ -94,4 +161,5 @@ export function runEngagePreflight(args: EngagePreflightArguments) {
     next_real_action:
       "Run a managed manager or agent.engage from Team Control only after approving this policy and budget.",
   };
+  return { ...output, approval_digest: preflightApprovalDigest(output) };
 }

--- a/apps/team-preflight/src/run-approved-main.ts
+++ b/apps/team-preflight/src/run-approved-main.ts
@@ -1,0 +1,77 @@
+import { runApprovedPreflight } from "./approved-run.js";
+
+interface Arguments {
+  readonly preflightPath: string;
+  readonly approvedDigest: string;
+  readonly launcher: string;
+  readonly codex: string;
+  readonly copilot: string;
+  readonly waitMs: number;
+  readonly codexModels?: string;
+  readonly copilotModels?: string;
+  readonly codexSkills?: string;
+  readonly copilotSkills?: string;
+}
+
+function required(value: string | undefined, name: string): string {
+  if (!value) throw new TypeError(`missing ${name}`);
+  return value;
+}
+
+function integer(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) throw new TypeError("invalid integer argument");
+  return parsed;
+}
+
+function parseArguments(argv: readonly string[]): Arguments {
+  const values = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!name?.startsWith("--") || value === undefined || value.startsWith("--"))
+      throw new TypeError("invalid approved run arguments");
+    values.set(name.slice(2), value);
+  }
+  const codexModels = values.get("codex-models") ?? process.env.YUKH_CODEX_MODELS;
+  const copilotModels = values.get("copilot-models") ?? process.env.YUKH_COPILOT_MODELS;
+  const codexSkills = values.get("codex-skills") ?? process.env.YUKH_CODEX_SKILLS;
+  const copilotSkills = values.get("copilot-skills") ?? process.env.YUKH_COPILOT_SKILLS;
+  return {
+    preflightPath: required(values.get("preflight"), "--preflight"),
+    approvedDigest: required(values.get("approved-digest"), "--approved-digest"),
+    launcher: required(
+      values.get("launcher") ?? process.env.YUKH_COORDINATION_LAUNCHER,
+      "--launcher or YUKH_COORDINATION_LAUNCHER",
+    ),
+    codex: required(
+      values.get("codex") ?? process.env.YUKH_CODEX_EXECUTABLE,
+      "--codex or YUKH_CODEX_EXECUTABLE",
+    ),
+    copilot: required(
+      values.get("copilot") ?? process.env.YUKH_COPILOT_EXECUTABLE,
+      "--copilot or YUKH_COPILOT_EXECUTABLE",
+    ),
+    waitMs: integer(values.get("wait-ms"), 0),
+    ...(codexModels ? { codexModels } : {}),
+    ...(copilotModels ? { copilotModels } : {}),
+    ...(codexSkills ? { codexSkills } : {}),
+    ...(copilotSkills ? { copilotSkills } : {}),
+  };
+}
+
+try {
+  const output = await runApprovedPreflight(parseArguments(process.argv.slice(2)));
+  process.stdout.write(`${JSON.stringify(output)}\n`);
+} catch (error) {
+  process.stdout.write(
+    `${JSON.stringify({
+      schema: 1,
+      status: "error",
+      command: "team run-approved",
+      code: error instanceof Error ? error.message : "team_run_approved_failed",
+    })}\n`,
+  );
+  process.exitCode = 1;
+}

--- a/bin/yukh.mjs
+++ b/bin/yukh.mjs
@@ -9,9 +9,12 @@ if (process.argv[2] === "conversation" && process.argv[3] === "watch") {
 } else if (process.argv[2] === "team" && process.argv[3] === "preflight-engage") {
   process.argv.splice(2, 2);
   await import("../dist/apps/team-preflight/src/main.js");
+} else if (process.argv[2] === "team" && process.argv[3] === "run-approved") {
+  process.argv.splice(2, 2);
+  await import("../dist/apps/team-preflight/src/run-approved-main.js");
 } else {
   process.stderr.write(
-    "usage: yukh conversation watch [--full] [--verbose]\n       yukh team serve\n       yukh team preflight-engage [--role backend-reviewer] [--work-profile implementation]\n",
+    "usage: yukh conversation watch [--full] [--verbose]\n       yukh team serve\n       yukh team preflight-engage [--role backend-reviewer] [--work-profile implementation]\n       yukh team run-approved --preflight file --approved-digest sha-256:...\n",
   );
   process.exitCode = 2;
 }

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -8,6 +8,7 @@ import test from "node:test";
 import { TeamStore } from "../../packages/team-control/src/store.js";
 import { TeamSupervisor } from "../../packages/team-control/src/supervisor.js";
 import { RuntimeOutput } from "../../packages/team-control/src/runtime-output.js";
+import { runApprovedPreflight } from "../../apps/team-preflight/src/approved-run.js";
 import { runEngagePreflight } from "../../apps/team-preflight/src/preflight.js";
 import {
   copilotModelCatalogFromDiscoveries,
@@ -177,6 +178,67 @@ test("engage preflight composes a worker without launching a provider runtime", 
     assert.equal(output.budget.allocated, 230_000);
     assert.equal(output.budget.observed, 0);
     assert.equal(output.budget.pending_agents, 2);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("approved preflight launches exactly the planned worker after digest approval", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-approved-run-")));
+  try {
+    const executable = join(root, "agent-cli");
+    const launcher = join(root, "launcher");
+    const support = join(root, "support.mjs");
+    const preflightPath = join(root, "preflight.json");
+    await writeFile(
+      executable,
+      `#!/bin/sh
+printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"approved worker ran"}}'
+printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":20,"reasoning_output_tokens":5}}'
+`,
+      { mode: 0o700 },
+    );
+    await writeFile(
+      launcher,
+      '#!/bin/sh\ncat >/dev/null\nprintf \'{"schema":1,"status":"ok","command":"test"}\\n\'\n',
+      { mode: 0o700 },
+    );
+    await writeFile(support, "", { mode: 0o600 });
+    const preflight = runEngagePreflight({
+      workspace: root,
+      goal: "Preflight backend worker",
+      role: "backend-reviewer",
+      workProfile: "review",
+      preferredRuntime: "codex",
+      teamBudget: 220_000,
+      managerBudget: 180_000,
+      codexModels: ["default"],
+      copilotModels: ["default"],
+      codexSkills: ["api-design", "testing"],
+      copilotSkills: ["frontend"],
+    });
+    await writeFile(preflightPath, `${JSON.stringify(preflight)}\n`, { mode: 0o600 });
+    const output = await runApprovedPreflight({
+      preflightPath,
+      approvedDigest: preflight.approval_digest,
+      launcher,
+      codex: executable,
+      copilot: executable,
+      waitMs: 0,
+      codexModels: "default",
+      copilotModels: "default",
+      codexSkills: "api-design,testing",
+      copilotSkills: "frontend",
+    });
+    assert.equal(output.status, "ok");
+    assert.equal(output.provider_runtime_launched, true);
+    assert.equal(output.launched_worker, preflight.planned_worker.agent_id);
+    assert.equal(output.receipt.action, "agent.engage");
+    assert.equal(output.receipt.actor_agent_id, preflight.manager.agent_id);
+    assert.equal(output.receipt.subject_agent_id, preflight.planned_worker.agent_id);
+    assert.equal(output.terminal_agent, undefined);
+    assert.equal(output.tokens.observed, 0);
+    assert.equal(output.tokens.unaccounted_agents, 0);
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- add `approval_digest` to `team preflight-engage`
- add `yukh team run-approved --preflight file --approved-digest sha-256:...`
- verify the approved digest before launching anything
- launch only the preflighted worker, then optionally wait and report observed token accounting

## Validation
- `npm run -s typecheck`
- `node --import tsx --test test/runtime/team-control.test.ts`
- `npm run -s build`
- `npm run -s format:check`
- `git diff --check`
- CLI fake-provider smoke: preflight → run-approved → worker completed → observed tokens 120

## Token behavior
- preflight remains provider-token free
- run-approved is the explicit boundary where provider runtime starts
