### PR TITLE
Add Codex Python worker provider

### DIFF
--- a/.context/sessions/SESSION-2026-08-17-03-codex-python-worker-provider.md
+++ b/.context/sessions/SESSION-2026-08-17-03-codex-python-worker-provider.md
@@ -1,0 +1,47 @@
+# SESSION-2026-08-17-03 — Codex Python worker provider
+
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/224
+- Scope: opt-in Codex Python app-server provider for real `team-worker`
+
+## Implemented
+
+`YUKH_CODEX_WORKER_PROVIDER=python-app-server` now routes Codex workers through
+the Python `openai-codex` app-server path when the worker is tool-free
+(`tool_mode: none`). The default Codex provider remains the CLI runner.
+
+The provider:
+
+- starts a Codex Python app-server client per worker wrapper;
+- uses read-only sandbox and deny-all approvals;
+- disables web search;
+- records token usage as `codex-python-app-server-v1`;
+- fails closed through the existing `token_accounting_unavailable` path when
+  usage is absent.
+
+`YUKH_CODEX_PYTHON_EXECUTABLE` can select the Python interpreter. The env opt-in
+is propagated through team-control, approved preflight and approved plan
+execution.
+
+## Token floor
+
+The CLI floor stays at 120,000 tokens. With the Python app-server provider
+enabled, tool-free Codex workers use an 18,000 token floor based on the #222
+real-prompt qualification, which observed 10,830 total tokens in the safe
+no-context run.
+
+## Live runner probe
+
+A real provider smoke test with `gpt-5.6-terra` completed through
+`runCodexPythonWorker` with no repository context:
+
+- input tokens: 10,652
+- cached input tokens: 3,840
+- output tokens: 15
+- total tokens: 10,667
+- budget outcome: within an 18,000 token worker budget
+
+## Remaining constraint
+
+This does not yet multiplex multiple Yukh workers through one long-lived Codex
+Python client. It removes the CLI `exec` path for eligible tool-free workers,
+but each worker wrapper still owns its runtime lifecycle.

--- a/apps/team-control/src/main.ts
+++ b/apps/team-control/src/main.ts
@@ -32,7 +32,13 @@ const profileEnvironment = {
   YUKH_CODEX_MODEL_SOURCE: codexCatalog.source,
   YUKH_COPILOT_MODEL_SOURCE: copilotCatalog.source,
   ...Object.fromEntries(
-    ["YUKH_CODEX_SKILLS", "YUKH_COPILOT_SKILLS", "YUKH_COPILOT_WORKER_PROVIDER"]
+    [
+      "YUKH_CODEX_SKILLS",
+      "YUKH_COPILOT_SKILLS",
+      "YUKH_CODEX_WORKER_PROVIDER",
+      "YUKH_CODEX_PYTHON_EXECUTABLE",
+      "YUKH_COPILOT_WORKER_PROVIDER",
+    ]
       .filter((name) => process.env[name] !== undefined)
       .map((name) => [name, process.env[name]!] as const),
   ),

--- a/apps/team-preflight/src/approved-run.ts
+++ b/apps/team-preflight/src/approved-run.ts
@@ -57,6 +57,10 @@ function profileEnvironment(args: ApprovedRunArguments): Readonly<Record<string,
   if (args.copilotModels) env.YUKH_COPILOT_MODELS = args.copilotModels;
   if (args.codexSkills) env.YUKH_CODEX_SKILLS = args.codexSkills;
   if (args.copilotSkills) env.YUKH_COPILOT_SKILLS = args.copilotSkills;
+  if (process.env.YUKH_CODEX_WORKER_PROVIDER === "python-app-server")
+    env.YUKH_CODEX_WORKER_PROVIDER = "python-app-server";
+  if (process.env.YUKH_CODEX_PYTHON_EXECUTABLE)
+    env.YUKH_CODEX_PYTHON_EXECUTABLE = process.env.YUKH_CODEX_PYTHON_EXECUTABLE;
   if (process.env.YUKH_COPILOT_WORKER_PROVIDER === "sdk") env.YUKH_COPILOT_WORKER_PROVIDER = "sdk";
   return env;
 }

