### PR TITLE
Add opt-in Copilot SDK worker runner

### DIFF
--- a/apps/team-control/src/main.ts
+++ b/apps/team-control/src/main.ts
@@ -32,7 +32,7 @@ const profileEnvironment = {
   YUKH_CODEX_MODEL_SOURCE: codexCatalog.source,
   YUKH_COPILOT_MODEL_SOURCE: copilotCatalog.source,
   ...Object.fromEntries(
-    ["YUKH_CODEX_SKILLS", "YUKH_COPILOT_SKILLS"]
+    ["YUKH_CODEX_SKILLS", "YUKH_COPILOT_SKILLS", "YUKH_COPILOT_WORKER_PROVIDER"]
       .filter((name) => process.env[name] !== undefined)
       .map((name) => [name, process.env[name]!] as const),
   ),

--- a/apps/team-preflight/src/approved-run.ts
+++ b/apps/team-preflight/src/approved-run.ts
@@ -57,6 +57,7 @@ function profileEnvironment(args: ApprovedRunArguments): Readonly<Record<string,
   if (args.copilotModels) env.YUKH_COPILOT_MODELS = args.copilotModels;
   if (args.codexSkills) env.YUKH_CODEX_SKILLS = args.codexSkills;
   if (args.copilotSkills) env.YUKH_COPILOT_SKILLS = args.copilotSkills;
+  if (process.env.YUKH_COPILOT_WORKER_PROVIDER === "sdk") env.YUKH_COPILOT_WORKER_PROVIDER = "sdk";
   return env;
 }
 

--- a/apps/team-preflight/src/plan-execute.ts
+++ b/apps/team-preflight/src/plan-execute.ts
@@ -38,6 +38,7 @@ function profileEnvironment(args: ApprovedPlanRunArguments): Readonly<Record<str
   if (args.copilotModels) env.YUKH_COPILOT_MODELS = args.copilotModels;
   if (args.codexSkills) env.YUKH_CODEX_SKILLS = args.codexSkills;
   if (args.copilotSkills) env.YUKH_COPILOT_SKILLS = args.copilotSkills;
+  if (process.env.YUKH_COPILOT_WORKER_PROVIDER === "sdk") env.YUKH_COPILOT_WORKER_PROVIDER = "sdk";
   return env;
 }
 

