### PR TITLE
Make team verifier cheaper to operate

### DIFF
--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -170,9 +170,9 @@ function budgetFor(workProfile: TeamWorkProfile): {
     return { token_budget: 18_000, tool_mode: "none", max_commands: 0, runtime_timeout_ms: 60_000 };
   if (workProfile === "readonly")
     return {
-      token_budget: 50_000,
+      token_budget: 90_000,
       tool_mode: "none",
-      max_commands: 4,
+      max_commands: 1,
       runtime_timeout_ms: 120_000,
     };
   if (workProfile === "synthesis")

--- a/apps/team-preflight/src/arguments.ts
+++ b/apps/team-preflight/src/arguments.ts
@@ -36,11 +36,11 @@ const presets: Readonly<Record<string, PreflightPreset>> = {
     managerBudget: 180_000,
   },
   "suite-readonly-verifier": {
-    goal: "Verify the Yukh suite baseline for self-development with bounded read-only inspection only. Inspect minimal repository metadata under /home/codex/repos/nomed/yukh-workspace for nomed.github.io, yukh-mcp, yukh-projects and yukh-coordination. Use at most four safe read-only commands. Exclude node_modules, dist, build, .qualification, .worktrees and nested worktrees from every listing. Keep combined command output below 250 lines. Prefer compact commands for git status/log, root README heading, package/go module metadata and workflow command summaries. Do not modify files, install dependencies, start services, run network calls or write outside runtime logs. Produce a concise baseline, concrete blockers and the first safe implementation increment.",
+    goal: "Verify the Yukh suite self-development baseline with one compact read-only probe. Inspect only tracked checkout state and latest commit for nomed.github.io, yukh-mcp, yukh-projects and yukh-coordination. Do not modify files, install dependencies, start services or call the network. Report current state, blockers, token usage if available and one next increment.",
     role: "suite-readonly-verifier",
     workProfile: "readonly",
     preferredRuntime: "codex",
-    teamBudget: 300_000,
+    teamBudget: 340_000,
     managerBudget: 180_000,
   },
 };

--- a/apps/team-preflight/src/format.ts
+++ b/apps/team-preflight/src/format.ts
@@ -1,7 +1,9 @@
 import type { runApprovedPreflight } from "./approved-run.js";
 import type { EngagePreflightOutput } from "./preflight.js";
+import type { TeamStore } from "../../../packages/team-control/src/store.js";
 
 type ApprovedRunOutput = Awaited<ReturnType<typeof runApprovedPreflight>>;
+type TeamStatus = ReturnType<TeamStore["status"]>;
 
 function list(values: readonly string[]): string {
   return values.length > 0 ? values.join(", ") : "none";
@@ -70,4 +72,29 @@ export function formatApprovedRun(output: ApprovedRunOutput): string {
     "",
     `Terminal worker state: ${output.terminal_agent?.state ?? "not waited"}`,
   ].join("\n");
+}
+
+export function formatTeamStatus(output: TeamStatus): string {
+  const lines = [
+    "Yukh team status",
+    `Team: ${output.team.team_id}`,
+    `State: ${output.team.state}`,
+    `Workspace: ${output.team.workspace}`,
+    "",
+    "Tokens",
+    `- budget: ${output.tokens.budget}`,
+    `- allocated: ${output.tokens.allocated}`,
+    `- observed: ${output.tokens.observed}`,
+    `- remaining: ${output.tokens.remaining}`,
+    `- pending agents: ${output.tokens.pending_agents}`,
+    `- unaccounted agents: ${output.tokens.unaccounted_agents}`,
+    `- exceeded agents: ${output.tokens.exceeded_agents}`,
+    "",
+    "Agents",
+  ];
+  for (const agent of output.agents)
+    lines.push(
+      `- ${agent.agent_id} ${agent.kind}/${agent.role} state=${agent.state} budget=${agent.token_budget} observed=${agent.usage?.total_tokens ?? 0} outcome=${agent.completion?.outcome ?? "none"}`,
+    );
+  return lines.join("\n");
 }

