### PR TITLE
Save team proposals in selected workspace

### DIFF
--- a/apps/team-preflight/src/propose-main.ts
+++ b/apps/team-preflight/src/propose-main.ts
@@ -31,7 +31,7 @@ try {
     defaultWorkspace: workspace,
   });
   const output = runEngagePreflight(args);
-  const path = args.outputPath ?? approvalPath(workspace, output.planned_worker.role);
+  const path = args.outputPath ?? approvalPath(output.workspace, output.planned_worker.role);
   writeFileSync(path, `${JSON.stringify(output)}\n`, { mode: 0o600 });
   const rendered =
     args.format === "json"


### PR DESCRIPTION
## Summary
- save generated `team propose` approval files under the effective preflight workspace
- keep explicit `--workspace` runs self-contained
- avoid writing approvals into the CLI caller checkout by mistake

## Validation
- `npm run -s typecheck`
- `node --import tsx --test test/runtime/team-control.test.ts`
- `npm run -s build`
- `npm run -s format:check`
- `git diff --check`
- smoke: `team propose --workspace /tmp/...` saved approval under `/tmp/.../.yukh/approvals/`
