### PR TITLE
Document micro edit approval checks

### DIFF
--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -38,6 +38,11 @@ It budgets one non-delegating Codex worker at 35,000 tokens, `tool_mode: none`,
 one command and a 120-second runtime. Use it only when the target file and issue
 are already known; otherwise run a read-only verifier first.
 
+Before approving the generated run command, check four lines in the proposal:
+`token budget`, `max commands`, `provider launched` and `Approval digest`. If
+the worker is broader than the issue, if `provider launched` is `yes`, or if the
+budget is not appropriate for the edit, stop and create a narrower proposal.
+
 Use absolute paths below. Configure Codex as `agent-a`:
 
 ```toml


### PR DESCRIPTION
## Summary
- document the operator checks to perform before approving a micro-doc-edit run
- keep the guidance short and focused on token budget, command bound, provider launch state and digest

## Yukh preflight proof
Ran:
```sh
./bin/yukh.mjs team propose --preset micro-doc-edit --goal "Edit docs/guides/codex-copilot-coordination-preview.md for issue #205" --format text
```

Observed:
- worker token budget: 35000
- max commands: 1
- timeout: 120000ms
- provider launched: no
- allocated: 55000 / team budget 80000
- approval digest: sha-256:380309a5c073b911ea98adc55e9895c8c119ebf845aea8e376b5d0e874b90b5c

## Validation
- npm run -s format:check
- git diff --check
- suite baseline was run and reported the expected dirty-checkout error for this in-progress branch only

Closes #205