### PR TITLE
Show missing receipts in watcher status

### DIFF
--- a/packages/conversation-watch/src/watch.ts
+++ b/packages/conversation-watch/src/watch.ts
@@ -188,6 +188,9 @@ export function renderTeamChanges(
       const agentReceipts = snapshot.receipts
         .filter((receipt) => receipt.actor_agent_id === agent.agent_id)
         .map((receipt) => receipt.action);
+      const missingActions = agent.required_actions.filter(
+        (action) => !agentReceipts.includes(action),
+      );
       const value = `${agent.state}:${agent.task}:${agent.max_commands ?? 8}:${agent.timeout_ms ?? 300_000}:${agent.usage?.total_tokens ?? "pending"}:${agent.completion?.outcome ?? "pending"}:${agentReceipts.join(",")}`;
       if (previous.get(key) === value) continue;
       previous.set(key, value);
@@ -200,7 +203,7 @@ export function renderTeamChanges(
         ? `\n          summary=${compact(agent.completion.summary, 180)}`
         : "";
       lines.push(
-        `TIMELINE  ${agent.kind.toUpperCase()} ${agent.role}  ${agent.state.toUpperCase()}  status=${statusReason(agent)}${review}\n          task=${compact(agent.task, 180)}${summary}\n          runtime=${agent.runtime} model=${agent.profile?.model ?? "default"} tools=${agent.model_tool_mode ?? "default"} bounds=commands:${agent.max_commands ?? 8} timeout_ms:${agent.timeout_ms ?? 300_000}\n          tokens=${agent.usage?.total_tokens ?? "pending"}/${agent.token_budget} input=${agent.usage?.input_tokens ?? "pending"} cached=${agent.usage?.cached_input_tokens ?? "pending"} output=${agent.usage?.output_tokens ?? "pending"} reasoning=${agent.usage?.reasoning_output_tokens ?? "pending"} accounting=${agent.usage?.source ?? "pending"}\n          required=${agent.required_actions.join(",") || "none"} receipts=${agentReceipts.join(",") || "none"} coordination=${agent.coordination_participant}\n          id=${agent.agent_id} parent=${agent.parent_agent_id ?? (agent.kind === "manager" ? "root" : "manager")}`,
+        `TIMELINE  ${agent.kind.toUpperCase()} ${agent.role}  ${agent.state.toUpperCase()}  status=${statusReason(agent, missingActions)}${review}\n          task=${compact(agent.task, 180)}${summary}\n          runtime=${agent.runtime} model=${agent.profile?.model ?? "default"} tools=${agent.model_tool_mode ?? "default"} bounds=commands:${agent.max_commands ?? 8} timeout_ms:${agent.timeout_ms ?? 300_000}\n          tokens=${agent.usage?.total_tokens ?? "pending"}/${agent.token_budget} input=${agent.usage?.input_tokens ?? "pending"} cached=${agent.usage?.cached_input_tokens ?? "pending"} output=${agent.usage?.output_tokens ?? "pending"} reasoning=${agent.usage?.reasoning_output_tokens ?? "pending"} accounting=${agent.usage?.source ?? "pending"}\n          required=${agent.required_actions.join(",") || "none"} missing=${missingActions.join(",") || "none"} receipts=${agentReceipts.join(",") || "none"} coordination=${agent.coordination_participant}\n          id=${agent.agent_id} parent=${agent.parent_agent_id ?? (agent.kind === "manager" ? "root" : "manager")}`,
       );
     }
     for (const plan of snapshot.plans ?? []) {
@@ -221,11 +224,9 @@ function compact(value: string, limit: number): string {
   return normalized.length > limit ? `${normalized.slice(0, limit - 1)}…` : normalized;
 }
 
-function statusReason(agent: AgentRecord): string {
+function statusReason(agent: AgentRecord, missingActions: readonly string[]): string {
   if (agent.state === "defined")
-    return agent.required_actions.length > 0
-      ? `waiting:${agent.required_actions.join(",")}`
-      : "waiting:launch";
+    return missingActions.length > 0 ? `waiting:${missingActions.join(",")}` : "waiting:launch";
   if (agent.state === "running") return "working";
   if (agent.state === "stopped") return "stopped";
   if (agent.completion) return agent.completion.outcome;

--- a/test/runtime/conversation-watch.test.ts
+++ b/test/runtime/conversation-watch.test.ts
@@ -221,9 +221,78 @@ test("watch exposes manager accounting and receipt-backed actions", () => {
   ).join("\n");
   assert.match(changes, /TIMELINE  MANAGER delivery-manager  COMPLETED  status=succeeded/u);
   assert.match(changes, /input=5000 cached=3000 output=500 reasoning=100/u);
-  assert.match(changes, /required=team.status receipts=team.status/u);
+  assert.match(changes, /required=team.status missing=none receipts=team.status/u);
   assert.match(changes, /PLAN  plan-9776aa63-2b13-4d98-ab2b-5b0c8b0354aa  RUNNING/u);
   assert.match(changes, /workers=1 synthesis=worker-4dc1c6d1/u);
+});
+
+test("watch status names only missing required receipts", () => {
+  const teamID = "team-0eae0789-0d76-493a-9d89-2f44c9f819cd";
+  const managerID = "worker-9776aa63-2b13-4d98-ab2b-5b0c8b0354aa";
+  const changes = renderTeamChanges(
+    [
+      {
+        team: {
+          schema: 1,
+          team_id: teamID,
+          goal: "Track missing receipts",
+          workspace: "/tmp/project",
+          manager_runtime: "codex",
+          manager_role: "delivery-manager",
+          manager_mission: "Keep operator status precise",
+          max_agents: 3,
+          max_depth: 2,
+          token_budget: 60_000,
+          state: "active",
+        },
+        agents: [
+          {
+            schema: 1,
+            agent_id: managerID,
+            kind: "manager",
+            coordination_agent: "agent-delivery-manager-61e1f378",
+            coordination_participant: "agent:delivery-manager-61e1f378",
+            team_id: teamID,
+            runtime: "codex",
+            role: "delivery-manager",
+            task: "Prepare and engage a worker",
+            depth: 0,
+            can_spawn: true,
+            token_budget: 20_000,
+            required_actions: ["policy.profile", "agent.engage"],
+            max_commands: 0,
+            timeout_ms: 60_000,
+            state: "defined",
+          },
+        ],
+        receipts: [
+          {
+            schema: 1,
+            receipt_id: "receipt-9776aa63-2b13-4d98-ab2b-5b0c8b0354aa",
+            team_id: teamID,
+            action: "agent.engage",
+            actor_agent_id: managerID,
+            subject_agent_id: "worker-3dc1c6d1-ac73-4f39-9d48-301123385534",
+            outcome: "succeeded",
+          },
+        ],
+        plans: [],
+        tokens: {
+          budget: 60_000,
+          allocated: 20_000,
+          observed: 0,
+          remaining: 60_000,
+          pending_agents: 1,
+          unaccounted_agents: 0,
+          exceeded_agents: 0,
+        },
+      },
+    ],
+    new Map(),
+  ).join("\n");
+  assert.match(changes, /status=waiting:policy\.profile/u);
+  assert.match(changes, /missing=policy\.profile receipts=agent\.engage/u);
+  assert.doesNotMatch(changes, /status=waiting:policy\.profile,agent\.engage/u);
 });
 
 test("watch marks over-budget summaries as reviewable", () => {


### PR DESCRIPTION
Closes #232.

Fixes the operator timeline status for required actions:
- computes missing actions from existing receipts;
- renders `status=waiting:<missing>` instead of all required actions;
- adds `missing=...` alongside `required=...` and `receipts=...` for evidence.

Validation:
- node --import tsx --test test/runtime/conversation-watch.test.ts
- npm run typecheck
- npm run format:check
- npm run build
- smoke watcher against a completed SDK worker workspace