--- a/apps/team-worker/src/copilot-sdk-runner.ts
+++ b/apps/team-worker/src/copilot-sdk-runner.ts
@@ -1,0 +1,148 @@
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { RuntimeOutput } from "../../../packages/team-control/src/runtime-output.js";
+import type { AgentRecord } from "../../../packages/team-control/src/store.js";
+
+interface CopilotSdkModule {
+  readonly CopilotClient: new (options: Record<string, unknown>) => {
+    start(): Promise<void>;
+    stop(): Promise<readonly Error[]>;
+    forceStop(): Promise<void>;
+    createSession(config: Record<string, unknown>): Promise<CopilotSdkSession>;
+  };
+  readonly RuntimeConnection: {
+    forStdio(options: { readonly path: string; readonly env: Record<string, string> }): unknown;
+  };
+}
+
+interface CopilotSdkSession {
+  on(handler: (event: unknown) => void): () => void;
+  sendAndWait(message: { readonly prompt: string }, timeout: number): Promise<unknown>;
+  disconnect?(): Promise<void>;
+}
+
+const importModule = new Function("specifier", "return import(specifier)") as (
+  specifier: string,
+) => Promise<unknown>;
+
+export interface CopilotSdkWorkerRunOptions {
+  readonly executable: string;
+  readonly workspace: string;
+  readonly prompt: string;
+  readonly agent: AgentRecord;
+  readonly timeoutMs: number;
+  readonly sdk?: CopilotSdkModule;
+}
+
+export interface WorkerRunOutcome {
+  readonly exitCode: number;
+  readonly stopped: boolean;
+  readonly bound?: "commands" | "deadline";
+  readonly output: RuntimeOutput;
+}
+
+export async function runCopilotSdkWorker({
+  executable,
+  workspace,
+  prompt,
+  agent,
+  timeoutMs,
+  sdk,
+}: CopilotSdkWorkerRunOptions): Promise<WorkerRunOutcome> {
+  const output = new RuntimeOutput("copilot");
+  const module = sdk ?? ((await importModule("@github/copilot-sdk")) as CopilotSdkModule);
+  const baseDirectory = join(workspace, ".yukh", "copilot-sdk");
+  mkdirSync(baseDirectory, { recursive: true, mode: 0o700 });
+  const client = new module.CopilotClient({
+    mode: "empty",
+    baseDirectory,
+    workingDirectory: workspace,
+    logLevel: "none",
+    connection: module.RuntimeConnection.forStdio({
+      path: executable,
+      env: {
+        HOME: process.env.HOME ?? "",
+        PATH: process.env.PATH ?? "/usr/bin:/bin",
+      },
+    }),
+  });
+  let deadline = false;
+  const timer = setTimeout(() => {
+    deadline = true;
+    void client.forceStop().catch(() => undefined);
+  }, timeoutMs);
+  try {
+    await client.start();
+    const session = await client.createSession({
+      clientName: "yukh-team-worker",
+      ...(agent.profile && agent.profile.model !== "default" ? { model: agent.profile.model } : {}),
+      availableTools: [],
+      infiniteSessions: { enabled: false },
+    });
+    session.on((event) => {
+      output.line(JSON.stringify(event));
+      captureCopilotSdkUsage(output, event);
+    });
+    const response = await session.sendAndWait({ prompt }, timeoutMs);
+    const content = assistantMessageContent(response);
+    if (content) output.setSummary(content);
+    await session.disconnect?.();
+    const errors = await client.stop();
+    return {
+      exitCode: errors.length === 0 && !deadline ? 0 : 1,
+      stopped: false,
+      ...(deadline ? { bound: "deadline" as const } : {}),
+      output,
+    };
+  } catch (error) {
+    if (deadline) {
+      return { exitCode: 1, stopped: false, bound: "deadline", output };
+    }
+    process.stderr.write(`yukh-team-worker: copilot sdk runner failed: ${errorMessage(error)}\n`);
+    await client.forceStop().catch(() => undefined);
+    return { exitCode: 1, stopped: false, output };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function captureCopilotSdkUsage(output: RuntimeOutput, event: unknown): void {
+  if (!record(event) || event.type !== "session.shutdown" || !record(event.data)) return;
+  const totals = Object.values(event.data.modelMetrics ?? {}).reduce(
+    (accumulator, metric) => {
+      if (!record(metric) || !record(metric.usage)) return accumulator;
+      const usage = metric.usage;
+      accumulator.input_tokens += safeInteger(usage.inputTokens);
+      accumulator.cached_input_tokens += safeInteger(usage.cacheReadTokens);
+      accumulator.output_tokens += safeInteger(usage.outputTokens);
+      accumulator.reasoning_output_tokens += safeInteger(usage.reasoningTokens);
+      return accumulator;
+    },
+    {
+      input_tokens: 0,
+      cached_input_tokens: 0,
+      output_tokens: 0,
+      reasoning_output_tokens: 0,
+    },
+  );
+  if (totals.input_tokens > 0 || totals.output_tokens > 0)
+    output.addUsage("copilot-sdk-v1", totals);
+}
+
+function assistantMessageContent(value: unknown): string {
+  return record(value) && record(value.data) && typeof value.data.content === "string"
+    ? value.data.content
+    : "";
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function safeInteger(value: unknown): number {
+  return Number.isSafeInteger(value) && Number(value) >= 0 ? Number(value) : 0;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "unknown";
+}

--- a/apps/team-worker/src/main.ts
+++ b/apps/team-worker/src/main.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
 import { RuntimeOutput } from "../../../packages/team-control/src/runtime-output.js";
 import { buildWorkerPrompt } from "./prompt.js";
+import { runCopilotSdkWorker } from "./copilot-sdk-runner.js";
 
 const required = (name: string): string => {
   const value = process.env[name];
@@ -115,6 +116,10 @@ const command =
   agent.runtime === "codex"
     ? required("YUKH_CODEX_EXECUTABLE")
     : required("YUKH_COPILOT_EXECUTABLE");
+const useCopilotSdk =
+  agent.runtime === "copilot" &&
+  modelToolMode === "none" &&
+  process.env.YUKH_COPILOT_WORKER_PROVIDER === "sdk";
 const args =
   agent.runtime === "codex"
     ? [
@@ -259,72 +264,80 @@ if (!joined) {
 
 const outcome = !joined
   ? { exitCode: 1, stopped: false }
-  : await new Promise<{
-      readonly exitCode: number;
-      readonly stopped: boolean;
-      readonly bound?: "commands" | "deadline";
-      readonly output: RuntimeOutput;
-    }>((resolve) => {
-      const output = new RuntimeOutput(agent.runtime);
-      const child = spawn(command, args, {
-        cwd: workspace,
-        detached: process.platform !== "win32",
-        shell: false,
-        stdio: ["ignore", "pipe", "pipe"],
-        env: { HOME: process.env.HOME ?? "", PATH: process.env.PATH ?? "/usr/bin:/bin" },
-      });
-      if (!child.stdout || !child.stderr) throw new Error("agent_output_unavailable");
-      child.stdout.pipe(process.stdout);
-      child.stderr.pipe(process.stderr);
-      const lines = createInterface({ input: child.stdout, crlfDelay: Infinity });
-      lines.on("line", (line) => output.line(line));
-      let stopped = false;
-      let bound: "commands" | "deadline" | undefined;
-      let terminating = false;
-      let killTimer: NodeJS.Timeout | undefined;
-      const terminate = (): void => {
-        if (terminating || !child.pid) return;
-        terminating = true;
-        try {
-          if (process.platform !== "win32") process.kill(-child.pid, "SIGTERM");
-          else child.kill("SIGTERM");
-        } catch {
-          child.kill("SIGTERM");
-        }
-        killTimer = setTimeout(() => {
+  : useCopilotSdk
+    ? await runCopilotSdkWorker({
+        executable: command,
+        workspace,
+        prompt,
+        agent,
+        timeoutMs: agent.timeout_ms ?? 300_000,
+      })
+    : await new Promise<{
+        readonly exitCode: number;
+        readonly stopped: boolean;
+        readonly bound?: "commands" | "deadline";
+        readonly output: RuntimeOutput;
+      }>((resolve) => {
+        const output = new RuntimeOutput(agent.runtime);
+        const child = spawn(command, args, {
+          cwd: workspace,
+          detached: process.platform !== "win32",
+          shell: false,
+          stdio: ["ignore", "pipe", "pipe"],
+          env: { HOME: process.env.HOME ?? "", PATH: process.env.PATH ?? "/usr/bin:/bin" },
+        });
+        if (!child.stdout || !child.stderr) throw new Error("agent_output_unavailable");
+        child.stdout.pipe(process.stdout);
+        child.stderr.pipe(process.stderr);
+        const lines = createInterface({ input: child.stdout, crlfDelay: Infinity });
+        lines.on("line", (line) => output.line(line));
+        let stopped = false;
+        let bound: "commands" | "deadline" | undefined;
+        let terminating = false;
+        let killTimer: NodeJS.Timeout | undefined;
+        const terminate = (): void => {
+          if (terminating || !child.pid) return;
+          terminating = true;
           try {
-            if (child.pid && process.platform !== "win32") process.kill(-child.pid, "SIGKILL");
-            else child.kill("SIGKILL");
+            if (process.platform !== "win32") process.kill(-child.pid, "SIGTERM");
+            else child.kill("SIGTERM");
           } catch {
-            child.kill("SIGKILL");
+            child.kill("SIGTERM");
           }
-        }, 5_000);
-      };
-      lines.on("line", () => {
-        if (bound || output.commandsStarted() <= (agent.max_commands ?? 8)) return;
-        bound = "commands";
-        terminate();
+          killTimer = setTimeout(() => {
+            try {
+              if (child.pid && process.platform !== "win32") process.kill(-child.pid, "SIGKILL");
+              else child.kill("SIGKILL");
+            } catch {
+              child.kill("SIGKILL");
+            }
+          }, 5_000);
+        };
+        lines.on("line", () => {
+          if (bound || output.commandsStarted() <= (agent.max_commands ?? 8)) return;
+          bound = "commands";
+          terminate();
+        });
+        const deadlineTimer = setTimeout(() => {
+          if (bound) return;
+          bound = "deadline";
+          terminate();
+        }, agent.timeout_ms ?? 300_000);
+        const monitor = setInterval(() => {
+          if (stopped || store.status(teamID).team.state !== "stopped") return;
+          stopped = true;
+          terminate();
+        }, 500);
+        const finish = (exitCode: number): void => {
+          clearInterval(monitor);
+          clearTimeout(deadlineTimer);
+          if (killTimer) clearTimeout(killTimer);
+          lines.close();
+          resolve({ exitCode, stopped, ...(bound ? { bound } : {}), output });
+        };
+        child.once("error", () => finish(1));
+        child.once("close", (code) => finish(code ?? 1));
       });
-      const deadlineTimer = setTimeout(() => {
-        if (bound) return;
-        bound = "deadline";
-        terminate();
-      }, agent.timeout_ms ?? 300_000);
-      const monitor = setInterval(() => {
-        if (stopped || store.status(teamID).team.state !== "stopped") return;
-        stopped = true;
-        terminate();
-      }, 500);
-      const finish = (exitCode: number): void => {
-        clearInterval(monitor);
-        clearTimeout(deadlineTimer);
-        if (killTimer) clearTimeout(killTimer);
-        lines.close();
-        resolve({ exitCode, stopped, ...(bound ? { bound } : {}), output });
-      };
-      child.once("error", () => finish(1));
-      child.once("close", (code) => finish(code ?? 1));
-    });
 let wrapperExitCode = outcome.stopped ? 0 : outcome.exitCode;
 if (joined && "output" in outcome) {
   if (outcome.stopped) {

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -837,6 +837,9 @@ usage is accepted only from its structured runtime event and is persisted with
 the bounded completion artifact. Missing accounting, missing completion,
 runtime failure and post-turn budget overrun are distinct fail-closed outcomes.
 Copilot credit or duration metadata is never represented as token usage.
+Issue #218 adds an opt-in Copilot SDK worker runner for tool-free workers only:
+SDK shutdown metrics may be persisted as `copilot-sdk-v1`, while absent or
+malformed SDK usage still fails closed as unavailable accounting.
 
 The current boundary cannot interrupt a model exactly at the token limit
 because the CLI reports usage at turn completion. It therefore detects and

--- a/packages/team-control/src/runtime-output.ts
+++ b/packages/team-control/src/runtime-output.ts
@@ -7,6 +7,8 @@ interface MutableUsage {
   reasoning_output_tokens: number;
 }
 
+type UsageSource = AgentUsage["source"];
+
 export class RuntimeOutput {
   readonly #runtime: "codex" | "copilot";
   #summary = "";
@@ -18,6 +20,7 @@ export class RuntimeOutput {
   };
   #usageObserved = false;
   #commandsStarted = 0;
+  #usageSource: UsageSource = "codex-json-v1";
 
   constructor(runtime: "codex" | "copilot") {
     this.#runtime = runtime;
@@ -46,12 +49,34 @@ export class RuntimeOutput {
     return this.#commandsStarted;
   }
 
+  setSummary(summary: string): void {
+    this.#summary = summary;
+  }
+
+  addUsage(source: UsageSource, usage: MutableUsage): void {
+    const counts = [
+      usage.input_tokens,
+      usage.cached_input_tokens,
+      usage.output_tokens,
+      usage.reasoning_output_tokens,
+    ];
+    if (counts.some((count) => !Number.isSafeInteger(count) || count < 0)) return;
+    if (usage.cached_input_tokens > usage.input_tokens) return;
+    if (usage.reasoning_output_tokens > usage.output_tokens) return;
+    this.#usageSource = source;
+    this.#usage.input_tokens += usage.input_tokens;
+    this.#usage.cached_input_tokens += usage.cached_input_tokens;
+    this.#usage.output_tokens += usage.output_tokens;
+    this.#usage.reasoning_output_tokens += usage.reasoning_output_tokens;
+    this.#usageObserved = true;
+  }
+
   usage(budget: number): AgentUsage | undefined {
     if (!this.#usageObserved) return undefined;
     const total = this.#usage.input_tokens + this.#usage.output_tokens;
     return {
       schema: 1,
-      source: "codex-json-v1",
+      source: this.#usageSource,
       ...this.#usage,
       total_tokens: total,
       budget_outcome: total <= budget ? "within" : "exceeded",
@@ -78,11 +103,12 @@ export class RuntimeOutput {
       usage.reasoning_output_tokens,
     ];
     if (counts.some((count) => !Number.isSafeInteger(count) || Number(count) < 0)) return;
-    this.#usage.input_tokens += Number(usage.input_tokens);
-    this.#usage.cached_input_tokens += Number(usage.cached_input_tokens);
-    this.#usage.output_tokens += Number(usage.output_tokens);
-    this.#usage.reasoning_output_tokens += Number(usage.reasoning_output_tokens);
-    this.#usageObserved = true;
+    this.addUsage("codex-json-v1", {
+      input_tokens: Number(usage.input_tokens),
+      cached_input_tokens: Number(usage.cached_input_tokens),
+      output_tokens: Number(usage.output_tokens),
+      reasoning_output_tokens: Number(usage.reasoning_output_tokens),
+    });
   }
 
   #copilot(event: Record<string, unknown>): void {

--- a/packages/team-control/src/store.ts
+++ b/packages/team-control/src/store.ts
@@ -19,7 +19,7 @@ export type AgentState = "defined" | "running" | "completed" | "failed" | "stopp
 
 export interface AgentUsage {
   readonly schema: 1;
-  readonly source: "codex-json-v1";
+  readonly source: "codex-json-v1" | "copilot-sdk-v1";
   readonly input_tokens: number;
   readonly cached_input_tokens: number;
   readonly output_tokens: number;
@@ -938,7 +938,7 @@ export class TeamStore {
     ];
     if (
       usage.schema !== 1 ||
-      usage.source !== "codex-json-v1" ||
+      !["codex-json-v1", "copilot-sdk-v1"].includes(usage.source) ||
       counts.some((value) => !Number.isSafeInteger(value) || value < 0) ||
       usage.total_tokens !== usage.input_tokens + usage.output_tokens ||
       usage.cached_input_tokens > usage.input_tokens ||

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -20,6 +20,7 @@ import {
 import { runApprovedPlanWithDependencies } from "../../apps/team-preflight/src/plan-execute.js";
 import { runEngagePreflight } from "../../apps/team-preflight/src/preflight.js";
 import { buildWorkerPrompt, isMicroWorker } from "../../apps/team-worker/src/prompt.js";
+import { runCopilotSdkWorker } from "../../apps/team-worker/src/copilot-sdk-runner.js";
 import {
   copilotModelCatalogFromDiscoveries,
   parseCodexModelCatalog,
@@ -1565,6 +1566,25 @@ test("runtime output extracts Codex completion and refuses invented Copilot toke
   );
   assert.equal(copilot.usage(50_000), undefined);
 
+  copilot.setSummary("SDK completion");
+  copilot.addUsage("copilot-sdk-v1", {
+    input_tokens: 120,
+    cached_input_tokens: 30,
+    output_tokens: 40,
+    reasoning_output_tokens: 10,
+  });
+  assert.equal(copilot.summary(), "SDK completion");
+  assert.deepEqual(copilot.usage(200), {
+    schema: 1,
+    source: "copilot-sdk-v1",
+    input_tokens: 120,
+    cached_input_tokens: 30,
+    output_tokens: 40,
+    reasoning_output_tokens: 10,
+    total_tokens: 160,
+    budget_outcome: "within",
+  });
+
   const malformed = new RuntimeOutput("codex");
   malformed.line(
     JSON.stringify({
@@ -1585,6 +1605,102 @@ test("runtime output extracts Codex completion and refuses invented Copilot toke
   );
   assert.equal(malformed.usage(50_000), undefined);
   assert.equal(malformed.summary(), "");
+});
+
+test("copilot sdk worker runs tool-free empty sessions with shutdown token accounting", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-copilot-sdk-worker-")));
+  try {
+    const store = new TeamStore(root);
+    const team = store.create("SDK probe", "copilot");
+    const agent = store.spawn(team.team_id, {
+      runtime: "copilot",
+      role: "sdk-reviewer",
+      task: "Summarize only",
+      profile: {
+        schema: 1,
+        mission: "Review",
+        model: "copilot-test-model",
+        skills: [],
+        instructions: "Be brief",
+      },
+      model_tool_mode: "none",
+      token_budget: 1_000,
+    });
+    const createdClients: Record<string, unknown>[] = [];
+    const createdSessions: Record<string, unknown>[] = [];
+    const sdk = {
+      RuntimeConnection: {
+        forStdio(options: unknown) {
+          return { kind: "stdio", options };
+        },
+      },
+      CopilotClient: class {
+        constructor(options: Record<string, unknown>) {
+          createdClients.push(options);
+        }
+        async start(): Promise<void> {}
+        async stop(): Promise<readonly Error[]> {
+          return [];
+        }
+        async forceStop(): Promise<void> {}
+        async createSession(config: Record<string, unknown>) {
+          createdSessions.push(config);
+          let handler: (event: unknown) => void = () => undefined;
+          return {
+            on(next: (event: unknown) => void) {
+              handler = next;
+              return () => undefined;
+            },
+            async sendAndWait() {
+              handler({
+                type: "session.shutdown",
+                data: {
+                  modelMetrics: {
+                    "copilot-test-model": {
+                      usage: {
+                        inputTokens: 80,
+                        cacheReadTokens: 20,
+                        cacheWriteTokens: 5,
+                        outputTokens: 30,
+                        reasoningTokens: 7,
+                      },
+                    },
+                  },
+                },
+              });
+              return { data: { content: "SDK worker complete" } };
+            },
+            async disconnect(): Promise<void> {},
+          };
+        }
+      },
+    };
+    const outcome = await runCopilotSdkWorker({
+      executable: "/bin/copilot",
+      workspace: root,
+      prompt: "Do the task",
+      agent,
+      timeoutMs: 1_000,
+      sdk,
+    });
+    assert.equal(outcome.exitCode, 0);
+    assert.equal(outcome.output.summary(), "SDK worker complete");
+    assert.deepEqual(outcome.output.usage(1_000), {
+      schema: 1,
+      source: "copilot-sdk-v1",
+      input_tokens: 80,
+      cached_input_tokens: 20,
+      output_tokens: 30,
+      reasoning_output_tokens: 7,
+      total_tokens: 110,
+      budget_outcome: "within",
+    });
+    assert.deepEqual(createdClients[0]?.mode, "empty");
+    assert.deepEqual(createdSessions[0]?.availableTools, []);
+    assert.equal(createdSessions[0]?.model, "copilot-test-model");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 test("legacy teams stay readable but cannot bypass explicit token allocation", async () => {


### PR DESCRIPTION
Closes #218.\n\n## Summary\n- add an opt-in Copilot SDK runner for tool-free team workers via YUKH_COPILOT_WORKER_PROVIDER=sdk\n- persist trusted SDK shutdown token metrics as copilot-sdk-v1 while keeping missing/malformed accounting fail-closed\n- propagate the SDK worker provider setting through team-control, run-approved, and deterministic plan execution\n- update the threat model and add runtime coverage\n\n## Context impact\n- Updates docs/security/threat-model.md for issue #218.\n- No new RFC: this narrows execution to RFC-0025 tool-free workers and extends RFC-0020 accounting with a trusted SDK source; default CLI behavior is unchanged.\n\n## Validation\n- npm run -s typecheck\n- npm run -s build\n- npm run -s format:check\n- npm run -s test:runtime\n- git diff --check\n