### PR TITLE
Clarify approved plan operator command

### DIFF
--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -119,6 +119,22 @@ by team ID, plan ID and approved digest. A zero-command CLI proof on the VPS
 completed one worker plus synthesis with 28,440 observed tokens: 120 manager,
 14,092 worker and 14,228 synthesis.
 
+From the workspace configured for the existing team, run the approved plan with
+the identifiers returned by the proposal:
+
+```sh
+yukh team run-plan-approved \
+  --team team-... \
+  --plan plan-... \
+  --approved-digest sha-256:... \
+  --format text
+```
+
+Use the exact digest that the operator approved; the command fails closed if it
+does not match the stored plan. The default cost boundary accepts only workers
+and synthesis with `tool_mode: none` and `max_commands: 0`; unsafe dynamic
+workers require explicit isolated qualification.
+
 Issue #155 proved that a single provider turn can exceed its allocation before
 usage is reported. Deterministic plans therefore run by default only when every
 worker and the synthesizer use `tool_mode: none` and `max_commands: 0`; they


### PR DESCRIPTION
## Summary
- add a compact operator recipe for `yukh team run-plan-approved`
- show the exact `--team`, `--plan`, `--approved-digest`, and `--format text` flow
- restate the fail-closed digest check and default zero-command cost boundary

## Yukh execution evidence
- attempted execution through `yukh team run-plan-approved` for issue #201
- first plan rejected before launch because the context pack exceeded the allowed context-file boundary
- second worker produced the doc edit but failed closed at 114,134 / 80,000 tokens; synthesis was not launched
- the resulting artifact was manually reviewed and corrected before commit

## Validation
- `npm run -s format:check`
- `npm run -s typecheck`
- `npm test`
- `npm run -s build`
- `git diff --check`

Closes #201
