### PR TITLE
Add guided team approval proposal

### DIFF
--- a/apps/team-preflight/src/arguments.ts
+++ b/apps/team-preflight/src/arguments.ts
@@ -1,0 +1,90 @@
+import type { AgentRuntime } from "../../../packages/team-control/src/store.js";
+import type { TeamWorkProfile } from "../../team-control/src/server.js";
+
+export interface PreflightArguments {
+  readonly workspace?: string;
+  readonly goal: string;
+  readonly role: string;
+  readonly workProfile: TeamWorkProfile;
+  readonly preferredRuntime?: AgentRuntime;
+  readonly teamBudget: number;
+  readonly managerBudget: number;
+  readonly codexModels: readonly string[];
+  readonly copilotModels: readonly string[];
+  readonly codexSkills: readonly string[];
+  readonly copilotSkills: readonly string[];
+  readonly format: "json" | "text";
+  readonly outputPath?: string;
+}
+
+function list(value: string | undefined, fallback: readonly string[]): readonly string[] {
+  return value ? value.split(",").filter(Boolean) : fallback;
+}
+
+function integer(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) throw new TypeError("invalid integer argument");
+  return parsed;
+}
+
+export function parseKeyValueArguments(
+  argv: readonly string[],
+  message: string,
+): Map<string, string> {
+  const values = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!name?.startsWith("--") || value === undefined || value.startsWith("--"))
+      throw new TypeError(message);
+    values.set(name.slice(2), value);
+  }
+  return values;
+}
+
+export function parsePreflightArguments(
+  argv: readonly string[],
+  options?: {
+    readonly defaultFormat?: "json" | "text";
+    readonly defaultWorkspace?: string;
+  },
+): PreflightArguments {
+  const values = parseKeyValueArguments(argv, "invalid team preflight arguments");
+  const preferredRuntime = values.get("preferred-runtime");
+  if (preferredRuntime !== undefined && !["codex", "copilot"].includes(preferredRuntime))
+    throw new TypeError("invalid preferred runtime");
+  const workProfile = values.get("work-profile") ?? "implementation";
+  if (!["review", "implementation", "synthesis"].includes(workProfile))
+    throw new TypeError("invalid work profile");
+  const format = values.get("format") ?? options?.defaultFormat ?? "json";
+  if (!["json", "text"].includes(format)) throw new TypeError("invalid output format");
+  const workspace = values.get("workspace") ?? options?.defaultWorkspace;
+  const outputPath = values.get("output");
+  return {
+    ...(workspace ? { workspace } : {}),
+    goal: values.get("goal") ?? "Preflight one dynamic Yukh worker engagement.",
+    role: values.get("role") ?? "backend-reviewer",
+    workProfile: workProfile as TeamWorkProfile,
+    ...(preferredRuntime ? { preferredRuntime: preferredRuntime as AgentRuntime } : {}),
+    teamBudget: integer(values.get("team-budget"), 260_000),
+    managerBudget: integer(values.get("manager-budget"), 180_000),
+    codexModels: list(values.get("codex-models") ?? process.env.YUKH_CODEX_MODELS, ["default"]),
+    copilotModels: list(values.get("copilot-models") ?? process.env.YUKH_COPILOT_MODELS, [
+      "default",
+    ]),
+    codexSkills: list(values.get("codex-skills") ?? process.env.YUKH_CODEX_SKILLS, [
+      "api-design",
+      "testing",
+      "product",
+      "documentation",
+      "security",
+    ]),
+    copilotSkills: list(values.get("copilot-skills") ?? process.env.YUKH_COPILOT_SKILLS, [
+      "frontend",
+      "testing",
+    ]),
+    format: format as "json" | "text",
+    ...(outputPath ? { outputPath } : {}),
+  };
+}

--- a/apps/team-preflight/src/format.ts
+++ b/apps/team-preflight/src/format.ts
@@ -7,10 +7,13 @@ function list(values: readonly string[]): string {
   return values.length > 0 ? values.join(", ") : "none";
 }
 
