### PR TITLE
Harden suite readonly verifier budget

### DIFF
--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -170,10 +170,10 @@ function budgetFor(workProfile: TeamWorkProfile): {
     return { token_budget: 18_000, tool_mode: "none", max_commands: 0, runtime_timeout_ms: 60_000 };
   if (workProfile === "readonly")
     return {
-      token_budget: 40_000,
+      token_budget: 30_000,
       tool_mode: "none",
-      max_commands: 8,
-      runtime_timeout_ms: 180_000,
+      max_commands: 4,
+      runtime_timeout_ms: 120_000,
     };
   if (workProfile === "synthesis")
     return { token_budget: 16_000, tool_mode: "none", max_commands: 0, runtime_timeout_ms: 60_000 };

--- a/apps/team-preflight/src/arguments.ts
+++ b/apps/team-preflight/src/arguments.ts
@@ -36,7 +36,7 @@ const presets: Readonly<Record<string, PreflightPreset>> = {
     managerBudget: 180_000,
   },
   "suite-readonly-verifier": {
-    goal: "Verify the Yukh suite baseline for self-development with bounded read-only inspection only. Inspect minimal repository metadata under /home/codex/repos/nomed/yukh-workspace for nomed.github.io, yukh-mcp, yukh-projects and yukh-coordination: git status/log, README, package/go module metadata and workflow files when present. Use safe read-only commands only. Do not modify files, install dependencies, start services, run network calls or write outside runtime logs. Produce a concise baseline, concrete blockers and the first safe implementation increment.",
+    goal: "Verify the Yukh suite baseline for self-development with bounded read-only inspection only. Inspect minimal repository metadata under /home/codex/repos/nomed/yukh-workspace for nomed.github.io, yukh-mcp, yukh-projects and yukh-coordination. Use at most four safe read-only commands. Exclude node_modules, dist, build, .qualification, .worktrees and nested worktrees from every listing. Keep combined command output below 250 lines. Prefer compact commands for git status/log, root README heading, package/go module metadata and workflow command summaries. Do not modify files, install dependencies, start services, run network calls or write outside runtime logs. Produce a concise baseline, concrete blockers and the first safe implementation increment.",
     role: "suite-readonly-verifier",
     workProfile: "readonly",
     preferredRuntime: "codex",

--- a/apps/team-preflight/src/preflight.ts
+++ b/apps/team-preflight/src/preflight.ts
@@ -46,6 +46,12 @@ function concise(value: string, maxLength: number): string {
   return `${value.slice(0, maxLength - 1)}…`;
 }
 
+function workerInstructions(workProfile: TeamWorkProfile): string {
+  if (workProfile === "readonly")
+    return "Execute only the approved read-only task. Use no model-facing tools. Do not mutate files, install dependencies, start services, call the network or traverse dependency/build/runtime artifact directories. Keep every command and final output compact; stop and summarize rather than dumping large listings.";
+  return "Execute only the approved task, stay within the approved runtime bounds, keep output concise, and report any missing context instead of guessing.";
+}
+
 export function approvalDigest(input: {
   readonly team_id: string;
   readonly manager_agent_id: string;
@@ -139,8 +145,7 @@ export function runEngagePreflight(args: EngagePreflightArguments): EngagePrefli
       mission: concise(args.goal, 1_024),
       model: policy.recommendation.model,
       skills: policy.recommendation.skills,
-      instructions:
-        "Execute only the approved task, stay within the approved runtime bounds, keep output concise, and report any missing context instead of guessing.",
+      instructions: workerInstructions(args.workProfile),
     },
     task: args.goal,
     can_spawn: false,

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -79,6 +79,7 @@ test("suite readonly verifier preset allows bounded read-only inspection", () =>
   assert.equal(args.format, "text");
   assert.match(args.goal, /bounded read-only inspection/u);
   assert.match(args.goal, /Do not modify files/u);
+  assert.match(args.goal, /Keep combined command output below 250 lines/u);
 });
 
 const usage = {
@@ -195,10 +196,10 @@ test("role profile policy maps specialists to allowlisted runtime models skills 
       runtime: "codex",
       model: "default",
       skills: ["testing"],
-      token_budget: 40_000,
+      token_budget: 30_000,
       tool_mode: "none",
-      max_commands: 8,
-      runtime_timeout_ms: 180_000,
+      max_commands: 4,
+      runtime_timeout_ms: 120_000,
     },
   );
   assert.deepEqual(roleProfilePolicy(options, "security-reviewer", "review").omitted_skills, [


### PR DESCRIPTION
Tightens the suite readonly verifier after the first real run exceeded the worker token budget due to oversized read-only command output.\n\nChanges:\n- readonly profile budget: 30k tokens, 4 commands, 120s\n- preset task excludes heavy artifact directories and caps combined command output guidance\n- readonly worker profile gets explicit no-mutation/no-output-dump instructions\n\nValidation:\n- npm run -s typecheck\n- node --import tsx --test test/runtime/team-control.test.ts\n- npm run -s build\n- npm run -s format:check\n- git diff --check\n- smoke: yukh team propose --preset suite-readonly-verifier