### PR TITLE
Add readable team preflight output

### DIFF
--- a/apps/team-preflight/src/format.ts
+++ b/apps/team-preflight/src/format.ts
@@ -1,0 +1,61 @@
+import type { runApprovedPreflight } from "./approved-run.js";
+import type { EngagePreflightOutput } from "./preflight.js";
+
+type ApprovedRunOutput = Awaited<ReturnType<typeof runApprovedPreflight>>;
+
+function list(values: readonly string[]): string {
+  return values.length > 0 ? values.join(", ") : "none";
+}
+
+export function formatEngagePreflight(output: EngagePreflightOutput): string {
+  const worker = output.planned_worker;
+  const policy = output.policy.recommendation;
+  return [
+    "Yukh team preflight",
+    `Status: ${output.status}`,
+    `Workspace: ${output.workspace}`,
+    `Approval digest: ${output.approval_digest}`,
+    "",
+    "Planned worker",
+    `- id: ${worker.agent_id}`,
+    `- role: ${worker.role}`,
+    `- runtime: ${policy.runtime}`,
+    `- model: ${policy.model}`,
+    `- skills: ${list(policy.skills)}`,
+    `- token budget: ${policy.token_budget}`,
+    `- tool mode: ${policy.tool_mode}`,
+    `- max commands: ${policy.max_commands}`,
+    `- timeout ms: ${policy.runtime_timeout_ms}`,
+    "",
+    "Budget",
+    `- team budget: ${output.budget.budget}`,
+    `- allocated: ${output.budget.allocated}`,
+    `- observed provider tokens: ${output.provider_tokens_observed}`,
+    `- provider launched: ${output.provider_runtime_launched ? "yes" : "no"}`,
+    "",
+    "Run after approval",
+    `yukh team run-approved --preflight <preflight.json> --approved-digest ${output.approval_digest}`,
+  ].join("\n");
+}
+
+export function formatApprovedRun(output: ApprovedRunOutput): string {
+  return [
+    "Yukh approved run",
+    `Status: ${output.status}`,
+    `Approval digest: ${output.approval_digest}`,
+    `Provider launched: ${output.provider_runtime_launched ? "yes" : "no"}`,
+    `Launched worker: ${output.launched_worker}`,
+    `Receipt: ${output.receipt.receipt_id} (${output.receipt.action})`,
+    `Runtime pid: ${output.runtime.pid}`,
+    `Runtime log: ${output.runtime.log}`,
+    "",
+    "Tokens",
+    `- observed: ${output.tokens.observed}`,
+    `- allocated: ${output.tokens.allocated}`,
+    `- remaining: ${output.tokens.remaining}`,
+    `- pending agents: ${output.tokens.pending_agents}`,
+    `- unaccounted agents: ${output.tokens.unaccounted_agents}`,
+    "",
+    `Terminal worker state: ${output.terminal_agent?.state ?? "not waited"}`,
+  ].join("\n");
+}

--- a/apps/team-preflight/src/main.ts
+++ b/apps/team-preflight/src/main.ts
@@ -1,5 +1,7 @@
+import { writeFileSync } from "node:fs";
 import type { AgentRuntime } from "../../../packages/team-control/src/store.js";
 import type { TeamWorkProfile } from "../../team-control/src/server.js";
