### PR TITLE
Add suite baseline preflight command

### DIFF
--- a/apps/suite-baseline/src/main.ts
+++ b/apps/suite-baseline/src/main.ts
@@ -1,0 +1,46 @@
+import {
+  formatSuiteBaseline,
+  suiteBaseline,
+} from "../../../packages/suite-baseline/src/baseline.js";
+
+interface Arguments {
+  readonly workspace?: string;
+  readonly format: "json" | "text";
+}
+
+function parseArguments(argv: readonly string[]): Arguments {
+  const values = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!name?.startsWith("--") || value === undefined || value.startsWith("--"))
+      throw new TypeError("invalid suite baseline arguments");
+    values.set(name.slice(2), value);
+  }
+  const format = values.get("format") ?? "text";
+  if (!["json", "text"].includes(format)) throw new TypeError("invalid output format");
+  const workspace = values.get("workspace");
+  return {
+    ...(workspace ? { workspace } : {}),
+    format: format as "json" | "text",
+  };
+}
+
+try {
+  const args = parseArguments(process.argv.slice(2));
+  const output = suiteBaseline(args.workspace);
+  process.stdout.write(
+    `${args.format === "json" ? JSON.stringify(output) : formatSuiteBaseline(output)}\n`,
+  );
+  if (output.state === "error") process.exitCode = 1;
+} catch (error) {
+  process.stdout.write(
+    `${JSON.stringify({
+      schema: 1,
+      status: "error",
+      command: "suite baseline",
+      code: error instanceof Error ? error.message : "suite_baseline_failed",
+    })}\n`,
+  );
+  process.exitCode = 1;
+}

