### PR TITLE
Add suite readonly verifier preset

### DIFF
--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -45,7 +45,7 @@ export interface TeamControlOptions {
   readonly dynamicExecution?: boolean;
 }
 
-export type TeamWorkProfile = "review" | "implementation" | "synthesis";
+export type TeamWorkProfile = "review" | "readonly" | "implementation" | "synthesis";
 
 export interface RoleProfilePolicy {
   readonly schema: 1;
@@ -168,6 +168,13 @@ function budgetFor(workProfile: TeamWorkProfile): {
 } {
   if (workProfile === "review")
     return { token_budget: 18_000, tool_mode: "none", max_commands: 0, runtime_timeout_ms: 60_000 };
+  if (workProfile === "readonly")
+    return {
+      token_budget: 40_000,
+      tool_mode: "none",
+      max_commands: 8,
+      runtime_timeout_ms: 180_000,
+    };
   if (workProfile === "synthesis")
     return { token_budget: 16_000, tool_mode: "none", max_commands: 0, runtime_timeout_ms: 60_000 };
   return {
@@ -608,7 +615,9 @@ export function createTeamControlServer(
         .object({
           team_id: id.optional(),
           role: z.string().regex(/^[a-z][a-z0-9-]{0,31}$/u),
-          work_profile: z.enum(["review", "implementation", "synthesis"]).default("implementation"),
+          work_profile: z
+            .enum(["review", "readonly", "implementation", "synthesis"])
+            .default("implementation"),
           preferred_runtime: z.enum(["codex", "copilot"]).optional(),
         })
         .strict(),

--- a/apps/team-preflight/src/arguments.ts
+++ b/apps/team-preflight/src/arguments.ts
@@ -35,6 +35,14 @@ const presets: Readonly<Record<string, PreflightPreset>> = {
     teamBudget: 260_000,
     managerBudget: 180_000,
   },
+  "suite-readonly-verifier": {
+    goal: "Verify the Yukh suite baseline for self-development with bounded read-only inspection only. Inspect minimal repository metadata under /home/codex/repos/nomed/yukh-workspace for nomed.github.io, yukh-mcp, yukh-projects and yukh-coordination: git status/log, README, package/go module metadata and workflow files when present. Use safe read-only commands only. Do not modify files, install dependencies, start services, run network calls or write outside runtime logs. Produce a concise baseline, concrete blockers and the first safe implementation increment.",
+    role: "suite-readonly-verifier",
+    workProfile: "readonly",
+    preferredRuntime: "codex",
+    teamBudget: 300_000,
+    managerBudget: 180_000,
+  },
 };
 
 function list(value: string | undefined, fallback: readonly string[]): readonly string[] {
@@ -78,7 +86,7 @@ export function parsePreflightArguments(
   if (preferredRuntime !== undefined && !["codex", "copilot"].includes(preferredRuntime))
     throw new TypeError("invalid preferred runtime");
   const workProfile = values.get("work-profile") ?? preset?.workProfile ?? "implementation";
-  if (!["review", "implementation", "synthesis"].includes(workProfile))
+  if (!["review", "readonly", "implementation", "synthesis"].includes(workProfile))
     throw new TypeError("invalid work profile");
   const format = values.get("format") ?? options?.defaultFormat ?? "json";
   if (!["json", "text"].includes(format)) throw new TypeError("invalid output format");

--- a/bin/yukh.mjs
+++ b/bin/yukh.mjs
@@ -17,7 +17,7 @@ if (process.argv[2] === "conversation" && process.argv[3] === "watch") {
   await import("../dist/apps/team-preflight/src/run-approved-main.js");
 } else {
   process.stderr.write(
-    "usage: yukh conversation watch [--full] [--verbose]\n       yukh team serve\n       yukh team propose [--preset suite-qualification] [--role backend-reviewer] [--work-profile implementation]\n       yukh team preflight-engage [--preset suite-qualification] [--role backend-reviewer] [--work-profile implementation] [--format json|text] [--output preflight.json]\n       yukh team run-approved --preflight file --approved-digest sha-256:... [--format json|text]\n",
+    "usage: yukh conversation watch [--full] [--verbose]\n       yukh team serve\n       yukh team propose [--preset suite-qualification|suite-readonly-verifier] [--role backend-reviewer] [--work-profile implementation]\n       yukh team preflight-engage [--preset suite-qualification|suite-readonly-verifier] [--role backend-reviewer] [--work-profile implementation] [--format json|text] [--output preflight.json]\n       yukh team run-approved --preflight file --approved-digest sha-256:... [--format json|text]\n",
   );
   process.exitCode = 2;
 }

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -66,6 +66,21 @@ test("suite qualification preset defines the official read-only reviewer profile
   assert.match(args.goal, /Do not modify repositories/u);
 });
 
+test("suite readonly verifier preset allows bounded read-only inspection", () => {
+  const args = parsePreflightArguments(["--preset", "suite-readonly-verifier"], {
+    defaultFormat: "text",
+    defaultWorkspace: "/tmp",
+  });
+  assert.equal(args.role, "suite-readonly-verifier");
+  assert.equal(args.workProfile, "readonly");
+  assert.equal(args.preferredRuntime, "codex");
+  assert.equal(args.teamBudget, 300_000);
+  assert.equal(args.managerBudget, 180_000);
+  assert.equal(args.format, "text");
+  assert.match(args.goal, /bounded read-only inspection/u);
+  assert.match(args.goal, /Do not modify files/u);
+});
+
 const usage = {
   schema: 1 as const,
   source: "codex-json-v1" as const,
@@ -174,6 +189,18 @@ test("role profile policy maps specialists to allowlisted runtime models skills 
     max_commands: 0,
     runtime_timeout_ms: 60_000,
   });
+  assert.deepEqual(
+    roleProfilePolicy(options, "suite-readonly-verifier", "readonly").recommendation,
+    {
+      runtime: "codex",
+      model: "default",
+      skills: ["testing"],
+      token_budget: 40_000,
+      tool_mode: "none",
+      max_commands: 8,
+      runtime_timeout_ms: 180_000,
+    },
+  );
   assert.deepEqual(roleProfilePolicy(options, "security-reviewer", "review").omitted_skills, [
     "security",
   ]);


### PR DESCRIPTION
Adds a bounded read-only suite verifier preset for the next self-development qualification run.\n\nValidation:\n- npm run -s typecheck\n- node --import tsx --test test/runtime/team-control.test.ts\n- npm run -s build\n- npm run -s format:check\n- git diff --check\n- smoke: yukh team propose --preset suite-readonly-verifier