+import { formatEngagePreflight } from "./format.js";
 import { runEngagePreflight } from "./preflight.js";
 
 interface Arguments {
@@ -14,6 +16,8 @@ interface Arguments {
   readonly copilotModels: readonly string[];
   readonly codexSkills: readonly string[];
   readonly copilotSkills: readonly string[];
+  readonly format: "json" | "text";
+  readonly outputPath?: string;
 }
 
 function list(value: string | undefined, fallback: readonly string[]): readonly string[] {
@@ -42,7 +46,10 @@ function parseArguments(argv: readonly string[]): Arguments {
   const workProfile = values.get("work-profile") ?? "implementation";
   if (!["review", "implementation", "synthesis"].includes(workProfile))
     throw new TypeError("invalid work profile");
+  const format = values.get("format") ?? "json";
+  if (!["json", "text"].includes(format)) throw new TypeError("invalid output format");
   const workspace = values.get("workspace");
+  const outputPath = values.get("output");
   return {
     ...(workspace ? { workspace } : {}),
     goal: values.get("goal") ?? "Preflight one dynamic Yukh worker engagement.",
@@ -66,12 +73,19 @@ function parseArguments(argv: readonly string[]): Arguments {
       "frontend",
       "testing",
     ]),
+    format: format as "json" | "text",
+    ...(outputPath ? { outputPath } : {}),
   };
 }
 
 try {
-  const output = runEngagePreflight(parseArguments(process.argv.slice(2)));
-  process.stdout.write(`${JSON.stringify(output)}\n`);
+  const args = parseArguments(process.argv.slice(2));
+  const output = runEngagePreflight(args);
+  if (args.outputPath)
+    writeFileSync(args.outputPath, `${JSON.stringify(output)}\n`, { mode: 0o600 });
+  process.stdout.write(
+    `${args.format === "json" ? JSON.stringify(output) : formatEngagePreflight(output)}\n`,
+  );
 } catch (error) {
   process.stdout.write(
     `${JSON.stringify({

--- a/apps/team-preflight/src/run-approved-main.ts
+++ b/apps/team-preflight/src/run-approved-main.ts
@@ -1,4 +1,5 @@
 import { runApprovedPreflight } from "./approved-run.js";
+import { formatApprovedRun } from "./format.js";
 
 interface Arguments {
   readonly preflightPath: string;
@@ -11,6 +12,7 @@ interface Arguments {
   readonly copilotModels?: string;
   readonly codexSkills?: string;
   readonly copilotSkills?: string;
+  readonly format: "json" | "text";
 }
 
 function required(value: string | undefined, name: string): string {
@@ -38,6 +40,8 @@ function parseArguments(argv: readonly string[]): Arguments {
   const copilotModels = values.get("copilot-models") ?? process.env.YUKH_COPILOT_MODELS;
   const codexSkills = values.get("codex-skills") ?? process.env.YUKH_CODEX_SKILLS;
   const copilotSkills = values.get("copilot-skills") ?? process.env.YUKH_COPILOT_SKILLS;
+  const format = values.get("format") ?? "json";
+  if (!["json", "text"].includes(format)) throw new TypeError("invalid output format");
   return {
     preflightPath: required(values.get("preflight"), "--preflight"),
     approvedDigest: required(values.get("approved-digest"), "--approved-digest"),
@@ -58,12 +62,16 @@ function parseArguments(argv: readonly string[]): Arguments {
     ...(copilotModels ? { copilotModels } : {}),
     ...(codexSkills ? { codexSkills } : {}),
     ...(copilotSkills ? { copilotSkills } : {}),
+    format: format as "json" | "text",
   };
 }
 
 try {
-  const output = await runApprovedPreflight(parseArguments(process.argv.slice(2)));
-  process.stdout.write(`${JSON.stringify(output)}\n`);
+  const args = parseArguments(process.argv.slice(2));
+  const output = await runApprovedPreflight(args);
+  process.stdout.write(
+    `${args.format === "json" ? JSON.stringify(output) : formatApprovedRun(output)}\n`,
+  );
 } catch (error) {
   process.stdout.write(
     `${JSON.stringify({

--- a/bin/yukh.mjs
+++ b/bin/yukh.mjs
@@ -14,7 +14,7 @@ if (process.argv[2] === "conversation" && process.argv[3] === "watch") {
   await import("../dist/apps/team-preflight/src/run-approved-main.js");
 } else {
   process.stderr.write(
-    "usage: yukh conversation watch [--full] [--verbose]\n       yukh team serve\n       yukh team preflight-engage [--role backend-reviewer] [--work-profile implementation]\n       yukh team run-approved --preflight file --approved-digest sha-256:...\n",
+    "usage: yukh conversation watch [--full] [--verbose]\n       yukh team serve\n       yukh team preflight-engage [--role backend-reviewer] [--work-profile implementation] [--format json|text] [--output preflight.json]\n       yukh team run-approved --preflight file --approved-digest sha-256:... [--format json|text]\n",
   );
   process.exitCode = 2;
 }

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -10,6 +10,7 @@ import { TeamSupervisor } from "../../packages/team-control/src/supervisor.js";
 import { RuntimeOutput } from "../../packages/team-control/src/runtime-output.js";
 import { teamRuntimeEntrypoints } from "../../packages/team-control/src/entrypoints.js";
 import { runApprovedPreflight } from "../../apps/team-preflight/src/approved-run.js";
+import { formatApprovedRun, formatEngagePreflight } from "../../apps/team-preflight/src/format.js";
 import { runEngagePreflight } from "../../apps/team-preflight/src/preflight.js";
 import {
   copilotModelCatalogFromDiscoveries,
@@ -194,6 +195,33 @@ test("engage preflight composes a worker without launching a provider runtime", 
   }
 });
 
+test("engage preflight text output shows approval and budget without raw JSON noise", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-engage-preflight-text-")));
+  try {
+    const output = runEngagePreflight({
+      workspace: root,
+      goal: "Preflight backend worker",
+      role: "backend-reviewer",
+      workProfile: "review",
+      preferredRuntime: "codex",
+      teamBudget: 220_000,
+      managerBudget: 180_000,
+      codexModels: ["default"],
+      copilotModels: ["default"],
+      codexSkills: ["api-design", "testing"],
+      copilotSkills: ["frontend"],
+    });
+    const text = formatEngagePreflight(output);
+    assert.match(text, /Yukh team preflight/u);
+    assert.match(text, new RegExp(output.approval_digest, "u"));
+    assert.match(text, /runtime: codex/u);
+    assert.match(text, /observed provider tokens: 0/u);
+    assert.doesNotMatch(text, /"planned_worker"/u);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("approved preflight launches exactly the planned worker after digest approval", async () => {
   const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-approved-run-")));
   try {
@@ -250,6 +278,10 @@ printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_inpu
     assert.equal(output.terminal_agent, undefined);
     assert.equal(output.tokens.observed, 0);
     assert.equal(output.tokens.unaccounted_agents, 0);
+    const text = formatApprovedRun(output);
+    assert.match(text, /Yukh approved run/u);
+    assert.match(text, /Provider launched: yes/u);
+    assert.match(text, /Terminal worker state: not waited/u);
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- add `--format text` to `team preflight-engage` and `team run-approved`
- add `--output preflight.json` to save the approvable JSON artifact while showing readable output
- keep JSON as the default output for scripts
- add formatter tests for approval digest, budget and token visibility

## Validation
- `npm run -s typecheck`
- `node --import tsx --test test/runtime/team-control.test.ts`
- `npm run -s build`
- `npm run -s format:check`
- `git diff --check`
- `./bin/yukh.mjs team preflight-engage --role backend-reviewer --work-profile review --preferred-runtime codex --format text --output /tmp/yukh-preflight-ui.json`
