### PR TITLE
Mark below-floor worker preflights non-launchable

### DIFF
--- a/apps/team-preflight/src/approved-run.ts
+++ b/apps/team-preflight/src/approved-run.ts
@@ -41,6 +41,9 @@ function loadPreflight(path: string): EngagePreflightOutput {
     value.schema !== 1 ||
     value.status !== "ok" ||
     value.command !== "team preflight-engage" ||
+    value.provider_launchable !==
+      (value.runtime_token_floor === undefined ||
+        value.planned_worker.token_budget >= value.runtime_token_floor.minimum_token_budget) ||
     value.provider_runtime_launched !== false ||
     value.provider_tokens_observed !== 0
   )

--- a/apps/team-preflight/src/format.ts
+++ b/apps/team-preflight/src/format.ts
@@ -52,9 +52,12 @@ export function formatEngagePreflight(
     `- allocated: ${output.budget.allocated}`,
     `- observed provider tokens: ${output.provider_tokens_observed}`,
     `- provider launched: ${output.provider_runtime_launched ? "yes" : "no"}`,
+    `- provider launchable: ${output.provider_launchable ? "yes" : "no"}`,
   );
-  const runCommand =
-    options?.runCommand === undefined
+  if (!output.provider_launchable) lines.push("", `Next action: ${output.next_real_action}`);
+  const runCommand = !output.provider_launchable
+    ? false
+    : options?.runCommand === undefined
       ? `yukh team run-approved --preflight <preflight.json> --approved-digest ${output.approval_digest}`
       : options.runCommand;
   if (runCommand) lines.push("", "Run after approval", runCommand);

--- a/apps/team-preflight/src/preflight.ts
+++ b/apps/team-preflight/src/preflight.ts
@@ -32,6 +32,7 @@ export interface EngagePreflightOutput {
   readonly workspace: string;
   readonly provider_tokens_observed: 0;
   readonly provider_runtime_launched: false;
+  readonly provider_launchable: boolean;
   readonly approval_digest: `sha-256:${string}`;
   readonly team: ReturnType<TeamStore["createManaged"]>["team"];
   readonly manager: ReturnType<TeamStore["createManaged"]>["manager"];
@@ -170,6 +171,7 @@ export function runEngagePreflight(args: EngagePreflightArguments): EngagePrefli
   });
   const floor = runtimeTokenFloor(worker);
   const budget = store.status(managed.team.team_id).tokens;
+  const providerLaunchable = !floor || worker.token_budget >= floor.minimum_token_budget;
   const output = {
     schema: 1 as const,
     status: "ok" as const,
@@ -177,6 +179,7 @@ export function runEngagePreflight(args: EngagePreflightArguments): EngagePrefli
     workspace,
     provider_tokens_observed: 0 as const,
     provider_runtime_launched: false as const,
+    provider_launchable: providerLaunchable,
     approval_digest: "sha-256:" as `sha-256:${string}`,
     team: managed.team,
     manager: managed.manager,
@@ -184,8 +187,9 @@ export function runEngagePreflight(args: EngagePreflightArguments): EngagePrefli
     planned_worker: worker,
     ...(floor ? { runtime_token_floor: floor } : {}),
     budget,
-    next_real_action:
-      "Run a managed manager or agent.engage from Team Control only after approving this policy and budget.",
+    next_real_action: providerLaunchable
+      ? "Run a managed manager or agent.engage from Team Control only after approving this policy and budget."
+      : "Do not launch this worker with the current CLI runtime budget. Use an SDK/lean worker runtime or raise the worker budget to the measured runtime floor.",
   };
   return { ...output, approval_digest: preflightApprovalDigest(output) };
 }

--- a/apps/team-preflight/src/propose-main.ts
+++ b/apps/team-preflight/src/propose-main.ts
@@ -38,7 +38,9 @@ try {
       ? JSON.stringify({ ...output, approval_file: path })
       : [
           formatEngagePreflight(output, {
-            runCommand: `yukh team run-approved --preflight ${path} --approved-digest ${output.approval_digest} --format text`,
+            runCommand: output.provider_launchable
+              ? `yukh team run-approved --preflight ${path} --approved-digest ${output.approval_digest} --format text`
+              : false,
           }),
           "",
           `Approval file: ${path}`,

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -283,6 +283,8 @@ test("micro documentation edit preflight overrides implementation bounds", async
     assert.equal(output.planned_worker.max_commands, 1);
     assert.equal(output.planned_worker.timeout_ms, 120_000);
     assert.equal(output.runtime_token_floor?.minimum_token_budget, 120_000);
+    assert.equal(output.provider_launchable, false);
+    assert.match(output.next_real_action, /SDK\/lean worker runtime/u);
     assert.equal(output.provider_runtime_launched, false);
     assert.equal(output.budget.allocated, 55_000);
   } finally {
@@ -308,6 +310,8 @@ test("micro code edit preflight keeps implementation bounded to one command", as
     assert.equal(output.planned_worker.max_commands, 1);
     assert.equal(output.planned_worker.timeout_ms, 180_000);
     assert.equal(output.runtime_token_floor?.minimum_token_budget, 120_000);
+    assert.equal(output.provider_launchable, false);
+    assert.match(output.next_real_action, /SDK\/lean worker runtime/u);
     assert.equal(output.provider_runtime_launched, false);
     assert.equal(output.budget.allocated, 65_000);
   } finally {
@@ -483,6 +487,7 @@ test("engage preflight composes a worker without launching a provider runtime", 
     });
     assert.equal(output.status, "ok");
     assert.equal(output.provider_runtime_launched, false);
+    assert.equal(output.provider_launchable, true);
     assert.equal(output.provider_tokens_observed, 0);
     assert.equal(output.policy.recommendation.runtime, "copilot");
     assert.equal(output.policy.recommendation.model, "default");
@@ -525,6 +530,9 @@ test("engage preflight text output shows approval and budget without raw JSON no
     assert.match(text, /observed provider tokens: 0/u);
     assert.match(text, /runtime token floor: 120000/u);
     assert.match(text, /cached input floor near 90k/u);
+    assert.match(text, /provider launchable: no/u);
+    assert.match(text, /Next action: Do not launch/u);
+    assert.doesNotMatch(text, /Run after approval/u);
     assert.doesNotMatch(text, /"planned_worker"/u);
   } finally {
     await rm(root, { recursive: true, force: true });


### PR DESCRIPTION
Closes #216

Summary:
- add provider_launchable to engage preflight output
- suppress Run after approval for non-launchable worker preflights
- keep run-approved fail-closed behavior for below-floor Codex CLI workers
- make next action explicit: use SDK/lean worker runtime or raise CLI worker budget

Context:
- Codex CLI remains suitable for manager/orchestrator sessions.
- Measured evidence shows current Codex CLI worker execution is too heavy for 45k micro-worker budgets.
- The Codex TypeScript SDK currently wraps/spawns Codex CLI, so it must not be treated as a guaranteed lean runtime without measurement.

Validation:
- node --import tsx --test test/runtime/team-control.test.ts
- npm run -s typecheck
- npm run -s format:check
- npm run -s build
- git diff --check