--- a/apps/team-preflight/src/preflight.ts
+++ b/apps/team-preflight/src/preflight.ts
@@ -48,7 +48,7 @@ function concise(value: string, maxLength: number): string {
 
 function workerInstructions(workProfile: TeamWorkProfile): string {
   if (workProfile === "readonly")
-    return "Execute only the approved read-only task. Use no model-facing tools. Do not mutate files, install dependencies, start services, call the network or traverse dependency/build/runtime artifact directories. Keep every command and final output compact; stop and summarize rather than dumping large listings.";
+    return "Run at most one compact read-only probe. Do not mutate files, install dependencies, start services, call the network, or list dependency/build/runtime trees. Keep command output and final summary short.";
   return "Execute only the approved task, stay within the approved runtime bounds, keep output concise, and report any missing context instead of guessing.";
 }
 

--- a/apps/team-preflight/src/status-main.ts
+++ b/apps/team-preflight/src/status-main.ts
@@ -1,0 +1,50 @@
+import { realpathSync } from "node:fs";
+import { TeamStore } from "../../../packages/team-control/src/store.js";
+import { formatTeamStatus } from "./format.js";
+
+interface Arguments {
+  readonly teamId: string;
+  readonly workspace: string;
+  readonly format: "json" | "text";
+}
+
+function required(value: string | undefined, name: string): string {
+  if (!value) throw new TypeError(`missing ${name}`);
+  return value;
+}
+
+function parseArguments(argv: readonly string[]): Arguments {
+  const values = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!name?.startsWith("--") || value === undefined || value.startsWith("--"))
+      throw new TypeError("invalid team status arguments");
+    values.set(name.slice(2), value);
+  }
+  const format = values.get("format") ?? "text";
+  if (!["json", "text"].includes(format)) throw new TypeError("invalid output format");
+  return {
+    teamId: required(values.get("team"), "--team"),
+    workspace: realpathSync(values.get("workspace") ?? process.cwd()),
+    format: format as "json" | "text",
+  };
+}
+
+try {
+  const args = parseArguments(process.argv.slice(2));
+  const output = new TeamStore(args.workspace).status(args.teamId);
+  process.stdout.write(
+    `${args.format === "json" ? JSON.stringify(output) : formatTeamStatus(output)}\n`,
+  );
+} catch (error) {
+  process.stdout.write(
+    `${JSON.stringify({
+      schema: 1,
+      status: "error",
+      command: "team status",
+      code: error instanceof Error ? error.message : "team_status_failed",
+    })}\n`,
+  );
+  process.exitCode = 1;
+}

--- a/apps/team-preflight/src/stop-main.ts
+++ b/apps/team-preflight/src/stop-main.ts
@@ -1,0 +1,52 @@
+import { realpathSync } from "node:fs";
+import { TeamStore } from "../../../packages/team-control/src/store.js";
+import { formatTeamStatus } from "./format.js";
+
+interface Arguments {
+  readonly teamId: string;
+  readonly workspace: string;
+  readonly format: "json" | "text";
+}
+
+function required(value: string | undefined, name: string): string {
+  if (!value) throw new TypeError(`missing ${name}`);
+  return value;
+}
+
+function parseArguments(argv: readonly string[]): Arguments {
+  const values = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!name?.startsWith("--") || value === undefined || value.startsWith("--"))
+      throw new TypeError("invalid team stop arguments");
+    values.set(name.slice(2), value);
+  }
+  const format = values.get("format") ?? "text";
+  if (!["json", "text"].includes(format)) throw new TypeError("invalid output format");
+  return {
+    teamId: required(values.get("team"), "--team"),
+    workspace: realpathSync(values.get("workspace") ?? process.cwd()),
+    format: format as "json" | "text",
+  };
+}
+
+try {
+  const args = parseArguments(process.argv.slice(2));
+  const store = new TeamStore(args.workspace);
+  store.stop(args.teamId);
+  const output = store.status(args.teamId);
+  process.stdout.write(
+    `${args.format === "json" ? JSON.stringify(output) : formatTeamStatus(output)}\n`,
+  );
+} catch (error) {
+  process.stdout.write(
+    `${JSON.stringify({
+      schema: 1,
+      status: "error",
+      command: "team stop",
+      code: error instanceof Error ? error.message : "team_stop_failed",
+    })}\n`,
+  );
+  process.exitCode = 1;
+}

