### PR TITLE
Calibrate simple implementation worker budget

### DIFF
--- a/apps/team-control/src/server.ts
+++ b/apps/team-control/src/server.ts
@@ -178,7 +178,7 @@ function budgetFor(workProfile: TeamWorkProfile): {
   if (workProfile === "synthesis")
     return { token_budget: 16_000, tool_mode: "none", max_commands: 0, runtime_timeout_ms: 60_000 };
   return {
-    token_budget: 120_000,
+    token_budget: 80_000,
     tool_mode: "none",
     max_commands: 8,
     runtime_timeout_ms: 300_000,

--- a/apps/team-preflight/src/arguments.ts
+++ b/apps/team-preflight/src/arguments.ts
@@ -98,7 +98,7 @@ export function parsePreflightArguments(
     role: values.get("role") ?? preset?.role ?? "backend-reviewer",
     workProfile: workProfile as TeamWorkProfile,
     ...(preferredRuntime ? { preferredRuntime: preferredRuntime as AgentRuntime } : {}),
-    teamBudget: integer(values.get("team-budget"), preset?.teamBudget ?? 340_000),
+    teamBudget: integer(values.get("team-budget"), preset?.teamBudget ?? 260_000),
     managerBudget: integer(values.get("manager-budget"), preset?.managerBudget ?? 180_000),
     codexModels: list(values.get("codex-models") ?? process.env.YUKH_CODEX_MODELS, ["default"]),
     copilotModels: list(values.get("copilot-models") ?? process.env.YUKH_COPILOT_MODELS, [

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -149,13 +149,15 @@ including 9,984 cached, and 647 output. The 20,000-token allocation provides a
 bounded margin; it is not a universal estimate. A one-command suite readonly
 probe on the VPS measured 82,240 total tokens, mostly fixed Codex input context,
 so the official readonly verifier allocation is 90,000 tokens and one command.
-A tiny documentation implementation worker measured 90,893 total tokens, so the
-default implementation allocation is 120,000 tokens and the generic team
-preflight default is 340,000 tokens.
+A tiny documentation implementation worker previously measured 90,893 total
+tokens when it received unnecessary model-facing Yukh MCP tools.
 After removing unnecessary model-facing Yukh MCP tools from simple
 non-delegating implementation workers, a minimal no-edit Codex probe measured
-14,003 total tokens. Delegating workers still receive the explicit Yukh tools
-they need for receipt-backed actions.
+14,003 total tokens and a real one-file documentation edit measured 60,965 total
+tokens. The default implementation allocation is therefore 80,000 tokens and
+the generic team preflight default is 260,000 tokens. Delegating workers still
+receive the explicit Yukh tools they need for receipt-backed actions.
+Keep simple workers non-delegating unless they need child agents or receipt-backed actions.
 A zero-command worker using two small context files measured 15,652 total tokens
 against an 8,000-token allocation and failed closed after preserving its summary
 for review. Use at least an 18,000-token worker budget for similar

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -179,7 +179,7 @@ test("role profile policy maps specialists to allowlisted runtime models skills 
       runtime: "copilot",
       model: "default",
       skills: ["frontend"],
-      token_budget: 120_000,
+      token_budget: 80_000,
       tool_mode: "none",
       max_commands: 8,
       runtime_timeout_ms: 300_000,
@@ -259,7 +259,7 @@ test("engage preflight composes a worker without launching a provider runtime", 
       role: "frontend-developer",
       workProfile: "implementation",
       preferredRuntime: "copilot",
-      teamBudget: 340_000,
+      teamBudget: 260_000,
       managerBudget: 180_000,
       codexModels: ["default"],
       copilotModels: ["default", "claude-sonnet-5"],
@@ -277,7 +277,7 @@ test("engage preflight composes a worker without launching a provider runtime", 
     assert.equal(output.planned_worker.profile?.mission, "Preflight frontend worker");
     assert.equal(output.planned_worker.parent_agent_id, output.manager.agent_id);
     assert.equal(output.planned_worker.model_tool_mode, "none");
-    assert.equal(output.budget.allocated, 300_000);
+    assert.equal(output.budget.allocated, 260_000);
     assert.equal(output.budget.observed, 0);
     assert.equal(output.budget.pending_agents, 2);
   } finally {
@@ -1608,7 +1608,7 @@ printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_inpu
       runtime: "codex",
       role: "documentation-worker",
       task: "Make one bounded documentation edit",
-      token_budget: 120_000,
+      token_budget: 80_000,
     });
     const child = spawn(
       process.execPath,


### PR DESCRIPTION
Closes #195.

## Summary
- measured a real Yukh-managed simple implementation worker that edited one tracked documentation file
- lowered the default implementation worker budget from 120k to 80k after the real edit completed at 60,965 tokens
- lowered the generic team preflight default from 340k to 260k, matching the 180k manager + 80k worker allocation
- kept delegating/receipt-backed behavior separate from simple non-delegating workers

## Real worker evidence
- worker: documentation-developer
- model tool mode: none
- task: one-file documentation edit
- outcome: succeeded
- validation inside worker: git diff --check passed
- usage: 60,965 total tokens, within 120,000 prior budget
- team stopped after measurement

## Validation
- npm run -s format:check
- npm run -s typecheck
- node --import tsx --test test/runtime/team-control.test.ts
- npm run -s build
- git diff --check
- npm test