--- a/bin/yukh.mjs
+++ b/bin/yukh.mjs
@@ -3,6 +3,9 @@
 if (process.argv[2] === "conversation" && process.argv[3] === "watch") {
   process.argv.splice(2, 2);
   await import("../dist/apps/conversation-watch/src/main.js");
+} else if (process.argv[2] === "suite" && process.argv[3] === "baseline") {
+  process.argv.splice(2, 2);
+  await import("../dist/apps/suite-baseline/src/main.js");
 } else if (process.argv[2] === "team" && process.argv[3] === "serve") {
   process.argv.splice(2, 2);
   await import("../dist/apps/team-control/src/main.js");
@@ -23,7 +26,7 @@ if (process.argv[2] === "conversation" && process.argv[3] === "watch") {
   await import("../dist/apps/team-preflight/src/stop-main.js");
 } else {
   process.stderr.write(
-    "usage: yukh conversation watch [--full] [--verbose]\n       yukh team serve\n       yukh team propose [--preset suite-qualification|suite-readonly-verifier] [--role backend-reviewer] [--work-profile implementation]\n       yukh team preflight-engage [--preset suite-qualification|suite-readonly-verifier] [--role backend-reviewer] [--work-profile implementation] [--format json|text] [--output preflight.json]\n       yukh team run-approved --preflight file --approved-digest sha-256:... [--format json|text]\n" +
+    "usage: yukh conversation watch [--full] [--verbose]\n       yukh suite baseline [--workspace path] [--format json|text]\n       yukh team serve\n       yukh team propose [--preset suite-qualification|suite-readonly-verifier] [--role backend-reviewer] [--work-profile implementation]\n       yukh team preflight-engage [--preset suite-qualification|suite-readonly-verifier] [--role backend-reviewer] [--work-profile implementation] [--format json|text] [--output preflight.json]\n       yukh team run-approved --preflight file --approved-digest sha-256:... [--format json|text]\n" +
       "       yukh team status --team team-... [--workspace path] [--format json|text]\n       yukh team stop --team team-... [--workspace path] [--format json|text]\n",
   );
   process.exitCode = 2;

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -10,6 +10,18 @@ npm ci --ignore-scripts
 npm run build
 ```
 
+Before starting a team, check the local suite checkout without installing
+dependencies or starting services:
+
+```sh
+yukh suite baseline --workspace /path/to/yukh-workspace
+```
+
+The command reports the tracked Git state, runtime hints and documented
+validation command for `nomed.github.io`, `yukh-mcp`, `yukh-projects` and
+`yukh-coordination`. Detached checkouts are warnings; missing repositories or
+tracked-file drift are errors.
+
 Use absolute paths below. Configure Codex as `agent-a`:
 
 ```toml

--- a/packages/suite-baseline/src/baseline.ts
+++ b/packages/suite-baseline/src/baseline.ts
@@ -1,0 +1,203 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+
+const repositories = ["nomed.github.io", "yukh-mcp", "yukh-projects", "yukh-coordination"] as const;
+
+export type SuiteRepositoryName = (typeof repositories)[number];
+
+export interface SuiteRepositoryBaseline {
+  readonly name: SuiteRepositoryName;
+  readonly path: string;
+  readonly exists: boolean;
+  readonly git_repository: boolean;
+  readonly branch: string;
+  readonly detached: boolean;
+  readonly tracked_clean: boolean;
+  readonly head: string;
+  readonly title: string;
+  readonly package_name?: string;
+  readonly package_manager?: string;
+  readonly node_engine?: string;
+  readonly go_module?: string;
+  readonly go_version?: string;
+  readonly validation_command: string;
+  readonly state: "ok" | "warning" | "error";
+  readonly diagnostics: readonly string[];
+}
+
+export interface SuiteBaseline {
+  readonly schema: 1;
+  readonly command: "suite baseline";
+  readonly workspace: string;
+  readonly state: "ok" | "warning" | "error";
+  readonly repositories: readonly SuiteRepositoryBaseline[];
+}
+
+const validationCommands: Record<SuiteRepositoryName, string> = {
+  "nomed.github.io":
+    "npm ci && npm run -s lint && npm test && npm run -s build:pages && npm run -s e2e && npm run -s test:network-denial && npm audit --audit-level=moderate",
+  "yukh-mcp":
+    "npm ci && npm run -s format:check && npm run -s typecheck && npm test && npm run -s build",
+  "yukh-projects":
+    "npm ci && npm test && npm run -s verify:bundles && npm audit --audit-level=moderate",
+  "yukh-coordination":
+    "go test -race ./... && npm install && npm run -s build:primitives && npm run -s check:primitives-bundle && npm test && npm run -s canonical-vectors",
+};
+
+function git(path: string, args: readonly string[]): string | undefined {
+  try {
+    return execFileSync("git", ["-C", path, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5_000,
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+function firstHeading(path: string): string {
+  const readme = join(path, "README.md");
+  if (!existsSync(readme)) return "";
+  for (const line of readFileSync(readme, "utf8").split(/\r?\n/u)) {
+    if (line.startsWith("#")) return line.replace(/^#+\s*/u, "").trim();
+  }
+  return "";
+}
+
+function packageMetadata(path: string): {
+  readonly package_name?: string;
+  readonly package_manager?: string;
+  readonly node_engine?: string;
+} {
+  const packagePath = join(path, "package.json");
+  if (!existsSync(packagePath)) return {};
+  const value = JSON.parse(readFileSync(packagePath, "utf8")) as {
+    readonly name?: unknown;
+    readonly packageManager?: unknown;
+    readonly engines?: { readonly node?: unknown };
+  };
+  return {
+    ...(typeof value.name === "string" ? { package_name: value.name } : {}),
+    ...(typeof value.packageManager === "string" ? { package_manager: value.packageManager } : {}),
+    ...(typeof value.engines?.node === "string" ? { node_engine: value.engines.node } : {}),
+  };
+}
+
+function goMetadata(path: string): {
+  readonly go_module?: string;
+  readonly go_version?: string;
+} {
+  const goMod = join(path, "go.mod");
+  if (!existsSync(goMod)) return {};
+  let moduleName: string | undefined;
+  let goVersion: string | undefined;
+  for (const line of readFileSync(goMod, "utf8").split(/\r?\n/u)) {
+    if (line.startsWith("module ")) moduleName = line.slice("module ".length).trim();
+    if (line.startsWith("go ")) goVersion = line.slice("go ".length).trim();
+  }
+  return {
+    ...(moduleName ? { go_module: moduleName } : {}),
+    ...(goVersion ? { go_version: goVersion } : {}),
+  };
+}
+
+function repositoryState(name: SuiteRepositoryName, workspace: string): SuiteRepositoryBaseline {
+  const path = join(workspace, name);
+  const exists = existsSync(path);
+  const gitRepository = exists && git(path, ["rev-parse", "--is-inside-work-tree"]) === "true";
+  const diagnostics: string[] = [];
+  if (!exists) diagnostics.push("missing repository directory");
+  if (exists && !gitRepository) diagnostics.push("not a git repository");
+  const branch = gitRepository ? (git(path, ["branch", "--show-current"]) ?? "") : "";
+  const detached = gitRepository && branch === "";
+  if (detached) diagnostics.push("detached HEAD");
+  const status = gitRepository
+    ? (git(path, ["status", "--short", "--untracked-files=no"]) ?? "")
+    : "";
+  const trackedClean = gitRepository && status === "";
+  if (gitRepository && !trackedClean) diagnostics.push("tracked files are not clean");
+  const head = gitRepository ? (git(path, ["rev-parse", "--short=12", "HEAD"]) ?? "") : "";
+  const state = diagnostics.some((diagnostic) =>
+    [
+      "missing repository directory",
+      "not a git repository",
+      "tracked files are not clean",
+    ].includes(diagnostic),
+  )
+    ? "error"
+    : diagnostics.length > 0
+      ? "warning"
+      : "ok";
+  return {
+    name,
+    path,
+    exists,
+    git_repository: gitRepository,
+    branch: branch || "(detached)",
+    detached,
+    tracked_clean: trackedClean,
+    head,
+    title: exists ? firstHeading(path) : "",
+    ...packageMetadata(path),
+    ...goMetadata(path),
+    validation_command: validationCommands[name],
+    state,
+    diagnostics,
+  };
+}
+
+export function detectSuiteWorkspace(input = process.cwd()): string {
+  const current = resolve(input);
+  const candidates = [current, dirname(current)];
+  for (const candidate of candidates) {
+    if (repositories.every((repo) => existsSync(join(candidate, repo)))) return candidate;
+  }
+  if ((repositories as readonly string[]).includes(basename(current))) return dirname(current);
+  return current;
+}
+
+export function suiteBaseline(input?: string): SuiteBaseline {
+  const workspace = detectSuiteWorkspace(input);
+  const results = repositories.map((repo) => repositoryState(repo, workspace));
+  const state = results.some((repo) => repo.state === "error")
+    ? "error"
+    : results.some((repo) => repo.state === "warning")
+      ? "warning"
+      : "ok";
+  return {
+    schema: 1,
+    command: "suite baseline",
+    workspace,
+    state,
+    repositories: results,
+  };
+}
+
+export function formatSuiteBaseline(output: SuiteBaseline): string {
+  const lines = [
+    "Yukh suite baseline",
+    `Workspace: ${output.workspace}`,
+    `State: ${output.state}`,
+    "",
+  ];
+  for (const repo of output.repositories) {
+    lines.push(
+      `${repo.name}: ${repo.state}`,
+      `  branch=${repo.branch} head=${repo.head || "unknown"} clean=${repo.tracked_clean ? "yes" : "no"}`,
+    );
+    const runtime = [
+      repo.package_name ? `package=${repo.package_name}` : undefined,
+      repo.package_manager ? `manager=${repo.package_manager}` : "manager=unspecified",
+      repo.node_engine ? `node=${repo.node_engine}` : undefined,
+      repo.go_module
+        ? `go=${repo.go_module}${repo.go_version ? `@${repo.go_version}` : ""}`
+        : undefined,
+    ].filter(Boolean);
+    if (runtime.length > 0) lines.push(`  ${runtime.join(" ")}`);
+    if (repo.diagnostics.length > 0) lines.push(`  diagnostics=${repo.diagnostics.join(", ")}`);
+    lines.push(`  validate=${repo.validation_command}`);
+  }
+  return lines.join("\n");
+}

--- a/test/runtime/suite-baseline.test.ts
+++ b/test/runtime/suite-baseline.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  detectSuiteWorkspace,
+  formatSuiteBaseline,
+  suiteBaseline,
+} from "../../packages/suite-baseline/src/baseline.js";
+
+const repositories = ["nomed.github.io", "yukh-mcp", "yukh-projects", "yukh-coordination"] as const;
+
+function git(path: string, args: readonly string[]): void {
+  execFileSync("git", ["-C", path, ...args], {
+    stdio: "ignore",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Yukh Test",
+      GIT_AUTHOR_EMAIL: "yukh-test@example.invalid",
+      GIT_COMMITTER_NAME: "Yukh Test",
+      GIT_COMMITTER_EMAIL: "yukh-test@example.invalid",
+    },
+  });
+}
+
+async function createRepository(root: string, name: (typeof repositories)[number]): Promise<void> {
+  const path = join(root, name);
+  await mkdir(path, { recursive: true });
+  git(path, ["init", "-b", "main"]);
+  await writeFile(join(path, "README.md"), `# ${name}\n`, "utf8");
+  if (name === "yukh-coordination") {
+    await writeFile(
+      join(path, "go.mod"),
+      "module github.com/nomed/yukh-coordination\n\ngo 1.26\n",
+      "utf8",
+    );
+    await writeFile(
+      join(path, "package.json"),
+      JSON.stringify({ name: "@yukh/coordination-conformance-js", engines: { node: ">=24" } }),
+      "utf8",
+    );
+  } else {
+    await writeFile(
+      join(path, "package.json"),
+      JSON.stringify({
+        name: name === "yukh-mcp" ? "yukh-mcp" : `@nomed/${name}`,
+        engines: { node: ">=22" },
+      }),
+      "utf8",
+    );
+  }
+  git(path, ["add", "."]);
+  git(path, ["commit", "-m", "initial"]);
+}
+
+test("suite baseline reports all repositories without mutating them", async () => {
+  const root = await mkdtemp(join(tmpdir(), "yukh-suite-baseline-"));
+  try {
+    for (const repo of repositories) await createRepository(root, repo);
+    const output = suiteBaseline(root);
+    assert.equal(output.state, "ok");
+    assert.equal(output.repositories.length, 4);
+    assert.deepEqual(
+      output.repositories.map((repo) => repo.name),
+      [...repositories],
+    );
+    assert.equal(
+      output.repositories.every((repo) => repo.tracked_clean),
+      true,
+    );
+    assert.equal(
+      output.repositories.every((repo) => repo.branch === "main"),
+      true,
+    );
+    assert.match(output.repositories[0]!.validation_command, /npm ci/u);
+    assert.match(output.repositories[3]!.validation_command, /go test -race/u);
+    const text = formatSuiteBaseline(output);
+    assert.match(text, /Yukh suite baseline/u);
+    assert.match(text, /nomed.github.io: ok/u);
+    assert.match(text, /yukh-coordination: ok/u);
+    assert.doesNotMatch(text, /"repositories"/u);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("suite baseline warns for detached heads and detects the parent workspace", async () => {
+  const root = await mkdtemp(join(tmpdir(), "yukh-suite-baseline-detached-"));
+  try {
+    for (const repo of repositories) await createRepository(root, repo);
+    git(join(root, "yukh-mcp"), ["switch", "--detach", "HEAD"]);
+    assert.equal(detectSuiteWorkspace(join(root, "yukh-mcp")), root);
+    const output = suiteBaseline(join(root, "yukh-mcp"));
+    const mcp = output.repositories.find((repo) => repo.name === "yukh-mcp");
+    assert.equal(output.state, "warning");
+    assert.equal(mcp?.detached, true);
+    assert.equal(mcp?.state, "warning");
+    assert.deepEqual(mcp?.diagnostics, ["detached HEAD"]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("suite baseline fails on tracked-file drift", async () => {
+  const root = await mkdtemp(join(tmpdir(), "yukh-suite-baseline-dirty-"));
+  try {
+    for (const repo of repositories) await createRepository(root, repo);
+    await writeFile(join(root, "yukh-projects", "README.md"), "# changed\n", "utf8");
+    const output = suiteBaseline(root);
+    const projects = output.repositories.find((repo) => repo.name === "yukh-projects");
+    assert.equal(output.state, "error");
+    assert.equal(projects?.state, "error");
+    assert.deepEqual(projects?.diagnostics, ["tracked files are not clean"]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #189.

## Changes
- Add `yukh suite baseline --workspace ... --format json|text`.
- Inspect the four local suite repositories without dependency installation, service startup, network calls or provider runtime.
- Report tracked Git cleanliness, branch/detached state, latest commit, runtime hints and documented validation command per repo.
- Add tests for clean baseline, detached warnings and tracked-file drift errors.
- Document the command in the local Codex/Copilot guide.

## Validation
- `npm run -s format:check`
- `npm run -s typecheck`
- `node --import tsx --test test/runtime/suite-baseline.test.ts`
- `npm test`
- `npm run -s build`
- `git diff --check`
- Manual CLI run: `yukh suite baseline --workspace /home/codex/repos/nomed/yukh-workspace --format text`.

## Observed local result
The current VPS workspace reports `warning` only because `yukh-mcp` and `yukh-coordination` are detached HEADs; all tracked trees are clean.