### PR TITLE
Carry approved goal into preflight worker

### DIFF
--- a/apps/team-preflight/src/format.ts
+++ b/apps/team-preflight/src/format.ts
@@ -7,6 +7,11 @@ function list(values: readonly string[]): string {
   return values.length > 0 ? values.join(", ") : "none";
 }
 
+function compact(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength - 1)}…`;
+}
+
 export function formatEngagePreflight(
   output: EngagePreflightOutput,
   options?: { readonly runCommand?: string | false },
@@ -22,6 +27,7 @@ export function formatEngagePreflight(
     "Planned worker",
     `- id: ${worker.agent_id}`,
     `- role: ${worker.role}`,
+    `- task: ${compact(worker.task, 240)}`,
     `- runtime: ${policy.runtime}`,
     `- model: ${policy.model}`,
     `- skills: ${list(policy.skills)}`,

--- a/apps/team-preflight/src/preflight.ts
+++ b/apps/team-preflight/src/preflight.ts
@@ -41,6 +41,11 @@ function runtimeSet(values: readonly string[]): ReadonlySet<string> {
   return new Set(values);
 }
 
+function concise(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength - 1)}…`;
+}
+
 export function approvalDigest(input: {
   readonly team_id: string;
   readonly manager_agent_id: string;
@@ -131,13 +136,13 @@ export function runEngagePreflight(args: EngagePreflightArguments): EngagePrefli
     role: policy.role,
     profile: {
       schema: 1,
-      mission: `Preflighted ${policy.role}`,
+      mission: concise(args.goal, 1_024),
       model: policy.recommendation.model,
       skills: policy.recommendation.skills,
       instructions:
-        "This worker was composed by preflight only. A real run must be launched separately.",
+        "Execute only the approved task, stay within the approved runtime bounds, keep output concise, and report any missing context instead of guessing.",
     },
-    task: "Preflight only: no provider runtime launched.",
+    task: args.goal,
     can_spawn: false,
     token_budget: policy.recommendation.token_budget,
     model_tool_mode: policy.recommendation.tool_mode,

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -186,6 +186,8 @@ test("engage preflight composes a worker without launching a provider runtime", 
     assert.equal(output.policy.recommendation.model, "default");
     assert.deepEqual(output.policy.recommendation.skills, ["frontend"]);
     assert.equal(output.planned_worker.state, "defined");
+    assert.equal(output.planned_worker.task, "Preflight frontend worker");
+    assert.equal(output.planned_worker.profile?.mission, "Preflight frontend worker");
     assert.equal(output.planned_worker.parent_agent_id, output.manager.agent_id);
     assert.equal(output.budget.allocated, 230_000);
     assert.equal(output.budget.observed, 0);
@@ -215,6 +217,7 @@ test("engage preflight text output shows approval and budget without raw JSON no
     assert.match(text, /Yukh team preflight/u);
     assert.match(text, new RegExp(output.approval_digest, "u"));
     assert.match(text, /runtime: codex/u);
+    assert.match(text, /task: Preflight backend worker/u);
     assert.match(text, /observed provider tokens: 0/u);
     assert.doesNotMatch(text, /"planned_worker"/u);
   } finally {


### PR DESCRIPTION
## Summary
- make preflighted workers carry the approved goal as their real task
- use the approved goal as the worker mission, bounded to profile limits
- show the planned task in readable preflight output
- keep provider runtime disabled during proposal/preflight

## Validation
- `npm run -s typecheck`
- `node --import tsx --test test/runtime/team-control.test.ts`
- `npm run -s build`
- `npm run -s format:check`
- `git diff --check`
- real proposal smoke: saved JSON now carries the suite-readiness goal in `planned_worker.task`
