### PR TITLE
Compact micro worker prompts

### DIFF
--- a/apps/team-worker/src/main.ts
+++ b/apps/team-worker/src/main.ts
@@ -3,6 +3,7 @@ import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
 import { RuntimeOutput } from "../../../packages/team-control/src/runtime-output.js";
+import { buildWorkerPrompt } from "./prompt.js";
 
 const required = (name: string): string => {
   const value = process.env[name];
@@ -72,28 +73,19 @@ const planConstraintInstruction =
   agent.output_contract === "team-plan-v1"
     ? `Plan constraints: use only allowlisted models. Codex models: ${allowlist("YUKH_CODEX_MODELS", ["default"]).join(", ")}. Copilot models: ${allowlist("YUKH_COPILOT_MODELS", ["default"]).join(", ")}. Prefer model "default" unless the task explicitly requires another allowlisted model. Do not invent model names. Worker context_paths must name repository-relative regular UTF-8 files, at most four per worker, each file at most 4096 bytes and each worker pack at most 12288 bytes total. If a requested or attractive file may exceed 4096 bytes, omit it or choose a smaller file; never rely on a large document being accepted at execution time. Synthesis must use no context_paths. Budget realistic runtime floors: Codex zero-command review/planning workers with small context currently need at least 18000 total tokens, and Codex tool-free synthesis currently needs at least 16000 total tokens, unless the task supplies fresher measured evidence. Prefer fewer planned agents over under-budgeted agents. Every planned worker and synthesis prompt must require a final public-safe completion summary below 4096 UTF-8 bytes; prefer 3500 bytes or less so the wrapper can persist it. Do not ask planned agents for multi-section reports that exceed the persistence cap.`
     : "";
-const outputInstruction =
-  agent.output_contract === "team-plan-v1"
-    ? "Return only the JSON team execution plan required by the supplied output schema. Include the minimum specialists needed and one concise delivery synthesizer. Every role must be a lowercase slug matching ^[a-z][a-z0-9-]{0,31}$, for example token-efficiency-auditor; spaces are invalid. Select at most four small repository-relative context_paths per worker and none for synthesis. Do not wrap JSON in Markdown."
-    : "End with one concise public-safe completion summary of at most 4096 UTF-8 bytes; the wrapper persists that final response.";
-const prompt = [
-  `You are ${agent.role}, ${agent.kind} ${agent.agent_id} in team ${agent.team_id}.`,
-  profile
-    ? `Mission: ${profile.mission}\nOperating instructions: ${profile.instructions}\nRequired skills: ${profile.skills.length > 0 ? profile.skills.join(", ") : "none"}.`
-    : "",
-  `Complete this task: ${agent.task}`,
-  contextPack
-    ? `Use only this server-prepared context pack (${contextPack.digest}, ${contextPack.byte_length} bytes):\n${contextPack.files.map((file) => `--- ${file.path} ---\n${file.content}`).join("\n")}`
-    : "",
-  `Token budget: ${agent.token_budget} total input plus output tokens. Runtime bounds: at most ${agent.max_commands ?? 8} command executions and ${agent.timeout_ms ?? 300_000} milliseconds. Keep inspection and tool output bounded.`,
+const prompt = buildWorkerPrompt({
+  agent,
+  ...(contextPack ? { contextPack } : {}),
+  modelToolMode,
+  requiredActions,
+  modelUsesCoordination,
+  modelUsesTeamControl,
+  modelTeamTools,
+  coordinationInstruction,
   teamControlInstruction,
   delegationInstruction,
-  coordinationInstruction,
   planConstraintInstruction,
-  outputInstruction,
-]
-  .filter(Boolean)
-  .join(" ");
+});
 const planSchema = fileURLToPath(
   new URL("../../../contracts/team-execution-plan-v1.schema.json", import.meta.url),
 );

--- a/apps/team-worker/src/prompt.ts
+++ b/apps/team-worker/src/prompt.ts
@@ -1,0 +1,73 @@
+import type {
+  AgentRecord,
+  ContextPackDocument,
+  ModelToolMode,
+} from "../../../packages/team-control/src/store.js";
+
+export function isMicroWorker(agent: AgentRecord): boolean {
+  return (
+    agent.kind === "worker" &&
+    (agent.model_tool_mode ?? "default") === "none" &&
+    (agent.max_commands ?? 8) <= 1 &&
+    agent.token_budget <= 45_000
+  );
+}
+
+function contextText(contextPack: ContextPackDocument | undefined): string {
+  return contextPack
+    ? `Context pack ${contextPack.digest}, ${contextPack.byte_length} bytes:\n${contextPack.files
+        .map((file) => `--- ${file.path} ---\n${file.content}`)
+        .join("\n")}`
+    : "No context pack was supplied. Inspect only the exact files named in the task.";
+}
+
+export function buildWorkerPrompt(input: {
+  readonly agent: AgentRecord;
+  readonly contextPack?: ContextPackDocument;
+  readonly modelToolMode: "default" | ModelToolMode;
+  readonly requiredActions: string;
+  readonly modelUsesCoordination: boolean;
+  readonly modelUsesTeamControl: boolean;
+  readonly modelTeamTools: readonly string[];
+  readonly coordinationInstruction: string;
+  readonly teamControlInstruction: string;
+  readonly delegationInstruction: string;
+  readonly planConstraintInstruction: string;
+}): string {
+  const { agent, contextPack } = input;
+  if (isMicroWorker(agent)) {
+    return [
+      `You are ${agent.role}, worker ${agent.agent_id}.`,
+      `Task: ${agent.task}`,
+      contextText(contextPack),
+      `Hard bounds: token budget ${agent.token_budget}; max commands ${agent.max_commands ?? 1}; deadline ${agent.timeout_ms ?? 180_000} ms.`,
+      "Do the smallest safe change. Do not browse broad repository context. Do not delegate. Keep command output small.",
+      "End with one concise public-safe summary under 1200 UTF-8 bytes: changed files, validation run, remaining risk.",
+    ].join(" ");
+  }
+
+  const profile = agent.profile;
+  const outputInstruction =
+    agent.output_contract === "team-plan-v1"
+      ? "Return only the JSON team execution plan required by the supplied output schema. Include the minimum specialists needed and one concise delivery synthesizer. Every role must be a lowercase slug matching ^[a-z][a-z0-9-]{0,31}$, for example token-efficiency-auditor; spaces are invalid. Select at most four small repository-relative context_paths per worker and none for synthesis. Do not wrap JSON in Markdown."
+      : "End with one concise public-safe completion summary of at most 4096 UTF-8 bytes; the wrapper persists that final response.";
+
+  return [
+    `You are ${agent.role}, ${agent.kind} ${agent.agent_id} in team ${agent.team_id}.`,
+    profile
+      ? `Mission: ${profile.mission}\nOperating instructions: ${profile.instructions}\nRequired skills: ${profile.skills.length > 0 ? profile.skills.join(", ") : "none"}.`
+      : "",
+    `Complete this task: ${agent.task}`,
+    contextPack
+      ? `Use only this server-prepared context pack (${contextPack.digest}, ${contextPack.byte_length} bytes):\n${contextPack.files.map((file) => `--- ${file.path} ---\n${file.content}`).join("\n")}`
+      : "",
+    `Token budget: ${agent.token_budget} total input plus output tokens. Runtime bounds: at most ${agent.max_commands ?? 8} command executions and ${agent.timeout_ms ?? 300_000} milliseconds. Keep inspection and tool output bounded.`,
+    input.teamControlInstruction,
+    input.delegationInstruction,
+    input.coordinationInstruction,
+    input.planConstraintInstruction,
+    outputInstruction,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../../apps/team-preflight/src/format.js";
 import { runApprovedPlanWithDependencies } from "../../apps/team-preflight/src/plan-execute.js";
 import { runEngagePreflight } from "../../apps/team-preflight/src/preflight.js";
+import { buildWorkerPrompt, isMicroWorker } from "../../apps/team-worker/src/prompt.js";
 import {
   copilotModelCatalogFromDiscoveries,
   parseCodexModelCatalog,
@@ -310,6 +311,56 @@ test("micro code edit preflight keeps implementation bounded to one command", as
   } finally {
     await rm(root, { recursive: true, force: true });
   }
+});
+
+test("micro workers receive compact prompts without orchestration noise", () => {
+  const agent = {
+    schema: 1,
+    agent_id: "worker-00000000-0000-4000-8000-000000000001",
+    kind: "worker",
+    coordination_agent: "agent-backend-developer-00000000-0000-4000-8000-000000000001",
+    coordination_participant: "agent:backend-developer-00000000-0000-4000-8000-000000000001",
+    team_id: "team-00000000-0000-4000-8000-000000000001",
+    runtime: "codex",
+    role: "backend-developer",
+    profile: {
+      schema: 1,
+      mission: "Implement a tiny code edit",
+      model: "default",
+      skills: ["api-design", "testing"],
+      instructions:
+        "Long profile instructions that are useful for a normal agent but wasteful for one-command micro work.",
+    },
+    task: "Edit apps/team-worker/src/prompt.ts and run one focused test.",
+    depth: 1,
+    can_spawn: false,
+    token_budget: 45_000,
+    required_actions: [],
+    model_tool_mode: "none",
+    max_commands: 1,
+    timeout_ms: 180_000,
+    state: "defined",
+  } as const;
+  const prompt = buildWorkerPrompt({
+    agent,
+    modelToolMode: "none",
+    requiredActions: "none",
+    modelUsesCoordination: false,
+    modelUsesTeamControl: false,
+    modelTeamTools: [],
+    coordinationInstruction: "",
+    teamControlInstruction: "Required receipt-backed actions before success: agent.engage.",
+    delegationInstruction: "When engaging a child, use the returned coordination_participant.",
+    planConstraintInstruction: "Plan constraints: use only allowlisted models.",
+  });
+  assert.equal(isMicroWorker(agent), true);
+  assert.ok(prompt.length < 900);
+  assert.match(prompt, /Task: Edit apps\/team-worker\/src\/prompt\.ts/u);
+  assert.match(prompt, /No context pack was supplied/u);
+  assert.doesNotMatch(prompt, /Long profile instructions/u);
+  assert.doesNotMatch(prompt, /Required receipt-backed actions/u);
+  assert.doesNotMatch(prompt, /Plan constraints/u);
+  assert.doesNotMatch(prompt, /coordination_participant/u);
 });
 
 test("team status formatter exposes stop and token state without raw JSON", async () => {


### PR DESCRIPTION
Summary:
- Move team-worker prompt construction into a testable module.
- Use a compact prompt for micro workers: tool_mode none, max_commands <= 1, budget <= 45k.
- Assert compact prompts omit orchestration and profile noise that wastes tokens.

Validation:
- node --import tsx --test test/runtime/team-control.test.ts
- npm run -s typecheck
- npm run -s format:check
- npm run -s build
- git diff --check

Note: full npm test in the managed sandbox still hits existing integration failures around coordination/gateway/profile loopback behavior; the touched runtime test file passes outside sandbox.