### PR TITLE
Expose deterministic plan execution in CLI

### DIFF
--- a/apps/team-preflight/src/format.ts
+++ b/apps/team-preflight/src/format.ts
@@ -1,8 +1,10 @@
 import type { runApprovedPreflight } from "./approved-run.js";
+import type { runApprovedPlan } from "./plan-execute.js";
 import type { EngagePreflightOutput } from "./preflight.js";
 import type { TeamStore } from "../../../packages/team-control/src/store.js";
 
 type ApprovedRunOutput = Awaited<ReturnType<typeof runApprovedPreflight>>;
+type ApprovedPlanRunOutput = Awaited<ReturnType<typeof runApprovedPlan>>;
 type TeamStatus = ReturnType<TeamStore["status"]>;
 
 function list(values: readonly string[]): string {
@@ -71,6 +73,26 @@ export function formatApprovedRun(output: ApprovedRunOutput): string {
     `- unaccounted agents: ${output.tokens.unaccounted_agents}`,
     "",
     `Terminal worker state: ${output.terminal_agent?.state ?? "not waited"}`,
+  ].join("\n");
+}
+
+export function formatApprovedPlanRun(output: ApprovedPlanRunOutput): string {
+  return [
+    "Yukh approved plan run",
+    `Status: ${output.status}`,
+    `Plan: ${output.plan.plan_id}`,
+    `Plan state: ${output.plan.state}`,
+    `Provider launched: ${output.provider_runtime_launched ? "yes" : "no"}`,
+    `Workers: ${output.plan.worker_agent_ids.length}`,
+    `Synthesis: ${output.plan.synthesis_agent_id ?? "none"}`,
+    "",
+    "Tokens",
+    `- observed: ${output.team.tokens.observed}`,
+    `- allocated: ${output.team.tokens.allocated}`,
+    `- remaining: ${output.team.tokens.remaining}`,
+    `- pending agents: ${output.team.tokens.pending_agents}`,
+    `- unaccounted agents: ${output.team.tokens.unaccounted_agents}`,
+    `- exceeded agents: ${output.team.tokens.exceeded_agents}`,
   ].join("\n");
 }
 

--- a/apps/team-preflight/src/plan-execute-main.ts
+++ b/apps/team-preflight/src/plan-execute-main.ts
@@ -1,0 +1,90 @@
+import { realpathSync } from "node:fs";
+import { runApprovedPlan } from "./plan-execute.js";
+import { formatApprovedPlanRun } from "./format.js";
+
+interface Arguments {
+  readonly workspace: string;
+  readonly teamId: string;
+  readonly planId: string;
+  readonly approvedDigest: string;
+  readonly launcher: string;
+  readonly codex: string;
+  readonly copilot: string;
+  readonly waitMs: number;
+  readonly codexModels?: string;
+  readonly copilotModels?: string;
+  readonly codexSkills?: string;
+  readonly copilotSkills?: string;
+  readonly format: "json" | "text";
+}
+
+function required(value: string | undefined, name: string): string {
+  if (!value) throw new TypeError(`missing ${name}`);
+  return value;
+}
+
+function integer(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) throw new TypeError("invalid integer argument");
+  return parsed;
+}
+
+function parseArguments(argv: readonly string[]): Arguments {
+  const values = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!name?.startsWith("--") || value === undefined || value.startsWith("--"))
+      throw new TypeError("invalid team plan run arguments");
+    values.set(name.slice(2), value);
+  }
+  const format = values.get("format") ?? "json";
+  if (!["json", "text"].includes(format)) throw new TypeError("invalid output format");
+  const codexModels = values.get("codex-models") ?? process.env.YUKH_CODEX_MODELS;
+  const copilotModels = values.get("copilot-models") ?? process.env.YUKH_COPILOT_MODELS;
+  const codexSkills = values.get("codex-skills") ?? process.env.YUKH_CODEX_SKILLS;
+  const copilotSkills = values.get("copilot-skills") ?? process.env.YUKH_COPILOT_SKILLS;
+  return {
+    workspace: realpathSync(values.get("workspace") ?? process.cwd()),
+    teamId: required(values.get("team"), "--team"),
+    planId: required(values.get("plan"), "--plan"),
+    approvedDigest: required(values.get("approved-digest"), "--approved-digest"),
+    launcher: required(
+      values.get("launcher") ?? process.env.YUKH_COORDINATION_LAUNCHER,
+      "--launcher or YUKH_COORDINATION_LAUNCHER",
+    ),
+    codex: required(
+      values.get("codex") ?? process.env.YUKH_CODEX_EXECUTABLE,
+      "--codex or YUKH_CODEX_EXECUTABLE",
+    ),
+    copilot: required(
+      values.get("copilot") ?? process.env.YUKH_COPILOT_EXECUTABLE,
+      "--copilot or YUKH_COPILOT_EXECUTABLE",
+    ),
+    waitMs: integer(values.get("wait-ms"), 300_000),
+    ...(codexModels ? { codexModels } : {}),
+    ...(copilotModels ? { copilotModels } : {}),
+    ...(codexSkills ? { codexSkills } : {}),
+    ...(copilotSkills ? { copilotSkills } : {}),
+    format: format as "json" | "text",
+  };
+}
+
+try {
+  const args = parseArguments(process.argv.slice(2));
+  const output = await runApprovedPlan(args);
+  process.stdout.write(
+    `${args.format === "json" ? JSON.stringify(output) : formatApprovedPlanRun(output)}\n`,
+  );
+} catch (error) {
+  process.stdout.write(
+    `${JSON.stringify({
+      schema: 1,
+      status: "error",
+      command: "team run-plan-approved",
+      code: error instanceof Error ? error.message : "team_run_plan_approved_failed",
+    })}\n`,
+  );
+  process.exitCode = 1;
+}

