### PR TITLE
Reduce model-facing tools for simple workers

### DIFF
--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -179,7 +179,7 @@ function budgetFor(workProfile: TeamWorkProfile): {
     return { token_budget: 16_000, tool_mode: "none", max_commands: 0, runtime_timeout_ms: 60_000 };
   return {
     token_budget: 120_000,
-    tool_mode: "team",
+    tool_mode: "none",
     max_commands: 8,
     runtime_timeout_ms: 300_000,
   };

--- a/apps/team-worker/src/main.ts
+++ b/apps/team-worker/src/main.ts
@@ -29,11 +29,13 @@ const profile = agent.profile;
 const contextPack = store.contextPack(teamID, agentID);
 const modelToolMode = agent.model_tool_mode ?? "default";
 const requiredActions = agent.required_actions.join(", ") || "none";
+const requiresDelegationAction = agent.required_actions.some(
+  (action) => action === "agent.engage" || action === "agent.await",
+);
 const modelUsesCoordination =
   modelToolMode === "coordination" ||
   modelToolMode === "team" ||
-  (modelToolMode === "default" &&
-    (agent.kind === "worker" || agent.required_actions.some((action) => action !== "team.status")));
+  (modelToolMode === "default" && requiresDelegationAction);
 const modelTeamTools = [
   ...new Set(
     modelToolMode === "none" || modelToolMode === "coordination"
@@ -44,9 +46,9 @@ const modelTeamTools = [
           : ["team.status", "agent.status"]
         : agent.kind === "manager"
           ? agent.required_actions
-          : agent.can_spawn
+          : agent.can_spawn && requiresDelegationAction
             ? ["team.status", "agent.status", "agent.engage", "agent.await"]
-            : ["team.status", "agent.status"],
+            : agent.required_actions,
   ),
 ];
 const modelUsesTeamControl = modelTeamTools.length > 0;
@@ -57,7 +59,7 @@ const teamControlInstruction = modelUsesTeamControl
   ? `Required receipt-backed actions before success: ${requiredActions}. A textual claim is not evidence; invoke each required yukh-team-control tool successfully.`
   : "";
 const delegationInstruction =
-  agent.can_spawn && modelUsesTeamControl
+  agent.can_spawn && modelUsesTeamControl && modelTeamTools.includes("agent.engage")
     ? agent.required_actions.includes("agent.await")
       ? "When engaging a child, use the returned coordination_participant exactly and never add another agent: prefix. Wait for each child with agent.await and inspect its completion before synthesizing. You may create a bounded child only when explicitly delegated."
       : "When engaging a child, use the returned coordination_participant exactly and never add another agent: prefix. Do not wait for the child unless the task explicitly requires agent.await. You may create a bounded child only when explicitly delegated."

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -152,6 +152,10 @@ so the official readonly verifier allocation is 90,000 tokens and one command.
 A tiny documentation implementation worker measured 90,893 total tokens, so the
 default implementation allocation is 120,000 tokens and the generic team
 preflight default is 340,000 tokens.
+After removing unnecessary model-facing Yukh MCP tools from simple
+non-delegating implementation workers, a minimal no-edit Codex probe measured
+14,003 total tokens. Delegating workers still receive the explicit Yukh tools
+they need for receipt-backed actions.
 A zero-command worker using two small context files measured 15,652 total tokens
 against an 8,000-token allocation and failed closed after preserving its summary
 for review. Use at least an 18,000-token worker budget for similar

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -180,7 +180,7 @@ test("role profile policy maps specialists to allowlisted runtime models skills 
       model: "default",
       skills: ["frontend"],
       token_budget: 120_000,
-      tool_mode: "team",
+      tool_mode: "none",
       max_commands: 8,
       runtime_timeout_ms: 300_000,
     },
@@ -276,6 +276,7 @@ test("engage preflight composes a worker without launching a provider runtime", 
     assert.equal(output.planned_worker.task, "Preflight frontend worker");
     assert.equal(output.planned_worker.profile?.mission, "Preflight frontend worker");
     assert.equal(output.planned_worker.parent_agent_id, output.manager.agent_id);
+    assert.equal(output.planned_worker.model_tool_mode, "none");
     assert.equal(output.budget.allocated, 300_000);
     assert.equal(output.budget.observed, 0);
     assert.equal(output.budget.pending_agents, 2);
@@ -1574,6 +1575,68 @@ printf '{"schema":1,"status":"ok","command":"test"}\\n'
       "Ready after Coordination recovered",
     );
     assert.equal((await readFile(marker)).length, 0);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("simple non-delegating worker receives no model-facing MCP configuration", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-simple-worker-tools-")));
+  try {
+    const executable = join(root, "agent-cli");
+    const argumentsFile = join(root, "agent-arguments");
+    const launcher = join(root, "launcher");
+    const support = join(root, "support.mjs");
+    await writeFile(
+      executable,
+      `#!/bin/sh
+printf '%s\n' "$@" >${argumentsFile}
+printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"simple worker complete"}}'
+printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":20,"reasoning_output_tokens":5}}'
+`,
+      { mode: 0o700 },
+    );
+    await writeFile(
+      launcher,
+      '#!/bin/sh\ncat >/dev/null\nprintf \'{"schema":1,"status":"ok","command":"test"}\\n\'\n',
+      { mode: 0o700 },
+    );
+    await writeFile(support, "", { mode: 0o600 });
+    const store = new TeamStore(root);
+    const team = store.create("Run simple worker", "codex");
+    const agent = store.spawn(team.team_id, {
+      runtime: "codex",
+      role: "documentation-worker",
+      task: "Make one bounded documentation edit",
+      token_budget: 120_000,
+    });
+    const child = spawn(
+      process.execPath,
+      ["--import", tsxLoader, workerMain, team.team_id, agent.agent_id],
+      {
+        cwd: root,
+        stdio: "ignore",
+        env: {
+          HOME: process.env.HOME ?? "",
+          PATH: process.env.PATH ?? "/usr/bin:/bin",
+          YUKH_TEAM_WORKSPACE: root,
+          YUKH_COORDINATION_LAUNCHER: launcher,
+          YUKH_COORDINATION_MCP_MAIN: support,
+          YUKH_TEAM_CONTROL_MCP_MAIN: support,
+          YUKH_CODEX_EXECUTABLE: executable,
+          YUKH_COPILOT_EXECUTABLE: executable,
+        },
+      },
+    );
+    assert.equal(await new Promise<number | null>((resolve) => child.once("close", resolve)), 0);
+    const runtimeArguments = await readFile(argumentsFile, "utf8");
+    assert.match(runtimeArguments, /--ignore-user-config/u);
+    assert.doesNotMatch(runtimeArguments, /mcp_servers\.yukh-team-control/u);
+    assert.doesNotMatch(runtimeArguments, /mcp_servers\.yukh-coordination/u);
+    const completed = store.agent(team.team_id, agent.agent_id);
+    assert.equal(completed.state, "completed");
+    assert.equal(completed.completion?.outcome, "succeeded");
+    assert.equal(completed.usage?.total_tokens, 120);
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #193.

## Summary
- default implementation workers now use `tool_mode: none` so simple workers do not receive Yukh MCP tool schemas they do not need
- worker prompt assembly now exposes Coordination/team-control only for explicit tool modes or delegation actions
- added a runtime test proving a non-delegating worker receives no model-facing Yukh MCP config
- documented the measured no-edit Codex probe after the reduction

## Real probe
- Coordination preview started on the VPS using Docker/NATS via `sg docker`
- minimal non-delegating implementation worker completed with `model_tool_mode: none`
- measured usage: 14,003 total tokens, 13,994 input, 9 output, within 120,000 budget
- stopped probe teams after measurement

## Validation
- npm run -s format:check
- npm run -s typecheck
- node --import tsx --test test/runtime/team-control.test.ts
- npm run -s build
- git diff --check
- npm test