### PR TITLE
Expose cached token usage in approved runs

### DIFF
--- a/apps/team-preflight/src/format.ts
+++ b/apps/team-preflight/src/format.ts
@@ -55,7 +55,8 @@ export function formatEngagePreflight(
 }
 
 export function formatApprovedRun(output: ApprovedRunOutput): string {
-  return [
+  const usage = output.terminal_agent?.usage;
+  const lines = [
     "Yukh approved run",
     `Status: ${output.status}`,
     `Approval digest: ${output.approval_digest}`,
@@ -71,9 +72,17 @@ export function formatApprovedRun(output: ApprovedRunOutput): string {
     `- remaining: ${output.tokens.remaining}`,
     `- pending agents: ${output.tokens.pending_agents}`,
     `- unaccounted agents: ${output.tokens.unaccounted_agents}`,
-    "",
-    `Terminal worker state: ${output.terminal_agent?.state ?? "not waited"}`,
-  ].join("\n");
+  ];
+  if (usage)
+    lines.push(
+      `- terminal input: ${usage.input_tokens}`,
+      `- terminal cached input: ${usage.cached_input_tokens}`,
+      `- terminal uncached input: ${usage.input_tokens - usage.cached_input_tokens}`,
+      `- terminal output: ${usage.output_tokens}`,
+      `- terminal reasoning output: ${usage.reasoning_output_tokens}`,
+    );
+  lines.push("", `Terminal worker state: ${output.terminal_agent?.state ?? "not waited"}`);
+  return lines.join("\n");
 }
 
 export function formatApprovedPlanRun(output: ApprovedPlanRunOutput): string {

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -354,6 +354,7 @@ test("micro workers receive compact prompts without orchestration noise", () => 
     planConstraintInstruction: "Plan constraints: use only allowlisted models.",
   });
   assert.equal(isMicroWorker(agent), true);
+  assert.equal(isMicroWorker({ ...agent, max_commands: 2 }), false);
   assert.ok(prompt.length < 900);
   assert.match(prompt, /Task: Edit apps\/team-worker\/src\/prompt\.ts/u);
   assert.match(prompt, /No context pack was supplied/u);
@@ -361,6 +362,66 @@ test("micro workers receive compact prompts without orchestration noise", () => 
   assert.doesNotMatch(prompt, /Required receipt-backed actions/u);
   assert.doesNotMatch(prompt, /Plan constraints/u);
   assert.doesNotMatch(prompt, /coordination_participant/u);
+});
+
+test("approved run formatter exposes terminal cached and uncached token usage", () => {
+  const text = formatApprovedRun({
+    schema: 1,
+    status: "ok",
+    command: "team run-approved",
+    approval_digest: "sha-256:1111111111111111111111111111111111111111111111111111111111111111",
+    provider_runtime_launched: true,
+    launched_worker: "worker-00000000-0000-4000-8000-000000000001",
+    receipt: {
+      schema: 1,
+      receipt_id: "receipt-00000000-0000-4000-8000-000000000001",
+      team_id: "team-00000000-0000-4000-8000-000000000001",
+      action: "agent.engage",
+      actor_agent_id: "worker-00000000-0000-4000-8000-000000000000",
+      subject_agent_id: "worker-00000000-0000-4000-8000-000000000001",
+      outcome: "succeeded",
+    },
+    runtime: { pid: 123, log: "/tmp/worker.log" },
+    terminal_agent: {
+      schema: 1,
+      agent_id: "worker-00000000-0000-4000-8000-000000000001",
+      kind: "worker",
+      coordination_agent: "agent-backend-developer-00000000-0000-4000-8000-000000000001",
+      coordination_participant: "agent:backend-developer-00000000-0000-4000-8000-000000000001",
+      team_id: "team-00000000-0000-4000-8000-000000000001",
+      runtime: "codex",
+      role: "backend-developer",
+      task: "Probe token accounting.",
+      depth: 1,
+      can_spawn: false,
+      token_budget: 45_000,
+      required_actions: [],
+      state: "failed",
+      usage: {
+        schema: 1,
+        source: "codex-json-v1",
+        input_tokens: 114_867,
+        cached_input_tokens: 89_600,
+        output_tokens: 1_846,
+        reasoning_output_tokens: 1_259,
+        total_tokens: 116_713,
+        budget_outcome: "exceeded",
+      },
+    },
+    tokens: {
+      budget: 90_000,
+      allocated: 65_000,
+      observed: 116_713,
+      remaining: 0,
+      pending_agents: 1,
+      unaccounted_agents: 0,
+      exceeded_agents: 1,
+    },
+  } as Parameters<typeof formatApprovedRun>[0]);
+  assert.match(text, /terminal cached input: 89600/u);
+  assert.match(text, /terminal uncached input: 25267/u);
+  assert.match(text, /terminal output: 1846/u);
+  assert.match(text, /Terminal worker state: failed/u);
 });
 
 test("team status formatter exposes stop and token state without raw JSON", async () => {


### PR DESCRIPTION
Summary:
- Show terminal cached input, uncached input, output and reasoning tokens in team run-approved text output.
- Keep the micro prompt regression test tighter by proving max_commands=2 is not classified as a micro worker.

Real probe result:
- Ran a real micro-code-edit worker with allow-micro-launch true.
- Worker completed the tiny edit but was correctly marked failed for token_budget_exceeded.
- Observed 116713 total tokens: 114867 input, 89600 cached input, 1846 output, 1259 reasoning output.
- Root cause: Codex CLI runner has a large cached input floor, so a 45k total-token micro budget is not realistic with the current CLI runner.

Validation:
- node --import tsx --test test/runtime/team-control.test.ts
- npm run -s typecheck
- npm run -s format:check
- npm run -s build
- git diff --check