### PR TITLE
Exercise agentic development cycle

### DIFF
--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -178,7 +178,7 @@ function budgetFor(workProfile: TeamWorkProfile): {
   if (workProfile === "synthesis")
     return { token_budget: 16_000, tool_mode: "none", max_commands: 0, runtime_timeout_ms: 60_000 };
   return {
-    token_budget: 50_000,
+    token_budget: 120_000,
     tool_mode: "team",
     max_commands: 8,
     runtime_timeout_ms: 300_000,

--- a/apps/team-preflight/src/arguments.ts
+++ b/apps/team-preflight/src/arguments.ts
@@ -98,7 +98,7 @@ export function parsePreflightArguments(
     role: values.get("role") ?? preset?.role ?? "backend-reviewer",
     workProfile: workProfile as TeamWorkProfile,
     ...(preferredRuntime ? { preferredRuntime: preferredRuntime as AgentRuntime } : {}),
-    teamBudget: integer(values.get("team-budget"), preset?.teamBudget ?? 260_000),
+    teamBudget: integer(values.get("team-budget"), preset?.teamBudget ?? 340_000),
     managerBudget: integer(values.get("manager-budget"), preset?.managerBudget ?? 180_000),
     codexModels: list(values.get("codex-models") ?? process.env.YUKH_CODEX_MODELS, ["default"]),
     copilotModels: list(values.get("copilot-models") ?? process.env.YUKH_COPILOT_MODELS, [

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -22,6 +22,11 @@ validation command for `nomed.github.io`, `yukh-mcp`, `yukh-projects` and
 `yukh-coordination`. Detached checkouts are warnings; missing repositories or
 tracked-file drift are errors.
 
+Operator note: a warning means inspect the checkout before development; an
+error means stop and fix the checkout before continuing.
+
+This command is the gate before starting a Yukh-managed implementation worker.
+
 Use absolute paths below. Configure Codex as `agent-a`:
 
 ```toml
@@ -144,6 +149,9 @@ including 9,984 cached, and 647 output. The 20,000-token allocation provides a
 bounded margin; it is not a universal estimate. A one-command suite readonly
 probe on the VPS measured 82,240 total tokens, mostly fixed Codex input context,
 so the official readonly verifier allocation is 90,000 tokens and one command.
+A tiny documentation implementation worker measured 90,893 total tokens, so the
+default implementation allocation is 120,000 tokens and the generic team
+preflight default is 340,000 tokens.
 A zero-command worker using two small context files measured 15,652 total tokens
 against an 8,000-token allocation and failed closed after preserving its summary
 for review. Use at least an 18,000-token worker budget for similar

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -179,7 +179,7 @@ test("role profile policy maps specialists to allowlisted runtime models skills 
       runtime: "copilot",
       model: "default",
       skills: ["frontend"],
-      token_budget: 50_000,
+      token_budget: 120_000,
       tool_mode: "team",
       max_commands: 8,
       runtime_timeout_ms: 300_000,
@@ -259,7 +259,7 @@ test("engage preflight composes a worker without launching a provider runtime", 
       role: "frontend-developer",
       workProfile: "implementation",
       preferredRuntime: "copilot",
-      teamBudget: 260_000,
+      teamBudget: 340_000,
       managerBudget: 180_000,
       codexModels: ["default"],
       copilotModels: ["default", "claude-sonnet-5"],
@@ -276,7 +276,7 @@ test("engage preflight composes a worker without launching a provider runtime", 
     assert.equal(output.planned_worker.task, "Preflight frontend worker");
     assert.equal(output.planned_worker.profile?.mission, "Preflight frontend worker");
     assert.equal(output.planned_worker.parent_agent_id, output.manager.agent_id);
-    assert.equal(output.budget.allocated, 230_000);
+    assert.equal(output.budget.allocated, 300_000);
     assert.equal(output.budget.observed, 0);
     assert.equal(output.budget.pending_agents, 2);
   } finally {


### PR DESCRIPTION
Closes #191.

## Summary
- exercised a real Yukh-managed implementation worker against this repo
- preserved the worker-authored operator notes in the Coordination preview guide
- raised the default implementation worker budget from 50k to 120k after the first measured run failed closed at 90,893 tokens
- raised the generic team preflight default from 260k to 340k to keep the calibrated implementation budget viable

## Measured agentic cycle
- first worker: failed closed at 90,893 / 50,000 tokens, preserving reviewable doc output
- second worker: succeeded at 97,411 / 120,000 tokens and verified its doc change

## Validation
- npm run -s format:check
- npm run -s typecheck
- node --import tsx --test test/runtime/team-control.test.ts
- npm run -s build
- git diff --check
- npm test