### PR TITLE
Centralize team runtime entrypoints

### DIFF
--- a/apps/team-control/src/main.ts
+++ b/apps/team-control/src/main.ts
@@ -1,10 +1,10 @@
 import { serveStdio } from "@modelcontextprotocol/server/stdio";
-import { fileURLToPath } from "node:url";
 import {
   discoverCodexModels,
   discoverCopilotModelCatalog,
   runtimeModelCatalog,
 } from "../../../packages/team-control/src/model-discovery.js";
+import { teamRuntimeEntrypoints } from "../../../packages/team-control/src/entrypoints.js";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
 import { TeamSupervisor } from "../../../packages/team-control/src/supervisor.js";
 import { createTeamControlServer } from "./server.js";
@@ -37,13 +37,12 @@ const profileEnvironment = {
       .map((name) => [name, process.env[name]!] as const),
   ),
 };
+const entrypoints = teamRuntimeEntrypoints();
 const supervisor = new TeamSupervisor({
   node: process.execPath,
-  worker: fileURLToPath(new URL("../../team-worker/src/main.js", import.meta.url)),
-  coordinationMcp: fileURLToPath(
-    new URL("../../coordination-preview/src/main.js", import.meta.url),
-  ),
-  teamControlMcp: fileURLToPath(new URL("./main.js", import.meta.url)),
+  worker: entrypoints.worker,
+  coordinationMcp: entrypoints.coordinationMcp,
+  teamControlMcp: entrypoints.teamControlMcp,
   launcher,
   codex,
   copilot,

--- a/apps/team-preflight/src/approved-run.ts
+++ b/apps/team-preflight/src/approved-run.ts
@@ -1,11 +1,9 @@
 import { readFileSync, realpathSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { teamRuntimeEntrypoints } from "../../../packages/team-control/src/entrypoints.js";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
 import { TeamSupervisor } from "../../../packages/team-control/src/supervisor.js";
 import type { AgentRecord } from "../../../packages/team-control/src/store.js";
 import { preflightApprovalDigest, type EngagePreflightOutput } from "./preflight.js";
-
-const runtimeExtension = fileURLToPath(import.meta.url).endsWith(".ts") ? "ts" : "js";
 
 export interface ApprovedRunArguments {
   readonly preflightPath: string;
@@ -70,17 +68,12 @@ export async function runApprovedPreflight(args: ApprovedRunArguments) {
   if (team.state !== "active") throw new Error("team_not_active");
   if (worker.state !== "defined") throw new Error("worker_not_defined");
 
+  const entrypoints = teamRuntimeEntrypoints();
   const supervisor = new TeamSupervisor({
     node: process.execPath,
-    worker: fileURLToPath(
-      new URL(`../../team-worker/src/main.${runtimeExtension}`, import.meta.url),
-    ),
-    coordinationMcp: fileURLToPath(
-      new URL(`../../coordination-preview/src/main.${runtimeExtension}`, import.meta.url),
-    ),
-    teamControlMcp: fileURLToPath(
-      new URL(`../../team-control/src/main.${runtimeExtension}`, import.meta.url),
-    ),
+    worker: entrypoints.worker,
+    coordinationMcp: entrypoints.coordinationMcp,
+    teamControlMcp: entrypoints.teamControlMcp,
     launcher: realpathSync(args.launcher),
     codex: realpathSync(args.codex),
     copilot: realpathSync(args.copilot),

--- a/packages/team-control/src/entrypoints.ts
+++ b/packages/team-control/src/entrypoints.ts
@@ -1,0 +1,25 @@
+import { fileURLToPath } from "node:url";
+
+export interface TeamRuntimeEntrypoints {
+  readonly worker: string;
+  readonly coordinationMcp: string;
+  readonly teamControlMcp: string;
+}
+
+function runtimeExtension(): "js" | "ts" {
+  return fileURLToPath(import.meta.url).endsWith(".ts") ? "ts" : "js";
+}
+
+function appEntrypoint(name: string): string {
+  return fileURLToPath(
+    new URL(`../../../apps/${name}/src/main.${runtimeExtension()}`, import.meta.url),
+  );
+}
+
+export function teamRuntimeEntrypoints(): TeamRuntimeEntrypoints {
+  return {
+    worker: appEntrypoint("team-worker"),
+    coordinationMcp: appEntrypoint("coordination-preview"),
+    teamControlMcp: appEntrypoint("team-control"),
+  };
+}

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -8,6 +8,7 @@ import test from "node:test";
 import { TeamStore } from "../../packages/team-control/src/store.js";
 import { TeamSupervisor } from "../../packages/team-control/src/supervisor.js";
 import { RuntimeOutput } from "../../packages/team-control/src/runtime-output.js";
+import { teamRuntimeEntrypoints } from "../../packages/team-control/src/entrypoints.js";
 import { runApprovedPreflight } from "../../apps/team-preflight/src/approved-run.js";
 import { runEngagePreflight } from "../../apps/team-preflight/src/preflight.js";
 import {
@@ -95,6 +96,16 @@ const planDocument = (workerBudget = 2_000, synthesisBudget = 2_000) => ({
 
 const workerMain = fileURLToPath(new URL("../../apps/team-worker/src/main.ts", import.meta.url));
 const tsxLoader = fileURLToPath(import.meta.resolve("tsx"));
+
+test("team runtime entrypoints are resolved centrally for source execution", () => {
+  assert.deepEqual(teamRuntimeEntrypoints(), {
+    worker: fileURLToPath(new URL("../../apps/team-worker/src/main.ts", import.meta.url)),
+    coordinationMcp: fileURLToPath(
+      new URL("../../apps/coordination-preview/src/main.ts", import.meta.url),
+    ),
+    teamControlMcp: fileURLToPath(new URL("../../apps/team-control/src/main.ts", import.meta.url)),
+  });
+});
 
 test("composed profiles require allowlisted runtime models and skills", () => {
   const options = {


### PR DESCRIPTION
## Summary
- centralize Team Control runtime entrypoint resolution
- remove duplicated sibling-app `src/main` URL construction from `team-control` and `run-approved`
- keep source execution on `.ts` and built execution on `.js` through one tested resolver

## Validation
- `npm run -s typecheck`
- `node --import tsx --test test/runtime/team-control.test.ts`
- `npm run -s build`
- `npm run -s format:check`
- `git diff --check`
