### PR TITLE
Record compact Yukh team cycle evidence

### DIFF
--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -158,6 +158,10 @@ tokens. The default implementation allocation is therefore 80,000 tokens and
 the generic team preflight default is 260,000 tokens. Delegating workers still
 receive the explicit Yukh tools they need for receipt-backed actions.
 Keep simple workers non-delegating unless they need child agents or receipt-backed actions.
+Compact implementation probes should use one small tracked file and one
+explicit validation command. A compact preflight-to-worker documentation edit
+measured 59,006 total worker tokens against the 80,000-token implementation
+allocation.
 A zero-command worker using two small context files measured 15,652 total tokens
 against an 8,000-token allocation and failed closed after preserving its summary
 for review. Use at least an 18,000-token worker budget for similar


### PR DESCRIPTION
Closes #197.

## Summary
- exercised a compact Yukh preflight-to-worker cycle on a one-file documentation edit
- recorded the measured token cost in the operator guide
- kept the task simple and non-delegating with one explicit validation command

## Real cycle evidence
- preflight team budget: 260,000
- manager allocation: 180,000
- worker allocation: 80,000
- worker model tool mode: none
- worker outcome: succeeded
- worker validation: git diff --check passed
- worker usage: 59,006 total tokens, within the 80,000 implementation budget
- probe/preflight teams stopped after measurement

## Validation
- npm run -s format:check
- npm run -s typecheck
- node --import tsx --test test/runtime/team-control.test.ts
- npm run -s build
- git diff --check
- npm test