### PR TITLE
Validate preflight role arguments

### DIFF
--- a/apps/team-preflight/src/arguments.ts
+++ b/apps/team-preflight/src/arguments.ts
@@ -116,6 +116,8 @@ export function parsePreflightArguments(
   const workProfile = values.get("work-profile") ?? preset?.workProfile ?? "implementation";
   if (!["review", "readonly", "implementation", "synthesis"].includes(workProfile))
     throw new TypeError("invalid work profile");
+  const role = values.get("role") ?? preset?.role ?? "backend-reviewer";
+  if (!/^[a-z][a-z0-9-]{0,31}$/u.test(role)) throw new TypeError("invalid role argument");
   const format = values.get("format") ?? options?.defaultFormat ?? "json";
   if (!["json", "text"].includes(format)) throw new TypeError("invalid output format");
   const workspace = values.get("workspace") ?? options?.defaultWorkspace;
@@ -123,7 +125,7 @@ export function parsePreflightArguments(
   return {
     ...(workspace ? { workspace } : {}),
     goal: values.get("goal") ?? preset?.goal ?? "Preflight one dynamic Yukh worker engagement.",
-    role: values.get("role") ?? preset?.role ?? "backend-reviewer",
+    role,
     workProfile: workProfile as TeamWorkProfile,
     ...(preferredRuntime ? { preferredRuntime: preferredRuntime as AgentRuntime } : {}),
     teamBudget: integer(values.get("team-budget"), preset?.teamBudget ?? 260_000),

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -125,6 +125,20 @@ test("micro code edit preset requires a narrow code path and one validation comm
   assert.match(args.goal, /Do not read broad repository context/u);
 });
 
+test("preflight rejects invalid role arguments with a focused error", () => {
+  for (const role of [
+    "Backend Developer",
+    "-backend-developer",
+    "backend_developer",
+    "a".repeat(33),
+  ]) {
+    assert.throws(
+      () => parsePreflightArguments(["--role", role]),
+      (error: unknown) => error instanceof TypeError && error.message === "invalid role argument",
+    );
+  }
+});
+
 const usage = {
   schema: 1 as const,
   source: "codex-json-v1" as const,


### PR DESCRIPTION
## Summary
- validate preflight role values before creating a TeamStore worker
- return the focused stable error `invalid role argument` for invalid CLI role input
- add focused coverage for spaces, uppercase, underscores, leading hyphen and excessive length

## Real Yukh worker proof
Preflight:
- preset: micro-code-edit
- worker: backend-developer / codex
- token budget: 45000
- max commands: 1
- timeout: 180000ms
- provider launched before approval: no
- approval digest: sha-256:cc018bdcd148fe538d224c92be83cca61d5f59c6bc5a1e6b2e6da168eaf93a84

Approved run:
- provider launched: yes
- launched worker: worker-b4fbcbe8-1308-495c-83d5-34a8f83384f5
- terminal worker state: failed
- completion outcome: token_budget_exceeded
- observed tokens: 132509
- allocated tokens: 65000

The worker produced the useful patch, but Yukh correctly failed the run because token usage exceeded the approved budget. I manually reviewed the artifact before committing it.

## Validation
- npm run -s format:check
- npm run -s typecheck
- node --import tsx --test test/runtime/team-control.test.ts
- npm run -s build
- git diff --check
- npm test (passed outside sandbox; sandbox blocks local loopback/TLS tests)

Closes #209