--- a/bin/yukh.mjs
+++ b/bin/yukh.mjs
@@ -15,9 +15,16 @@ if (process.argv[2] === "conversation" && process.argv[3] === "watch") {
 } else if (process.argv[2] === "team" && process.argv[3] === "run-approved") {
   process.argv.splice(2, 2);
   await import("../dist/apps/team-preflight/src/run-approved-main.js");
+} else if (process.argv[2] === "team" && process.argv[3] === "status") {
+  process.argv.splice(2, 2);
+  await import("../dist/apps/team-preflight/src/status-main.js");
+} else if (process.argv[2] === "team" && process.argv[3] === "stop") {
+  process.argv.splice(2, 2);
+  await import("../dist/apps/team-preflight/src/stop-main.js");
 } else {
   process.stderr.write(
-    "usage: yukh conversation watch [--full] [--verbose]\n       yukh team serve\n       yukh team propose [--preset suite-qualification|suite-readonly-verifier] [--role backend-reviewer] [--work-profile implementation]\n       yukh team preflight-engage [--preset suite-qualification|suite-readonly-verifier] [--role backend-reviewer] [--work-profile implementation] [--format json|text] [--output preflight.json]\n       yukh team run-approved --preflight file --approved-digest sha-256:... [--format json|text]\n",
+    "usage: yukh conversation watch [--full] [--verbose]\n       yukh team serve\n       yukh team propose [--preset suite-qualification|suite-readonly-verifier] [--role backend-reviewer] [--work-profile implementation]\n       yukh team preflight-engage [--preset suite-qualification|suite-readonly-verifier] [--role backend-reviewer] [--work-profile implementation] [--format json|text] [--output preflight.json]\n       yukh team run-approved --preflight file --approved-digest sha-256:... [--format json|text]\n" +
+      "       yukh team status --team team-... [--workspace path] [--format json|text]\n       yukh team stop --team team-... [--workspace path] [--format json|text]\n",
   );
   process.exitCode = 2;
 }

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -129,20 +129,22 @@ more context.
 
 The tool-free planning profile measured 14,382 total tokens: 13,735 input,
 including 9,984 cached, and 647 output. The 20,000-token allocation provides a
-bounded margin; it is not a universal estimate. A zero-command worker using two
-small context files measured 15,652 total tokens against an 8,000-token
-allocation and failed closed after preserving its summary for review. Use at
-least an 18,000-token worker budget for similar review/planning workers. A
-tool-free synthesis measured 13,932 total tokens against a 10,000-token
-allocation and failed closed after preserving its summary, so use at least a
-16,000-token synthesis budget for the same runtime class unless fresh
-qualification evidence justifies less. Every operational tool call is a
-separate context round and
-needs its own justified budget. Deterministic plan execution adds no manager
-context rounds; only useful workers and the explicit final synthesis consume
-additional model tokens. If a worker returns useful text but exceeds budget, the
-plan fails before synthesis; inspect the worker summary as a review artifact and
-approve a fresh plan rather than retrying blindly.
+bounded margin; it is not a universal estimate. A one-command suite readonly
+probe on the VPS measured 82,240 total tokens, mostly fixed Codex input context,
+so the official readonly verifier allocation is 90,000 tokens and one command.
+A zero-command worker using two small context files measured 15,652 total tokens
+against an 8,000-token allocation and failed closed after preserving its summary
+for review. Use at least an 18,000-token worker budget for similar
+review/planning workers. A tool-free synthesis measured 13,932 total tokens
+against a 10,000-token allocation and failed closed after preserving its summary,
+so use at least a 16,000-token synthesis budget for the same runtime class
+unless fresh qualification evidence justifies less. Every operational tool call
+is a separate context round and needs its own justified budget. Deterministic
+plan execution adds no manager context rounds; only useful workers and the
+explicit final synthesis consume additional model tokens. If a worker returns
+useful text but exceeds budget, the plan fails before synthesis; inspect the
+worker summary as a review artifact and approve a fresh plan rather than
+retrying blindly.
 
 Codex managers run without inherited user configuration. Yukh injects only the
 tools required by the manager record; a pure planning turn receives no
@@ -156,9 +158,11 @@ only bounded children inside its team. It cannot create another root team,
 cross team boundaries or stop the team.
 
 Use `yukh conversation watch --full` to observe verified messages. Follow the
-returned agent log when command-level detail is needed. `team.status` shows the
-persistent team and worker states. `team.stop` marks the team stopped; each
-worker wrapper observes that state and terminates its own agent CLI.
+returned agent log when command-level detail is needed. For local team runtime
+state, use `yukh team status --team team-...` and
+`yukh team stop --team team-...`. The MCP tools `team.status` and `team.stop`
+remain available to authorized manager sessions; the CLI commands are the
+operator path when no manager server is running.
 
 ## Run bounded automatic wake-up
 

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -11,7 +11,11 @@ import { RuntimeOutput } from "../../packages/team-control/src/runtime-output.js
 import { teamRuntimeEntrypoints } from "../../packages/team-control/src/entrypoints.js";
 import { parsePreflightArguments } from "../../apps/team-preflight/src/arguments.js";
 import { runApprovedPreflight } from "../../apps/team-preflight/src/approved-run.js";
