### PR TITLE
Calibrate readonly verifier token budget

### DIFF
--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -170,7 +170,7 @@ function budgetFor(workProfile: TeamWorkProfile): {
     return { token_budget: 18_000, tool_mode: "none", max_commands: 0, runtime_timeout_ms: 60_000 };
   if (workProfile === "readonly")
     return {
-      token_budget: 30_000,
+      token_budget: 50_000,
       tool_mode: "none",
       max_commands: 4,
       runtime_timeout_ms: 120_000,

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -196,7 +196,7 @@ test("role profile policy maps specialists to allowlisted runtime models skills 
       runtime: "codex",
       model: "default",
       skills: ["testing"],
-      token_budget: 30_000,
+      token_budget: 50_000,
       tool_mode: "none",
       max_commands: 4,
       runtime_timeout_ms: 120_000,


### PR DESCRIPTION
Calibrates the suite readonly verifier budget to 50k after a hardened real run measured 48,337 total tokens with 2 read-only commands. The stricter 4-command and output-bounded instructions remain in place.\n\nValidation:\n- npm run -s typecheck\n- node --import tsx --test test/runtime/team-control.test.ts\n- npm run -s build\n- npm run -s format:check\n- git diff --check