--- a/apps/team-preflight/src/plan-execute.ts
+++ b/apps/team-preflight/src/plan-execute.ts
@@ -38,6 +38,10 @@ function profileEnvironment(args: ApprovedPlanRunArguments): Readonly<Record<str
   if (args.copilotModels) env.YUKH_COPILOT_MODELS = args.copilotModels;
   if (args.codexSkills) env.YUKH_CODEX_SKILLS = args.codexSkills;
   if (args.copilotSkills) env.YUKH_COPILOT_SKILLS = args.copilotSkills;
+  if (process.env.YUKH_CODEX_WORKER_PROVIDER === "python-app-server")
+    env.YUKH_CODEX_WORKER_PROVIDER = "python-app-server";
+  if (process.env.YUKH_CODEX_PYTHON_EXECUTABLE)
+    env.YUKH_CODEX_PYTHON_EXECUTABLE = process.env.YUKH_CODEX_PYTHON_EXECUTABLE;
   if (process.env.YUKH_COPILOT_WORKER_PROVIDER === "sdk") env.YUKH_COPILOT_WORKER_PROVIDER = "sdk";
   return env;
 }

--- a/apps/team-preflight/src/runtime-floor.ts
+++ b/apps/team-preflight/src/runtime-floor.ts
@@ -4,13 +4,23 @@ export interface RuntimeTokenFloor {
   readonly schema: 1;
   readonly applies: true;
   readonly runtime: "codex";
+  readonly provider: "cli" | "python-app-server";
   readonly minimum_token_budget: number;
   readonly measured_total_tokens: number;
   readonly measured_cached_input_tokens: number;
   readonly reason: string;
 }
 