-import { formatApprovedRun, formatEngagePreflight } from "../../apps/team-preflight/src/format.js";
+import {
+  formatApprovedRun,
+  formatEngagePreflight,
+  formatTeamStatus,
+} from "../../apps/team-preflight/src/format.js";
 import { runEngagePreflight } from "../../apps/team-preflight/src/preflight.js";
 import {
   copilotModelCatalogFromDiscoveries,
@@ -74,12 +78,12 @@ test("suite readonly verifier preset allows bounded read-only inspection", () =>
   assert.equal(args.role, "suite-readonly-verifier");
   assert.equal(args.workProfile, "readonly");
   assert.equal(args.preferredRuntime, "codex");
-  assert.equal(args.teamBudget, 300_000);
+  assert.equal(args.teamBudget, 340_000);
   assert.equal(args.managerBudget, 180_000);
   assert.equal(args.format, "text");
-  assert.match(args.goal, /bounded read-only inspection/u);
+  assert.match(args.goal, /one compact read-only probe/u);
   assert.match(args.goal, /Do not modify files/u);
-  assert.match(args.goal, /Keep combined command output below 250 lines/u);
+  assert.doesNotMatch(args.goal, /250 lines/u);
 });
 
 const usage = {
@@ -196,15 +200,54 @@ test("role profile policy maps specialists to allowlisted runtime models skills 
       runtime: "codex",
       model: "default",
       skills: ["testing"],
-      token_budget: 50_000,
+      token_budget: 90_000,
       tool_mode: "none",
-      max_commands: 4,
+      max_commands: 1,
       runtime_timeout_ms: 120_000,
     },
   );
   assert.deepEqual(roleProfilePolicy(options, "security-reviewer", "review").omitted_skills, [
     "security",
   ]);
+});
+
+test("team status formatter exposes stop and token state without raw JSON", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-team-status-text-")));
+  try {
+    const store = new TeamStore(root);
+    const { team, manager } = store.createManaged("Inspect team status", "codex", 2, 1, 160_000, {
+      role: "delivery-manager",
+      profile: {
+        schema: 1,
+        mission: "Inspect local team state",
+        model: "default",
+        skills: ["testing"],
+        instructions: "Read compact team state and stop when requested.",
+      },
+      task: "Manage the local team.",
+      token_budget: 40_000,
+      required_actions: ["team.status"],
+    });
+    store.spawn(team.team_id, {
+      parent_agent_id: manager.agent_id,
+      runtime: "codex",
+      role: "suite-readonly-verifier",
+      task: "Probe the suite.",
+      token_budget: 90_000,
+      model_tool_mode: "none",
+      max_commands: 1,
+      timeout_ms: 120_000,
+    });
+    store.stop(team.team_id);
+    const text = formatTeamStatus(store.status(team.team_id));
+    assert.match(text, /Yukh team status/u);
+    assert.match(text, /State: stopped/u);
+    assert.match(text, /allocated: 130000/u);
+    assert.match(text, /suite-readonly-verifier/u);
+    assert.doesNotMatch(text, /"agents"/u);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 test("engage preflight composes a worker without launching a provider runtime", async () => {


### PR DESCRIPTION
Closes #187.

## Changes
- Reduce the suite readonly verifier from a four-command inspection to one compact read-only probe.
- Set the readonly verifier budget to 90k tokens based on the observed 82,240-token VPS run instead of failing below the fixed Codex input floor.
- Add local operator CLI commands: `yukh team status` and `yukh team stop`.
- Document status/stop usage and the measured readonly verifier token floor.

## Validation
- `npm run -s format:check`
- `npm run -s typecheck`
- `node --import tsx --test test/runtime/team-control.test.ts`
- `npm test`
- `npm run -s build`
- `git diff --check`
- Manual CLI check: `yukh team propose`, `yukh team status`, `yukh team stop` against a temporary workspace.

## Notes
This does not remove fail-closed accounting. Workers that exceed budget still fail with `token_budget_exceeded` and preserve a bounded summary for review.