--- a/apps/team-preflight/src/plan-execute.ts
+++ b/apps/team-preflight/src/plan-execute.ts
@@ -1,0 +1,113 @@
+import { realpathSync } from "node:fs";
+import {
+  costSafeDeterministicPlan,
+  dynamicExecutionEnabled,
+  executePlan,
+} from "../../team-control/src/server.js";
+import type { TeamControlOptions } from "../../team-control/src/server.js";
+import { teamRuntimeEntrypoints } from "../../../packages/team-control/src/entrypoints.js";
+import { TeamStore } from "../../../packages/team-control/src/store.js";
+import { TeamSupervisor } from "../../../packages/team-control/src/supervisor.js";
+
+export interface ApprovedPlanRunArguments {
+  readonly workspace: string;
+  readonly teamId: string;
+  readonly planId: string;
+  readonly approvedDigest: string;
+  readonly launcher: string;
+  readonly codex: string;
+  readonly copilot: string;
+  readonly waitMs: number;
+  readonly codexModels?: string;
+  readonly copilotModels?: string;
+  readonly codexSkills?: string;
+  readonly copilotSkills?: string;
+}
+
+function list(value: string | undefined, fallback: readonly string[]): readonly string[] {
+  return value ? value.split(",").filter(Boolean) : fallback;
+}
+
+function allowlist(value: string | undefined, fallback: readonly string[]): ReadonlySet<string> {
+  return new Set(list(value, fallback));
+}
+
+function profileEnvironment(args: ApprovedPlanRunArguments): Readonly<Record<string, string>> {
+  const env: Record<string, string> = { YUKH_ENABLE_UNSAFE_DYNAMIC_WORKERS: "1" };
+  if (args.codexModels) env.YUKH_CODEX_MODELS = args.codexModels;
+  if (args.copilotModels) env.YUKH_COPILOT_MODELS = args.copilotModels;
+  if (args.codexSkills) env.YUKH_CODEX_SKILLS = args.codexSkills;
+  if (args.copilotSkills) env.YUKH_COPILOT_SKILLS = args.copilotSkills;
+  return env;
+}
+
+export async function runApprovedPlan(args: ApprovedPlanRunArguments) {
+  return runApprovedPlanWithDependencies(args);
+}
+
+export async function runApprovedPlanWithDependencies(
+  args: ApprovedPlanRunArguments,
+  dependencies?: {
+    readonly store: TeamStore;
+    readonly supervisor: Pick<TeamSupervisor, "launch">;
+    readonly options: TeamControlOptions;
+  },
+) {
+  const workspace = realpathSync(args.workspace);
+  const store = dependencies?.store ?? new TeamStore(workspace);
+  const supervisor =
+    dependencies?.supervisor ??
+    (() => {
+      const entrypoints = teamRuntimeEntrypoints();
+      return new TeamSupervisor({
+        node: process.execPath,
+        worker: entrypoints.worker,
+        coordinationMcp: entrypoints.coordinationMcp,
+        teamControlMcp: entrypoints.teamControlMcp,
+        launcher: realpathSync(args.launcher),
+        codex: realpathSync(args.codex),
+        copilot: realpathSync(args.copilot),
+        workspace,
+        profileEnvironment: profileEnvironment(args),
+      });
+    })();
+  const options =
+    dependencies?.options ??
+    ({
+      dynamicExecution: process.env.YUKH_ENABLE_UNSAFE_DYNAMIC_WORKERS === "1",
+      models: {
+        codex: allowlist(args.codexModels, ["default"]),
+        copilot: allowlist(args.copilotModels, ["default"]),
+      },
+      skills: {
+        codex: allowlist(args.codexSkills, [
+          "api-design",
+          "testing",
+          "product",
+          "documentation",
+          "security",
+        ]),
+        copilot: allowlist(args.copilotSkills, ["frontend", "testing"]),
+      },
+    } satisfies TeamControlOptions);
+  const plan = store.plan(args.teamId, args.planId);
+  if (!dynamicExecutionEnabled(options) && !costSafeDeterministicPlan(plan))
+    throw new Error("dynamic_worker_cost_boundary_unavailable");
+  const completed = await executePlan(
+    store,
+    supervisor,
+    options,
+    args.teamId,
+    args.planId,
+    args.approvedDigest,
+    args.waitMs,
+  );
+  return {
+    schema: 1 as const,
+    status: "ok" as const,
+    command: "team run-plan-approved" as const,
+    provider_runtime_launched: true,
+    plan: completed,
+    team: store.status(args.teamId),
+  };
+}