-export function runtimeTokenFloor(worker: AgentRecord): RuntimeTokenFloor | undefined {
+export function codexWorkerProvider(): "cli" | "python-app-server" {
+  return process.env.YUKH_CODEX_WORKER_PROVIDER === "python-app-server"
+    ? "python-app-server"
+    : "cli";
+}
+
+export function runtimeTokenFloor(
+  worker: AgentRecord,
+  provider: "cli" | "python-app-server" = codexWorkerProvider(),
+): RuntimeTokenFloor | undefined {
   if (
     worker.runtime !== "codex" ||
     (worker.model_tool_mode ?? "default") !== "none" ||
@@ -22,16 +32,30 @@ export function runtimeTokenFloor(worker: AgentRecord): RuntimeTokenFloor | unde
     schema: 1,
     applies: true,
     runtime: "codex",
-    minimum_token_budget: 120_000,
-    measured_total_tokens: 116_713,
-    measured_cached_input_tokens: 89_600,
-    reason:
-      "Codex CLI one-command workers have a measured cached input floor near 90k tokens, so smaller total-token budgets are not launch-safe with the CLI runner.",
+    provider,
+    ...(provider === "python-app-server"
+      ? {
+          minimum_token_budget: 18_000,
+          measured_total_tokens: 10_830,
+          measured_cached_input_tokens: 10_112,
+          reason:
+            "Codex Python app-server tool-free workers qualified at 10,830 total tokens with the real Yukh prompt; 18k keeps a conservative launch floor for this opt-in provider.",
+        }
+      : {
+          minimum_token_budget: 120_000,
+          measured_total_tokens: 116_713,
+          measured_cached_input_tokens: 89_600,
+          reason:
+            "Codex CLI one-command workers have a measured cached input floor near 90k tokens, so smaller total-token budgets are not launch-safe with the CLI runner.",
+        }),
   };
 }
 
-export function assertRuntimeTokenFloor(worker: AgentRecord): void {
-  const floor = runtimeTokenFloor(worker);
+export function assertRuntimeTokenFloor(
+  worker: AgentRecord,
+  provider: "cli" | "python-app-server" = codexWorkerProvider(),
+): void {
+  const floor = runtimeTokenFloor(worker, provider);
   if (floor && worker.token_budget < floor.minimum_token_budget)
     throw new Error("worker_token_budget_below_runtime_floor");
 }

--- a/apps/team-worker/src/codex-python-runner.ts
+++ b/apps/team-worker/src/codex-python-runner.ts
@@ -1,0 +1,186 @@
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { RuntimeOutput } from "../../../packages/team-control/src/runtime-output.js";
+import type { AgentRecord } from "../../../packages/team-control/src/store.js";
+import type { WorkerRunOutcome } from "./copilot-sdk-runner.js";
+
+export interface CodexPythonWorkerRunOptions {
+  readonly executable: string;
+  readonly python: string;
+  readonly workspace: string;
+  readonly prompt: string;
+  readonly agent: AgentRecord;
+  readonly timeoutMs: number;
+  readonly workerSource?: string;
+}
+
+export async function runCodexPythonWorker({
+  executable,
+  python,
+  workspace,
+  prompt,
+  agent,
+  timeoutMs,
+  workerSource,
+}: CodexPythonWorkerRunOptions): Promise<WorkerRunOutcome> {
+  const output = new RuntimeOutput("codex");
+  const temporary = mkdtempSync(join(tmpdir(), "yukh-codex-python-worker."));
+  const promptPath = join(temporary, "prompt.txt");
+  const probePath = join(temporary, "worker.py");
+  writeFileSync(promptPath, prompt, { mode: 0o600 });
+  writeFileSync(probePath, workerSource ?? pythonWorkerSource(), { mode: 0o600 });
+
+  return await new Promise<WorkerRunOutcome>((resolve) => {
+    let bound: "deadline" | undefined;
+    const child = spawn(python, [probePath], {
+      cwd: workspace,
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        HOME: process.env.HOME ?? "",
+        PATH: process.env.PATH ?? "/usr/bin:/bin",
+        YUKH_CODEX_EXECUTABLE: executable,
+        YUKH_CODEX_PYTHON_PROMPT_PATH: promptPath,
+        YUKH_CODEX_PYTHON_MODEL: agent.profile?.model ?? "default",
+      },
+    });
+    if (!child.stdout || !child.stderr) throw new Error("agent_output_unavailable");
+    child.stderr.pipe(process.stderr);
+    const chunks: Buffer[] = [];
+    child.stdout.on("data", (chunk: Buffer) => chunks.push(chunk));
+    let stdoutEnded = false;
+    let closed = false;
+    let childExitCode = 1;
+    const timer = setTimeout(() => {
+      bound = "deadline";
+      child.kill("SIGTERM");
+    }, timeoutMs);
+    const killTimer = setTimeout(() => {
+      if (bound) child.kill("SIGKILL");
+    }, timeoutMs + 5_000);
+    child.once("error", () => {
+      clearTimeout(timer);
+      clearTimeout(killTimer);
+      rmSync(temporary, { recursive: true, force: true });
+      resolve({ exitCode: 1, stopped: false, output });
+    });
+    const maybeFinish = (): void => {
+      if (!stdoutEnded || !closed) return;
+      clearTimeout(timer);
+      clearTimeout(killTimer);
+      try {
+        const result = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+          readonly final_response?: unknown;
+          readonly usage_last?: unknown;
+        };
+        if (typeof result.final_response === "string") output.setSummary(result.final_response);
+        if (record(result.usage_last))
+          output.addUsage("codex-python-app-server-v1", {
+            input_tokens: safeInteger(result.usage_last.input_tokens),
+            cached_input_tokens: safeInteger(result.usage_last.cached_input_tokens),
+            output_tokens: safeInteger(result.usage_last.output_tokens),
+            reasoning_output_tokens: safeInteger(result.usage_last.reasoning_output_tokens),
+          });
+      } catch {
+        // The wrapper fails closed below through exitCode and missing accounting.
+        process.stderr.write(
+          `yukh-team-worker: codex python runner emitted invalid output bytes=${Buffer.concat(chunks).length}\n`,
+        );
+      } finally {
+        rmSync(temporary, { recursive: true, force: true });
+      }
+      resolve({ exitCode: childExitCode, stopped: false, ...(bound ? { bound } : {}), output });
+    };
+    child.stdout.once("end", () => {
+      stdoutEnded = true;
+      maybeFinish();
+    });
+    child.once("close", (code) => {
+      closed = true;
+      childExitCode = code ?? 1;
+      maybeFinish();
+    });
+  });
+}
+
+function pythonWorkerSource(): string {
+  return String.raw`
+import json
+import os
+from pathlib import Path
+
+from openai_codex import ApprovalMode, Codex, CodexConfig, Sandbox
+
+codex_bin = os.environ["YUKH_CODEX_EXECUTABLE"]
+workspace = os.getcwd()
+prompt = Path(os.environ["YUKH_CODEX_PYTHON_PROMPT_PATH"]).read_text()
+model = os.environ.get("YUKH_CODEX_PYTHON_MODEL", "default")
+
+config = CodexConfig(
+    codex_bin=codex_bin,
+    cwd=workspace,
+    env={
+        "HOME": os.environ.get("HOME", ""),
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+    },
+    config_overrides=('web_search="disabled"',),
+)
+
+
+def breakdown(value):
+    if value is None:
+        return None
+    return {
+        name: getattr(value, name)
+        for name in (
+            "cached_input_tokens",
+            "input_tokens",
+            "output_tokens",
+            "reasoning_output_tokens",
+            "total_tokens",
+        )
+    }
+
+
+with Codex(config) as codex:
+    thread = codex.thread_start(
+        cwd=workspace,
+        sandbox=Sandbox.read_only,
+        approval_mode=ApprovalMode.deny_all,
+        ephemeral=True,
+    )
+    run_options = {
+        "sandbox": Sandbox.read_only,
+        "approval_mode": ApprovalMode.deny_all,
+        "effort": "low",
+        "summary": "none",
+    }
+    if model != "default":
+        run_options["model"] = model
+    result = thread.run(prompt, **run_options)
+    print(
+        json.dumps(
+            {
+                "schema": 1,
+                "status": result.status.value,
+                "thread_id": thread.id,
+                "turn_id": result.id,
+                "duration_ms": result.duration_ms,
+                "final_response": result.final_response or "",
+                "usage_last": breakdown(result.usage.last if result.usage else None),
+            },
+            sort_keys=True,
+        )
+    )
+`;
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function safeInteger(value: unknown): number {
+  return Number.isSafeInteger(value) && Number(value) >= 0 ? Number(value) : 0;
+}

--- a/apps/team-worker/src/main.ts
+++ b/apps/team-worker/src/main.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
 import { RuntimeOutput } from "../../../packages/team-control/src/runtime-output.js";
 import { buildWorkerPrompt } from "./prompt.js";
+import { runCodexPythonWorker } from "./codex-python-runner.js";
 import { runCopilotSdkWorker } from "./copilot-sdk-runner.js";
 
 const required = (name: string): string => {
@@ -105,6 +106,8 @@ const teamControlEnv = {
       "YUKH_COPILOT_MODEL_SOURCE",
       "YUKH_CODEX_SKILLS",
       "YUKH_COPILOT_SKILLS",
+      "YUKH_CODEX_WORKER_PROVIDER",
+      "YUKH_CODEX_PYTHON_EXECUTABLE",
       "YUKH_ENABLE_UNSAFE_DYNAMIC_WORKERS",
     ]
       .filter((name) => process.env[name] !== undefined)
@@ -120,6 +123,10 @@ const useCopilotSdk =
   agent.runtime === "copilot" &&
   modelToolMode === "none" &&
   process.env.YUKH_COPILOT_WORKER_PROVIDER === "sdk";
+const useCodexPython =
+  agent.runtime === "codex" &&
+  modelToolMode === "none" &&
+  process.env.YUKH_CODEX_WORKER_PROVIDER === "python-app-server";
 const args =
   agent.runtime === "codex"
     ? [
@@ -264,80 +271,89 @@ if (!joined) {
 
 const outcome = !joined
   ? { exitCode: 1, stopped: false }
-  : useCopilotSdk
-    ? await runCopilotSdkWorker({
+  : useCodexPython
+    ? await runCodexPythonWorker({
         executable: command,
+        python: process.env.YUKH_CODEX_PYTHON_EXECUTABLE ?? "python3",
         workspace,
         prompt,
         agent,
         timeoutMs: agent.timeout_ms ?? 300_000,
       })
-    : await new Promise<{
-        readonly exitCode: number;
-        readonly stopped: boolean;
-        readonly bound?: "commands" | "deadline";
-        readonly output: RuntimeOutput;
-      }>((resolve) => {
-        const output = new RuntimeOutput(agent.runtime);
-        const child = spawn(command, args, {
-          cwd: workspace,
-          detached: process.platform !== "win32",
-          shell: false,
-          stdio: ["ignore", "pipe", "pipe"],
-          env: { HOME: process.env.HOME ?? "", PATH: process.env.PATH ?? "/usr/bin:/bin" },
-        });
-        if (!child.stdout || !child.stderr) throw new Error("agent_output_unavailable");
-        child.stdout.pipe(process.stdout);
-        child.stderr.pipe(process.stderr);
-        const lines = createInterface({ input: child.stdout, crlfDelay: Infinity });
-        lines.on("line", (line) => output.line(line));
-        let stopped = false;
-        let bound: "commands" | "deadline" | undefined;
-        let terminating = false;
-        let killTimer: NodeJS.Timeout | undefined;
-        const terminate = (): void => {
-          if (terminating || !child.pid) return;
-          terminating = true;
-          try {
-            if (process.platform !== "win32") process.kill(-child.pid, "SIGTERM");
-            else child.kill("SIGTERM");
-          } catch {
-            child.kill("SIGTERM");
-          }
-          killTimer = setTimeout(() => {
+    : useCopilotSdk
+      ? await runCopilotSdkWorker({
+          executable: command,
+          workspace,
+          prompt,
+          agent,
+          timeoutMs: agent.timeout_ms ?? 300_000,
+        })
+      : await new Promise<{
+          readonly exitCode: number;
+          readonly stopped: boolean;
+          readonly bound?: "commands" | "deadline";
+          readonly output: RuntimeOutput;
+        }>((resolve) => {
+          const output = new RuntimeOutput(agent.runtime);
+          const child = spawn(command, args, {
+            cwd: workspace,
+            detached: process.platform !== "win32",
+            shell: false,
+            stdio: ["ignore", "pipe", "pipe"],
+            env: { HOME: process.env.HOME ?? "", PATH: process.env.PATH ?? "/usr/bin:/bin" },
+          });
+          if (!child.stdout || !child.stderr) throw new Error("agent_output_unavailable");
+          child.stdout.pipe(process.stdout);
+          child.stderr.pipe(process.stderr);
+          const lines = createInterface({ input: child.stdout, crlfDelay: Infinity });
+          lines.on("line", (line) => output.line(line));
+          let stopped = false;
+          let bound: "commands" | "deadline" | undefined;
+          let terminating = false;
+          let killTimer: NodeJS.Timeout | undefined;
+          const terminate = (): void => {
+            if (terminating || !child.pid) return;
+            terminating = true;
             try {
-              if (child.pid && process.platform !== "win32") process.kill(-child.pid, "SIGKILL");
-              else child.kill("SIGKILL");
+              if (process.platform !== "win32") process.kill(-child.pid, "SIGTERM");
+              else child.kill("SIGTERM");
             } catch {
-              child.kill("SIGKILL");
+              child.kill("SIGTERM");
             }
-          }, 5_000);
-        };
-        lines.on("line", () => {
-          if (bound || output.commandsStarted() <= (agent.max_commands ?? 8)) return;
-          bound = "commands";
-          terminate();
+            killTimer = setTimeout(() => {
+              try {
+                if (child.pid && process.platform !== "win32") process.kill(-child.pid, "SIGKILL");
+                else child.kill("SIGKILL");
+              } catch {
+                child.kill("SIGKILL");
+              }
+            }, 5_000);
+          };
+          lines.on("line", () => {
+            if (bound || output.commandsStarted() <= (agent.max_commands ?? 8)) return;
+            bound = "commands";
+            terminate();
+          });
+          const deadlineTimer = setTimeout(() => {
+            if (bound) return;
+            bound = "deadline";
+            terminate();
+          }, agent.timeout_ms ?? 300_000);
+          const monitor = setInterval(() => {
+            if (stopped || store.status(teamID).team.state !== "stopped") return;
+            stopped = true;
+            terminate();
+          }, 500);
+          const finish = (exitCode: number): void => {
+            clearInterval(monitor);
+            clearTimeout(deadlineTimer);
+            if (killTimer) clearTimeout(killTimer);
+            lines.close();
+            resolve({ exitCode, stopped, ...(bound ? { bound } : {}), output });
+          };
+          child.once("error", () => finish(1));
+          child.once("close", (code) => finish(code ?? 1));
         });
-        const deadlineTimer = setTimeout(() => {
-          if (bound) return;
-          bound = "deadline";
-          terminate();
-        }, agent.timeout_ms ?? 300_000);
-        const monitor = setInterval(() => {
-          if (stopped || store.status(teamID).team.state !== "stopped") return;
-          stopped = true;
-          terminate();
-        }, 500);
-        const finish = (exitCode: number): void => {
-          clearInterval(monitor);
-          clearTimeout(deadlineTimer);
-          if (killTimer) clearTimeout(killTimer);
-          lines.close();
-          resolve({ exitCode, stopped, ...(bound ? { bound } : {}), output });
-        };
-        child.once("error", () => finish(1));
-        child.once("close", (code) => finish(code ?? 1));
-      });
 let wrapperExitCode = outcome.stopped ? 0 : outcome.exitCode;
 if (joined && "output" in outcome) {
   if (outcome.stopped) {

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -116,6 +116,19 @@ override or narrow that discovered list. Skills remain explicit local policy:
 env = { YUKH_CODEX_MODELS = "default,approved-codex-model", YUKH_COPILOT_MODELS = "default,approved-copilot-model", YUKH_CODEX_SKILLS = "api-design,testing,review", YUKH_COPILOT_SKILLS = "frontend,testing,product" }
 ```
 
+Codex workers use the CLI runner by default. For tool-free Codex workers, opt
+into the lower-overhead Python app-server provider only after installing
+`openai-codex` for the selected Python:
+
+```toml
+env = { YUKH_CODEX_WORKER_PROVIDER = "python-app-server", YUKH_CODEX_PYTHON_EXECUTABLE = "/absolute/path/to/python3" }
+```
+
+This provider is used only when the worker runs with `tool_mode: none`; workers
+that need Coordination or team-control tools stay on the CLI path. The preflight
+token floor remains 120k for the CLI and becomes 18k for the opt-in Python
+app-server path.
+
 Start work with `manager.start`, not `team.create`. It creates the team and a
 depth-zero manager runtime together, reserves the manager budget and returns a
 server receipt plus the manager agent ID. Use `agent.await` from the controlling

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -909,3 +909,9 @@ Issue #222 adds a guarded Codex Python app-server qualification for the real
 Yukh worker prompt. It is inert unless explicitly enabled and sends no
 repository file content by default. Optional context paths are bounded to the
 same small-file shape used by zero-command workers.
+
+Issue #224 wires that Codex Python app-server path into real team-worker
+execution behind `YUKH_CODEX_WORKER_PROVIDER=python-app-server`. The default
+Codex CLI path remains unchanged. The Python provider is limited to tool-free
+workers, runs with read-only sandbox and deny-all approvals, records usage as
+`codex-python-app-server-v1` and fails closed if token accounting is absent.

--- a/packages/team-control/src/store.ts
+++ b/packages/team-control/src/store.ts
@@ -19,7 +19,7 @@ export type AgentState = "defined" | "running" | "completed" | "failed" | "stopp
 
 export interface AgentUsage {
   readonly schema: 1;
-  readonly source: "codex-json-v1" | "copilot-sdk-v1";
+  readonly source: "codex-json-v1" | "codex-python-app-server-v1" | "copilot-sdk-v1";
   readonly input_tokens: number;
   readonly cached_input_tokens: number;
   readonly output_tokens: number;
@@ -938,7 +938,7 @@ export class TeamStore {
     ];
     if (
       usage.schema !== 1 ||
-      !["codex-json-v1", "copilot-sdk-v1"].includes(usage.source) ||
+      !["codex-json-v1", "codex-python-app-server-v1", "copilot-sdk-v1"].includes(usage.source) ||
       counts.some((value) => !Number.isSafeInteger(value) || value < 0) ||
       usage.total_tokens !== usage.input_tokens + usage.output_tokens ||
       usage.cached_input_tokens > usage.input_tokens ||

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -10,6 +10,7 @@ import { TeamSupervisor } from "../../packages/team-control/src/supervisor.js";
 import { RuntimeOutput } from "../../packages/team-control/src/runtime-output.js";
 import { teamRuntimeEntrypoints } from "../../packages/team-control/src/entrypoints.js";
 import { parsePreflightArguments } from "../../apps/team-preflight/src/arguments.js";
+import { runCodexPythonWorker } from "../../apps/team-worker/src/codex-python-runner.js";
 import { runApprovedPreflight } from "../../apps/team-preflight/src/approved-run.js";
 import {
   formatApprovedPlanRun,
@@ -19,6 +20,7 @@ import {
 } from "../../apps/team-preflight/src/format.js";
 import { runApprovedPlanWithDependencies } from "../../apps/team-preflight/src/plan-execute.js";
 import { runEngagePreflight } from "../../apps/team-preflight/src/preflight.js";
+import { runtimeTokenFloor } from "../../apps/team-preflight/src/runtime-floor.js";
 import { buildWorkerPrompt, isMicroWorker } from "../../apps/team-worker/src/prompt.js";
 import { runCopilotSdkWorker } from "../../apps/team-worker/src/copilot-sdk-runner.js";
 import {
@@ -687,6 +689,42 @@ test("approved preflight blocks measured Codex CLI token floors before provider 
     assert.equal(worker.state, "defined");
     assert.equal(store.status(preflight.team.team_id).tokens.observed, 0);
   } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("Codex Python app-server opt-in uses the qualified lower token floor", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-codex-python-floor-")));
+  const previous = process.env.YUKH_CODEX_WORKER_PROVIDER;
+  try {
+    const preflight = runEngagePreflight({
+      workspace: root,
+      goal: "Review one bounded context pack",
+      role: "backend-reviewer",
+      workProfile: "review",
+      preferredRuntime: "codex",
+      teamBudget: 90_000,
+      managerBudget: 20_000,
+      workerBudget: 45_000,
+      workerMaxCommands: 1,
+      workerTimeoutMs: 180_000,
+      codexModels: ["default"],
+      copilotModels: ["default"],
+      codexSkills: ["api-design", "testing"],
+      copilotSkills: ["frontend"],
+    });
+    assert.equal(runtimeTokenFloor(preflight.planned_worker)?.provider, "cli");
+    assert.equal(runtimeTokenFloor(preflight.planned_worker)?.minimum_token_budget, 120_000);
+
+    process.env.YUKH_CODEX_WORKER_PROVIDER = "python-app-server";
+    const floor = runtimeTokenFloor(preflight.planned_worker);
+    assert.equal(floor?.provider, "python-app-server");
+    assert.equal(floor?.minimum_token_budget, 18_000);
+    assert.equal(floor?.measured_total_tokens, 10_830);
+    assert.match(floor?.reason ?? "", /real Yukh prompt/u);
+  } finally {
+    if (previous === undefined) delete process.env.YUKH_CODEX_WORKER_PROVIDER;
+    else process.env.YUKH_CODEX_WORKER_PROVIDER = previous;
     await rm(root, { recursive: true, force: true });
   }
 });
@@ -1698,6 +1736,67 @@ test("copilot sdk worker runs tool-free empty sessions with shutdown token accou
     assert.deepEqual(createdClients[0]?.mode, "empty");
     assert.deepEqual(createdSessions[0]?.availableTools, []);
     assert.equal(createdSessions[0]?.model, "copilot-test-model");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("codex python app-server worker captures final response and token accounting", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-codex-python-worker-")));
+  try {
+    const store = new TeamStore(root);
+    const team = store.create("Codex Python probe", "codex");
+    const agent = store.spawn(team.team_id, {
+      runtime: "codex",
+      role: "python-reviewer",
+      task: "Summarize only",
+      profile: {
+        schema: 1,
+        mission: "Review",
+        model: "codex-test-model",
+        skills: [],
+        instructions: "Be brief",
+      },
+      model_tool_mode: "none",
+      token_budget: 1_000,
+    });
+    const outcome = await runCodexPythonWorker({
+      executable: "/bin/codex",
+      python: process.env.PYTHON ?? "python3",
+      workspace: root,
+      prompt: "Do the task",
+      agent,
+      timeoutMs: 1_000,
+      workerSource: [
+        "import json",
+        "import os",
+        "required = ['YUKH_CODEX_EXECUTABLE', 'YUKH_CODEX_PYTHON_PROMPT_PATH']",
+        "if any(name not in os.environ for name in required): raise SystemExit(2)",
+        "print(json.dumps({",
+        "  'schema': 1,",
+        "  'status': 'completed',",
+        "  'final_response': 'Codex Python worker complete',",
+        "  'usage_last': {",
+        "    'input_tokens': 90,",
+        "    'cached_input_tokens': 40,",
+        "    'output_tokens': 25,",
+        "    'reasoning_output_tokens': 5,",
+        "  },",
+        "}))",
+      ].join("\n"),
+    });
+    assert.equal(outcome.exitCode, 0);
+    assert.equal(outcome.output.summary(), "Codex Python worker complete");
+    assert.deepEqual(outcome.output.usage(1_000), {
+      schema: 1,
+      source: "codex-python-app-server-v1",
+      input_tokens: 90,
+      cached_input_tokens: 40,
+      output_tokens: 25,
+      reasoning_output_tokens: 5,
+      total_tokens: 115,
+      budget_outcome: "within",
+    });
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #224

## Summary
- add opt-in Codex Python app-server provider for real tool-free team workers
- propagate YUKH_CODEX_WORKER_PROVIDER and YUKH_CODEX_PYTHON_EXECUTABLE through team-control/preflight launch paths
- add codex-python-app-server-v1 token accounting and lower opt-in preflight floor to 18k
- document threat model, operator guide and session evidence

## Validation
- npm run -s typecheck
- node --import tsx --test test/runtime/team-control.test.ts
- npm run -s test:contracts
- node --test test/supply-chain/qualification-scripts.test.mjs
- npm run -s format:check
- npm run -s build
- live runCodexPythonWorker smoke test with gpt-5.6-terra: 10,667 total tokens, within 18k budget