### PR TITLE
Add suite qualification team preset

### DIFF
--- a/apps/team-preflight/src/arguments.ts
+++ b/apps/team-preflight/src/arguments.ts
@@ -17,6 +17,26 @@ export interface PreflightArguments {
   readonly outputPath?: string;
 }
 
+interface PreflightPreset {
+  readonly goal: string;
+  readonly role: string;
+  readonly workProfile: TeamWorkProfile;
+  readonly preferredRuntime: AgentRuntime;
+  readonly teamBudget: number;
+  readonly managerBudget: number;
+}
+
+const presets: Readonly<Record<string, PreflightPreset>> = {
+  "suite-qualification": {
+    goal: "Review Yukh suite readiness for self-development across nomed.github.io, yukh-mcp, yukh-projects and yukh-coordination. Produce a concise read-only qualification checklist and identify the first safe implementation increment. Do not modify repositories.",
+    role: "suite-qualification-reviewer",
+    workProfile: "review",
+    preferredRuntime: "codex",
+    teamBudget: 260_000,
+    managerBudget: 180_000,
+  },
+};
+
 function list(value: string | undefined, fallback: readonly string[]): readonly string[] {
   return value ? value.split(",").filter(Boolean) : fallback;
 }
@@ -51,10 +71,13 @@ export function parsePreflightArguments(
   },
 ): PreflightArguments {
   const values = parseKeyValueArguments(argv, "invalid team preflight arguments");
-  const preferredRuntime = values.get("preferred-runtime");
+  const presetName = values.get("preset");
+  const preset = presetName ? presets[presetName] : undefined;
+  if (presetName && !preset) throw new TypeError("invalid team preflight preset");
+  const preferredRuntime = values.get("preferred-runtime") ?? preset?.preferredRuntime;
   if (preferredRuntime !== undefined && !["codex", "copilot"].includes(preferredRuntime))
     throw new TypeError("invalid preferred runtime");
-  const workProfile = values.get("work-profile") ?? "implementation";
+  const workProfile = values.get("work-profile") ?? preset?.workProfile ?? "implementation";
   if (!["review", "implementation", "synthesis"].includes(workProfile))
     throw new TypeError("invalid work profile");
   const format = values.get("format") ?? options?.defaultFormat ?? "json";
@@ -63,12 +86,12 @@ export function parsePreflightArguments(
   const outputPath = values.get("output");
   return {
     ...(workspace ? { workspace } : {}),
-    goal: values.get("goal") ?? "Preflight one dynamic Yukh worker engagement.",
-    role: values.get("role") ?? "backend-reviewer",
+    goal: values.get("goal") ?? preset?.goal ?? "Preflight one dynamic Yukh worker engagement.",
+    role: values.get("role") ?? preset?.role ?? "backend-reviewer",
     workProfile: workProfile as TeamWorkProfile,
     ...(preferredRuntime ? { preferredRuntime: preferredRuntime as AgentRuntime } : {}),
-    teamBudget: integer(values.get("team-budget"), 260_000),
-    managerBudget: integer(values.get("manager-budget"), 180_000),
+    teamBudget: integer(values.get("team-budget"), preset?.teamBudget ?? 260_000),
+    managerBudget: integer(values.get("manager-budget"), preset?.managerBudget ?? 180_000),
     codexModels: list(values.get("codex-models") ?? process.env.YUKH_CODEX_MODELS, ["default"]),
     copilotModels: list(values.get("copilot-models") ?? process.env.YUKH_COPILOT_MODELS, [
       "default",

--- a/bin/yukh.mjs
+++ b/bin/yukh.mjs
@@ -17,7 +17,7 @@ if (process.argv[2] === "conversation" && process.argv[3] === "watch") {
   await import("../dist/apps/team-preflight/src/run-approved-main.js");
 } else {
   process.stderr.write(
-    "usage: yukh conversation watch [--full] [--verbose]\n       yukh team serve\n       yukh team propose [--role backend-reviewer] [--work-profile implementation]\n       yukh team preflight-engage [--role backend-reviewer] [--work-profile implementation] [--format json|text] [--output preflight.json]\n       yukh team run-approved --preflight file --approved-digest sha-256:... [--format json|text]\n",
+    "usage: yukh conversation watch [--full] [--verbose]\n       yukh team serve\n       yukh team propose [--preset suite-qualification] [--role backend-reviewer] [--work-profile implementation]\n       yukh team preflight-engage [--preset suite-qualification] [--role backend-reviewer] [--work-profile implementation] [--format json|text] [--output preflight.json]\n       yukh team run-approved --preflight file --approved-digest sha-256:... [--format json|text]\n",
   );
   process.exitCode = 2;
 }

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -9,6 +9,7 @@ import { TeamStore } from "../../packages/team-control/src/store.js";
 import { TeamSupervisor } from "../../packages/team-control/src/supervisor.js";
 import { RuntimeOutput } from "../../packages/team-control/src/runtime-output.js";
 import { teamRuntimeEntrypoints } from "../../packages/team-control/src/entrypoints.js";
+import { parsePreflightArguments } from "../../apps/team-preflight/src/arguments.js";
 import { runApprovedPreflight } from "../../apps/team-preflight/src/approved-run.js";
 import { formatApprovedRun, formatEngagePreflight } from "../../apps/team-preflight/src/format.js";
 import { runEngagePreflight } from "../../apps/team-preflight/src/preflight.js";
@@ -48,6 +49,21 @@ test("only zero-command tool-free deterministic plans satisfy the default cost p
   safe.workers[0]!.max_commands = 0;
   (safe.workers[0] as { tool_mode: string }).tool_mode = "coordination";
   assert.equal(costSafeDeterministicPlan(record), false);
+});
+
+test("suite qualification preset defines the official read-only reviewer profile", () => {
+  const args = parsePreflightArguments(["--preset", "suite-qualification"], {
+    defaultFormat: "text",
+    defaultWorkspace: "/tmp",
+  });
+  assert.equal(args.role, "suite-qualification-reviewer");
+  assert.equal(args.workProfile, "review");
+  assert.equal(args.preferredRuntime, "codex");
+  assert.equal(args.teamBudget, 260_000);
+  assert.equal(args.managerBudget, 180_000);
+  assert.equal(args.format, "text");
+  assert.match(args.goal, /Review Yukh suite readiness/u);
+  assert.match(args.goal, /Do not modify repositories/u);
 });
 
 const usage = {


### PR DESCRIPTION
## Summary
- add official `suite-qualification` team preflight preset
- preset maps to `suite-qualification-reviewer`, Codex, review profile, zero commands
- keep budget bounded at 18k worker / 180k manager reservation
- document preset in CLI usage

## Validation
- `npm run -s typecheck`
- `node --import tsx --test test/runtime/team-control.test.ts`
- `npm run -s build`
- `npm run -s format:check`
- `git diff --check`
- smoke: `team propose --preset suite-qualification --format text`

## Runtime behavior
- provider runtime is not launched by the proposal
- observed provider tokens remain zero
- planned worker has `tool_mode=none` and `max_commands=0`