-export function formatEngagePreflight(output: EngagePreflightOutput): string {
+export function formatEngagePreflight(
+  output: EngagePreflightOutput,
+  options?: { readonly runCommand?: string | false },
+): string {
   const worker = output.planned_worker;
   const policy = output.policy.recommendation;
-  return [
+  const lines = [
     "Yukh team preflight",
     `Status: ${output.status}`,
     `Workspace: ${output.workspace}`,
@@ -32,10 +35,13 @@ export function formatEngagePreflight(output: EngagePreflightOutput): string {
     `- allocated: ${output.budget.allocated}`,
     `- observed provider tokens: ${output.provider_tokens_observed}`,
     `- provider launched: ${output.provider_runtime_launched ? "yes" : "no"}`,
-    "",
-    "Run after approval",
-    `yukh team run-approved --preflight <preflight.json> --approved-digest ${output.approval_digest}`,
-  ].join("\n");
+  ];
+  const runCommand =
+    options?.runCommand === undefined
+      ? `yukh team run-approved --preflight <preflight.json> --approved-digest ${output.approval_digest}`
+      : options.runCommand;
+  if (runCommand) lines.push("", "Run after approval", runCommand);
+  return lines.join("\n");
 }
 
 export function formatApprovedRun(output: ApprovedRunOutput): string {

--- a/apps/team-preflight/src/main.ts
+++ b/apps/team-preflight/src/main.ts
@@ -1,85 +1,10 @@
 import { writeFileSync } from "node:fs";
-import type { AgentRuntime } from "../../../packages/team-control/src/store.js";
-import type { TeamWorkProfile } from "../../team-control/src/server.js";
+import { parsePreflightArguments } from "./arguments.js";
 import { formatEngagePreflight } from "./format.js";
 import { runEngagePreflight } from "./preflight.js";
 
-interface Arguments {
-  readonly workspace?: string;
-  readonly goal: string;
-  readonly role: string;
-  readonly workProfile: TeamWorkProfile;
-  readonly preferredRuntime?: AgentRuntime;
-  readonly teamBudget: number;
-  readonly managerBudget: number;
-  readonly codexModels: readonly string[];
-  readonly copilotModels: readonly string[];
-  readonly codexSkills: readonly string[];
-  readonly copilotSkills: readonly string[];
-  readonly format: "json" | "text";
-  readonly outputPath?: string;
-}
-
-function list(value: string | undefined, fallback: readonly string[]): readonly string[] {
-  return value ? value.split(",").filter(Boolean) : fallback;
-}
-
-function integer(value: string | undefined, fallback: number): number {
-  if (value === undefined) return fallback;
-  const parsed = Number(value);
-  if (!Number.isSafeInteger(parsed)) throw new TypeError("invalid integer argument");
-  return parsed;
-}
-
-function parseArguments(argv: readonly string[]): Arguments {
-  const values = new Map<string, string>();
-  for (let index = 0; index < argv.length; index += 2) {
-    const name = argv[index];
-    const value = argv[index + 1];
-    if (!name?.startsWith("--") || value === undefined || value.startsWith("--"))
-      throw new TypeError("invalid team preflight arguments");
-    values.set(name.slice(2), value);
-  }
-  const preferredRuntime = values.get("preferred-runtime");
-  if (preferredRuntime !== undefined && !["codex", "copilot"].includes(preferredRuntime))
-    throw new TypeError("invalid preferred runtime");
-  const workProfile = values.get("work-profile") ?? "implementation";
-  if (!["review", "implementation", "synthesis"].includes(workProfile))
-    throw new TypeError("invalid work profile");
-  const format = values.get("format") ?? "json";
-  if (!["json", "text"].includes(format)) throw new TypeError("invalid output format");
-  const workspace = values.get("workspace");
-  const outputPath = values.get("output");
-  return {
-    ...(workspace ? { workspace } : {}),
-    goal: values.get("goal") ?? "Preflight one dynamic Yukh worker engagement.",
-    role: values.get("role") ?? "backend-reviewer",
-    workProfile: workProfile as TeamWorkProfile,
-    ...(preferredRuntime ? { preferredRuntime: preferredRuntime as AgentRuntime } : {}),
-    teamBudget: integer(values.get("team-budget"), 260_000),
-    managerBudget: integer(values.get("manager-budget"), 180_000),
-    codexModels: list(values.get("codex-models") ?? process.env.YUKH_CODEX_MODELS, ["default"]),
-    copilotModels: list(values.get("copilot-models") ?? process.env.YUKH_COPILOT_MODELS, [
-      "default",
-    ]),
-    codexSkills: list(values.get("codex-skills") ?? process.env.YUKH_CODEX_SKILLS, [
-      "api-design",
-      "testing",
-      "product",
-      "documentation",
-      "security",
-    ]),
-    copilotSkills: list(values.get("copilot-skills") ?? process.env.YUKH_COPILOT_SKILLS, [
-      "frontend",
-      "testing",
-    ]),
-    format: format as "json" | "text",
-    ...(outputPath ? { outputPath } : {}),
-  };
-}
-
 try {
-  const args = parseArguments(process.argv.slice(2));
+  const args = parsePreflightArguments(process.argv.slice(2));
   const output = runEngagePreflight(args);
   if (args.outputPath)
     writeFileSync(args.outputPath, `${JSON.stringify(output)}\n`, { mode: 0o600 });

--- a/apps/team-preflight/src/propose-main.ts
+++ b/apps/team-preflight/src/propose-main.ts
@@ -1,0 +1,57 @@
+import { mkdirSync, realpathSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { parsePreflightArguments } from "./arguments.js";
+import { formatEngagePreflight } from "./format.js";
+import { runEngagePreflight } from "./preflight.js";
+
+function slug(value: string): string {
+  return value
+    .replace(/[^a-z0-9-]/gu, "-")
+    .replace(/-+/gu, "-")
+    .replace(/^-|-$/gu, "");
+}
+
+function timestamp(): string {
+  return new Date()
+    .toISOString()
+    .replace(/[-:]/gu, "")
+    .replace(/\.\d{3}Z$/u, "Z");
+}
+
+function approvalPath(workspace: string, role: string): string {
+  const directory = join(workspace, ".yukh", "approvals");
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  return join(directory, `${timestamp()}-${slug(role) || "worker"}.json`);
+}
+
+try {
+  const workspace = realpathSync(process.cwd());
+  const args = parsePreflightArguments(process.argv.slice(2), {
+    defaultFormat: "text",
+    defaultWorkspace: workspace,
+  });
+  const output = runEngagePreflight(args);
+  const path = args.outputPath ?? approvalPath(workspace, output.planned_worker.role);
+  writeFileSync(path, `${JSON.stringify(output)}\n`, { mode: 0o600 });
+  const rendered =
+    args.format === "json"
+      ? JSON.stringify({ ...output, approval_file: path })
+      : [
+          formatEngagePreflight(output, {
+            runCommand: `yukh team run-approved --preflight ${path} --approved-digest ${output.approval_digest} --format text`,
+          }),
+          "",
+          `Approval file: ${path}`,
+        ].join("\n");
+  process.stdout.write(`${rendered}\n`);
+} catch (error) {
+  process.stdout.write(
+    `${JSON.stringify({
+      schema: 1,
+      status: "error",
+      command: "team propose",
+      code: error instanceof Error ? error.message : "team_propose_failed",
+    })}\n`,
+  );
+  process.exitCode = 1;
+}

--- a/bin/yukh.mjs
+++ b/bin/yukh.mjs
@@ -9,12 +9,15 @@ if (process.argv[2] === "conversation" && process.argv[3] === "watch") {
 } else if (process.argv[2] === "team" && process.argv[3] === "preflight-engage") {
   process.argv.splice(2, 2);
   await import("../dist/apps/team-preflight/src/main.js");
+} else if (process.argv[2] === "team" && process.argv[3] === "propose") {
+  process.argv.splice(2, 2);
+  await import("../dist/apps/team-preflight/src/propose-main.js");
 } else if (process.argv[2] === "team" && process.argv[3] === "run-approved") {
   process.argv.splice(2, 2);
   await import("../dist/apps/team-preflight/src/run-approved-main.js");
 } else {
   process.stderr.write(
-    "usage: yukh conversation watch [--full] [--verbose]\n       yukh team serve\n       yukh team preflight-engage [--role backend-reviewer] [--work-profile implementation] [--format json|text] [--output preflight.json]\n       yukh team run-approved --preflight file --approved-digest sha-256:... [--format json|text]\n",
+    "usage: yukh conversation watch [--full] [--verbose]\n       yukh team serve\n       yukh team propose [--role backend-reviewer] [--work-profile implementation]\n       yukh team preflight-engage [--role backend-reviewer] [--work-profile implementation] [--format json|text] [--output preflight.json]\n       yukh team run-approved --preflight file --approved-digest sha-256:... [--format json|text]\n",
   );
   process.exitCode = 2;
 }


### PR DESCRIPTION
## Summary
- add `yukh team propose` as the guided approval entrypoint
- save approval artifacts under `.yukh/approvals/`
- print a readable preflight with the exact `run-approved` command
- keep provider runtime disabled during proposal; observed provider tokens stay at zero
- share argument parsing with `preflight-engage`

## Validation
- `npm run -s typecheck`
- `node --import tsx --test test/runtime/team-control.test.ts`
- `npm run -s build`
- `npm run -s format:check`
- `git diff --check`
- `yukh team propose --role backend-reviewer --work-profile review --preferred-runtime codex --format text`

## Smoke evidence
- approval saved in `.yukh/approvals/*.json`
- one `Run after approval` section
- saved JSON reports `provider_runtime_launched=false`
- saved JSON reports `provider_tokens_observed=0`