--- a/bin/yukh.mjs
+++ b/bin/yukh.mjs
@@ -18,6 +18,9 @@ if (process.argv[2] === "conversation" && process.argv[3] === "watch") {
 } else if (process.argv[2] === "team" && process.argv[3] === "run-approved") {
   process.argv.splice(2, 2);
   await import("../dist/apps/team-preflight/src/run-approved-main.js");
+} else if (process.argv[2] === "team" && process.argv[3] === "run-plan-approved") {
+  process.argv.splice(2, 2);
+  await import("../dist/apps/team-preflight/src/plan-execute-main.js");
 } else if (process.argv[2] === "team" && process.argv[3] === "status") {
   process.argv.splice(2, 2);
   await import("../dist/apps/team-preflight/src/status-main.js");
@@ -27,6 +30,7 @@ if (process.argv[2] === "conversation" && process.argv[3] === "watch") {
 } else {
   process.stderr.write(
     "usage: yukh conversation watch [--full] [--verbose]\n       yukh suite baseline [--workspace path] [--format json|text]\n       yukh team serve\n       yukh team propose [--preset suite-qualification|suite-readonly-verifier] [--role backend-reviewer] [--work-profile implementation]\n       yukh team preflight-engage [--preset suite-qualification|suite-readonly-verifier] [--role backend-reviewer] [--work-profile implementation] [--format json|text] [--output preflight.json]\n       yukh team run-approved --preflight file --approved-digest sha-256:... [--format json|text]\n" +
+      "       yukh team run-plan-approved --team team-... --plan plan-... --approved-digest sha-256:... [--format json|text]\n" +
       "       yukh team status --team team-... [--workspace path] [--format json|text]\n       yukh team stop --team team-... [--workspace path] [--format json|text]\n",
   );
   process.exitCode = 2;

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -114,6 +114,10 @@ budget, accounting source and completion outcome. Codex currently supplies
 trustworthy token counts. Copilot exposes credits and duration but not tokens, so a
 token-strict Copilot worker terminates with `token_accounting_unavailable`
 rather than inventing a conversion.
+The CLI command `yukh team run-plan-approved` executes an already proposed plan
+by team ID, plan ID and approved digest. A zero-command CLI proof on the VPS
+completed one worker plus synthesis with 28,440 observed tokens: 120 manager,
+14,092 worker and 14,228 synthesis.
 
 Issue #155 proved that a single provider turn can exceed its allocation before
 usage is reported. Deterministic plans therefore run by default only when every
@@ -175,6 +179,11 @@ explicit final synthesis consume additional model tokens. If a worker returns
 useful text but exceeds budget, the plan fails before synthesis; inspect the
 worker summary as a review artifact and approve a fresh plan rather than
 retrying blindly.
+
+The local preview script allows 32 generated agent identities per runtime
+directory. Repeated dynamic-team tests can exhaust that preview limit and fail
+with `agent limit reached` or bootstrap errors. Reset only the disposable local
+preview runtime before continuing those tests.
 
 Codex managers run without inherited user configuration. Yukh injects only the
 tools required by the manager record; a pure planning turn receives no

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -12,10 +12,12 @@ import { teamRuntimeEntrypoints } from "../../packages/team-control/src/entrypoi
 import { parsePreflightArguments } from "../../apps/team-preflight/src/arguments.js";
 import { runApprovedPreflight } from "../../apps/team-preflight/src/approved-run.js";
 import {
+  formatApprovedPlanRun,
   formatApprovedRun,
   formatEngagePreflight,
   formatTeamStatus,
 } from "../../apps/team-preflight/src/format.js";
+import { runApprovedPlanWithDependencies } from "../../apps/team-preflight/src/plan-execute.js";
 import { runEngagePreflight } from "../../apps/team-preflight/src/preflight.js";
 import {
   copilotModelCatalogFromDiscoveries,
@@ -2220,6 +2222,155 @@ test("deterministic executor reserves, runs, awaits and synthesizes without mana
       2_000,
     );
     assert.equal(launches.length, 2);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("approved plan CLI runner executes workers and synthesis through the deterministic executor", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-plan-cli-runner-")));
+  try {
+    const store = new TeamStore(root);
+    const managed = store.createManaged("Execute plan from CLI", "codex", 4, 1, 10_000, {
+      role: "delivery-manager",
+      profile: {
+        schema: 1,
+        mission: "Plan one bounded increment",
+        model: "default",
+        skills: [],
+        instructions: "Return a closed plan.",
+      },
+      task: "Plan",
+      token_budget: 2_000,
+      required_actions: [],
+      output_contract: "team-plan-v1",
+    });
+    store.transition(managed.team.team_id, managed.manager.agent_id, "running");
+    const plan = store.proposePlan(
+      managed.team.team_id,
+      managed.manager.agent_id,
+      JSON.stringify(planDocument()),
+    );
+    store.finish(
+      managed.team.team_id,
+      managed.manager.agent_id,
+      {
+        schema: 1,
+        outcome: "succeeded",
+        summary: JSON.stringify(planDocument()),
+        plan_id: plan.plan_id,
+      },
+      usage,
+    );
+    const launches: string[] = [];
+    const supervisor = {
+      launch(agent: ReturnType<TeamStore["agent"]>) {
+        launches.push(agent.agent_id);
+        store.transition(agent.team_id, agent.agent_id, "running");
+        queueMicrotask(() =>
+          store.finish(
+            agent.team_id,
+            agent.agent_id,
+            { schema: 1, outcome: "succeeded", summary: `${agent.role} completed` },
+            usage,
+          ),
+        );
+        return { pid: 1, log: "test" };
+      },
+    };
+    const output = await runApprovedPlanWithDependencies(
+      {
+        workspace: root,
+        teamId: managed.team.team_id,
+        planId: plan.plan_id,
+        approvedDigest: plan.digest,
+        launcher: process.execPath,
+        codex: process.execPath,
+        copilot: process.execPath,
+        waitMs: 2_000,
+      },
+      {
+        store,
+        supervisor,
+        options: {
+          dynamicExecution: true,
+          models: { codex: new Set(["default"]), copilot: new Set(["default"]) },
+          skills: { codex: new Set<string>(), copilot: new Set<string>() },
+        },
+      },
+    );
+    assert.equal(output.status, "ok");
+    assert.equal(output.plan.state, "completed");
+    assert.equal(launches.length, 2);
+    assert.equal(output.team.tokens.observed, 360);
+    assert.match(formatApprovedPlanRun(output), /Yukh approved plan run/u);
+    assert.match(formatApprovedPlanRun(output), /Plan state: completed/u);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("approved plan CLI runner keeps the deterministic cost boundary", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-plan-cli-boundary-")));
+  try {
+    const store = new TeamStore(root);
+    const managed = store.createManaged("Reject unsafe plan from CLI", "codex", 4, 1, 10_000, {
+      role: "delivery-manager",
+      profile: {
+        schema: 1,
+        mission: "Plan one bounded increment",
+        model: "default",
+        skills: [],
+        instructions: "Return a closed plan.",
+      },
+      task: "Plan",
+      token_budget: 2_000,
+      required_actions: [],
+      output_contract: "team-plan-v1",
+    });
+    store.transition(managed.team.team_id, managed.manager.agent_id, "running");
+    const unsafe = planDocument();
+    unsafe.workers[0]!.max_commands = 1;
+    const plan = store.proposePlan(
+      managed.team.team_id,
+      managed.manager.agent_id,
+      JSON.stringify(unsafe),
+    );
+    store.finish(
+      managed.team.team_id,
+      managed.manager.agent_id,
+      {
+        schema: 1,
+        outcome: "succeeded",
+        summary: JSON.stringify(unsafe),
+        plan_id: plan.plan_id,
+      },
+      usage,
+    );
+    await assert.rejects(
+      runApprovedPlanWithDependencies(
+        {
+          workspace: root,
+          teamId: managed.team.team_id,
+          planId: plan.plan_id,
+          approvedDigest: plan.digest,
+          launcher: process.execPath,
+          codex: process.execPath,
+          copilot: process.execPath,
+          waitMs: 2_000,
+        },
+        {
+          store,
+          supervisor: { launch: () => ({ pid: 1, log: "test" }) },
+          options: {
+            dynamicExecution: false,
+            models: { codex: new Set(["default"]), copilot: new Set(["default"]) },
+            skills: { codex: new Set<string>(), copilot: new Set<string>() },
+          },
+        },
+      ),
+      /dynamic_worker_cost_boundary_unavailable/u,
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- add `yukh team run-plan-approved` to execute an already proposed deterministic plan by team id, plan id and approved digest
- reuse the existing `plan.execute` path, including worker reservation, worker await and synthesis
- keep the deterministic cost boundary in the CLI: unsafe plans still require explicit dynamic execution enablement
- document the VPS zero-command proof and local preview identity-limit behavior

## Verification
- `npm run -s format:check`
- `npm run -s typecheck`
- `node --import tsx --test test/runtime/team-control.test.ts`
- `npm run -s build`
- `git diff --check`
- `npm test`

## Real proof
- Coordination preview reset and relaunched on rufy-worker with NATS JetStream compose
- zero-command `run-plan-approved` proof completed worker plus synthesis
- observed tokens: 28,440 total; manager 120, worker 14,092, synthesis 14,228
- failed edit-plan proof preserved fail-closed behavior at 90,649 / 80,000 worker tokens before synthesis

Closes #199
