### PR TITLE
Block workers below measured runtime token floor

### DIFF
--- a/apps/team-preflight/src/approved-run.ts
+++ b/apps/team-preflight/src/approved-run.ts
@@ -4,6 +4,7 @@ import { TeamStore } from "../../../packages/team-control/src/store.js";
 import { TeamSupervisor } from "../../../packages/team-control/src/supervisor.js";
 import type { AgentRecord } from "../../../packages/team-control/src/store.js";
 import { preflightApprovalDigest, type EngagePreflightOutput } from "./preflight.js";
+import { assertRuntimeTokenFloor } from "./runtime-floor.js";
 
 export interface ApprovedRunArguments {
   readonly preflightPath: string;
@@ -76,6 +77,7 @@ export async function runApprovedPreflight(args: ApprovedRunArguments) {
   if (worker.state !== "defined") throw new Error("worker_not_defined");
   if (microWorkerRequiresExplicitAllow(worker) && args.allowMicroLaunch !== true)
     throw new Error("micro_worker_launch_requires_explicit_allow");
+  assertRuntimeTokenFloor(worker);
 
   const entrypoints = teamRuntimeEntrypoints();
   const supervisor = new TeamSupervisor({

--- a/apps/team-preflight/src/format.ts
+++ b/apps/team-preflight/src/format.ts
@@ -39,13 +39,20 @@ export function formatEngagePreflight(
     `- tool mode: ${policy.tool_mode}`,
     `- max commands: ${policy.max_commands}`,
     `- timeout ms: ${policy.runtime_timeout_ms}`,
+  ];
+  if (output.runtime_token_floor)
+    lines.push(
+      `- runtime token floor: ${output.runtime_token_floor.minimum_token_budget}`,
+      `- floor reason: ${compact(output.runtime_token_floor.reason, 180)}`,
+    );
+  lines.push(
     "",
     "Budget",
     `- team budget: ${output.budget.budget}`,
     `- allocated: ${output.budget.allocated}`,
     `- observed provider tokens: ${output.provider_tokens_observed}`,
     `- provider launched: ${output.provider_runtime_launched ? "yes" : "no"}`,
-  ];
+  );
   const runCommand =
     options?.runCommand === undefined
       ? `yukh team run-approved --preflight <preflight.json> --approved-digest ${output.approval_digest}`

--- a/apps/team-preflight/src/preflight.ts
+++ b/apps/team-preflight/src/preflight.ts
@@ -6,6 +6,7 @@ import { roleProfilePolicy } from "../../team-control/src/server.js";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
 import type { AgentRuntime } from "../../../packages/team-control/src/store.js";
 import type { TeamWorkProfile } from "../../team-control/src/server.js";
+import { runtimeTokenFloor, type RuntimeTokenFloor } from "./runtime-floor.js";
 
 export interface EngagePreflightArguments {
   readonly workspace?: string;
@@ -36,6 +37,7 @@ export interface EngagePreflightOutput {
   readonly manager: ReturnType<TeamStore["createManaged"]>["manager"];
   readonly policy: ReturnType<typeof roleProfilePolicy>;
   readonly planned_worker: ReturnType<TeamStore["spawn"]>;
+  readonly runtime_token_floor?: RuntimeTokenFloor;
   readonly budget: ReturnType<TeamStore["status"]>["tokens"];
   readonly next_real_action: string;
 }
@@ -166,6 +168,7 @@ export function runEngagePreflight(args: EngagePreflightArguments): EngagePrefli
     max_commands: policy.recommendation.max_commands,
     timeout_ms: policy.recommendation.runtime_timeout_ms,
   });
+  const floor = runtimeTokenFloor(worker);
   const budget = store.status(managed.team.team_id).tokens;
   const output = {
     schema: 1 as const,
@@ -179,6 +182,7 @@ export function runEngagePreflight(args: EngagePreflightArguments): EngagePrefli
     manager: managed.manager,
     policy,
     planned_worker: worker,
+    ...(floor ? { runtime_token_floor: floor } : {}),
     budget,
     next_real_action:
       "Run a managed manager or agent.engage from Team Control only after approving this policy and budget.",

--- a/apps/team-preflight/src/runtime-floor.ts
+++ b/apps/team-preflight/src/runtime-floor.ts
@@ -1,0 +1,37 @@
+import type { AgentRecord } from "../../../packages/team-control/src/store.js";
+
+export interface RuntimeTokenFloor {
+  readonly schema: 1;
+  readonly applies: true;
+  readonly runtime: "codex";
+  readonly minimum_token_budget: number;
+  readonly measured_total_tokens: number;
+  readonly measured_cached_input_tokens: number;
+  readonly reason: string;
+}
+
+export function runtimeTokenFloor(worker: AgentRecord): RuntimeTokenFloor | undefined {
+  if (
+    worker.runtime !== "codex" ||
+    (worker.model_tool_mode ?? "default") !== "none" ||
+    (worker.max_commands ?? 8) > 1
+  )
+    return undefined;
+
+  return {
+    schema: 1,
+    applies: true,
+    runtime: "codex",
+    minimum_token_budget: 120_000,
+    measured_total_tokens: 116_713,
+    measured_cached_input_tokens: 89_600,
+    reason:
+      "Codex CLI one-command workers have a measured cached input floor near 90k tokens, so smaller total-token budgets are not launch-safe with the CLI runner.",
+  };
+}
+
+export function assertRuntimeTokenFloor(worker: AgentRecord): void {
+  const floor = runtimeTokenFloor(worker);
+  if (floor && worker.token_budget < floor.minimum_token_budget)
+    throw new Error("worker_token_budget_below_runtime_floor");
+}

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -282,6 +282,7 @@ test("micro documentation edit preflight overrides implementation bounds", async
     assert.equal(output.planned_worker.token_budget, 35_000);
     assert.equal(output.planned_worker.max_commands, 1);
     assert.equal(output.planned_worker.timeout_ms, 120_000);
+    assert.equal(output.runtime_token_floor?.minimum_token_budget, 120_000);
     assert.equal(output.provider_runtime_launched, false);
     assert.equal(output.budget.allocated, 55_000);
   } finally {
@@ -306,6 +307,7 @@ test("micro code edit preflight keeps implementation bounded to one command", as
     assert.equal(output.planned_worker.token_budget, 45_000);
     assert.equal(output.planned_worker.max_commands, 1);
     assert.equal(output.planned_worker.timeout_ms, 180_000);
+    assert.equal(output.runtime_token_floor?.minimum_token_budget, 120_000);
     assert.equal(output.provider_runtime_launched, false);
     assert.equal(output.budget.allocated, 65_000);
   } finally {
@@ -493,6 +495,7 @@ test("engage preflight composes a worker without launching a provider runtime", 
     assert.equal(output.budget.allocated, 260_000);
     assert.equal(output.budget.observed, 0);
     assert.equal(output.budget.pending_agents, 2);
+    assert.equal(output.runtime_token_floor, undefined);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -520,6 +523,8 @@ test("engage preflight text output shows approval and budget without raw JSON no
     assert.match(text, /runtime: codex/u);
     assert.match(text, /task: Preflight backend worker/u);
     assert.match(text, /observed provider tokens: 0/u);
+    assert.match(text, /runtime token floor: 120000/u);
+    assert.match(text, /cached input floor near 90k/u);
     assert.doesNotMatch(text, /"planned_worker"/u);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -553,8 +558,9 @@ printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_inpu
       role: "backend-reviewer",
       workProfile: "review",
       preferredRuntime: "codex",
-      teamBudget: 220_000,
+      teamBudget: 320_000,
       managerBudget: 180_000,
+      workerBudget: 120_000,
       codexModels: ["default"],
       copilotModels: ["default"],
       codexSkills: ["api-design", "testing"],
@@ -623,6 +629,49 @@ test("approved preflight blocks micro workers before provider launch without exp
           waitMs: 0,
         }),
       /micro_worker_launch_requires_explicit_allow/u,
+    );
+    const store = new TeamStore(root);
+    const worker = store.agent(preflight.team.team_id, preflight.planned_worker.agent_id);
+    assert.equal(worker.state, "defined");
+    assert.equal(store.status(preflight.team.team_id).tokens.observed, 0);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("approved preflight blocks measured Codex CLI token floors before provider launch", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-approved-runtime-floor-")));
+  try {
+    const preflightPath = join(root, "preflight.json");
+    const preflight = runEngagePreflight({
+      workspace: root,
+      goal: "Edit one named file and run one focused test",
+      role: "backend-developer",
+      workProfile: "implementation",
+      preferredRuntime: "codex",
+      teamBudget: 90_000,
+      managerBudget: 20_000,
+      workerBudget: 45_000,
+      workerMaxCommands: 1,
+      workerTimeoutMs: 180_000,
+      codexModels: ["default"],
+      copilotModels: ["default"],
+      codexSkills: ["api-design", "testing"],
+      copilotSkills: ["frontend"],
+    });
+    await writeFile(preflightPath, `${JSON.stringify(preflight)}\n`, { mode: 0o600 });
+    await assert.rejects(
+      () =>
+        runApprovedPreflight({
+          preflightPath,
+          approvedDigest: preflight.approval_digest,
+          launcher: process.execPath,
+          codex: process.execPath,
+          copilot: process.execPath,
+          allowMicroLaunch: true,
+          waitMs: 0,
+        }),
+      /worker_token_budget_below_runtime_floor/u,
     );
     const store = new TeamStore(root);
     const worker = store.agent(preflight.team.team_id, preflight.planned_worker.agent_id);


### PR DESCRIPTION
Summary:
- Add a measured Codex CLI runtime token floor for one-command tool-free workers.
- Show that floor in team preflight output.
- Block run-approved before provider launch when a worker budget is below the measured floor.

Why:
- Real probe showed a tiny Codex CLI micro-worker used 116713 total tokens, with 89600 cached input tokens.
- Therefore a 45000 total-token micro budget is not launch-safe with the current CLI runner.

Validation:
- node --import tsx --test test/runtime/team-control.test.ts
- npm run -s typecheck
- npm run -s format:check
- npm run -s build
- git diff --check
- operator proof: micro-code-edit preflight shows runtime token floor 120000; run-approved exits before provider launch with worker_token_budget_below_runtime_floor.