### PR TITLE
Show agent activity in watcher timeline

### DIFF
--- a/apps/conversation-watch/src/main.ts
+++ b/apps/conversation-watch/src/main.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { createCoordinationLauncher } from "../../../packages/coordination-preview/src/launcher.js";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
@@ -9,6 +9,10 @@ import {
   renderRecord,
   renderTeamChanges,
   watchRecords,
+} from "../../../packages/conversation-watch/src/watch.js";
+import type {
+  AgentActivity,
+  TeamSnapshot,
 } from "../../../packages/conversation-watch/src/watch.js";
 
 const launcherPath = process.env.YUKH_COORDINATION_LAUNCHER;
@@ -98,8 +102,33 @@ for (;;) {
     lifecycleOffset += records.length;
   }
   if (teamStore) {
-    for (const line of renderTeamChanges(teamStore.teams(), teamView))
+    for (const line of renderTeamChanges(withActivity(workspace!, teamStore.teams()), teamView))
       process.stdout.write(`${line}\n\n`);
   }
   await new Promise((resolve) => setTimeout(resolve, 1_000));
+}
+
+function withActivity(workspace: string, snapshots: readonly TeamSnapshot[]): TeamSnapshot[] {
+  return snapshots.map((snapshot) => ({
+    ...snapshot,
+    activity: snapshot.agents.map((agent): AgentActivity => {
+      const root = join(workspace, ".yukh", "teams", snapshot.team.team_id, "agents");
+      return {
+        agent_id: agent.agent_id,
+        ...mtime(join(root, `${agent.agent_id}.json`), "state_updated_at"),
+        ...mtime(join(root, `${agent.agent_id}.log`), "log_updated_at"),
+      };
+    }),
+  }));
+}
+
+function mtime(path: string, key: "state_updated_at" | "log_updated_at"): Partial<AgentActivity> {
+  try {
+    const info = statSync(path);
+    if (!info.isFile()) return {};
+    return { [key]: info.mtime.toISOString() };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw error;
+  }
 }

--- a/packages/conversation-watch/src/watch.ts
+++ b/packages/conversation-watch/src/watch.ts
@@ -34,6 +34,7 @@ export interface TeamSnapshot {
   readonly agents: readonly AgentRecord[];
   readonly receipts: readonly TeamActionReceipt[];
   readonly plans?: readonly TeamExecutionPlanRecord[];
+  readonly activity?: readonly AgentActivity[];
   readonly tokens: {
     readonly budget: number;
     readonly allocated: number;
@@ -43,6 +44,12 @@ export interface TeamSnapshot {
     readonly unaccounted_agents: number;
     readonly exceeded_agents: number;
   };
+}
+
+export interface AgentActivity {
+  readonly agent_id: string;
+  readonly state_updated_at?: string;
+  readonly log_updated_at?: string;
 }
 
 const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
@@ -191,7 +198,8 @@ export function renderTeamChanges(
       const missingActions = agent.required_actions.filter(
         (action) => !agentReceipts.includes(action),
       );
-      const value = `${agent.state}:${agent.task}:${agent.max_commands ?? 8}:${agent.timeout_ms ?? 300_000}:${agent.usage?.total_tokens ?? "pending"}:${agent.completion?.outcome ?? "pending"}:${agentReceipts.join(",")}`;
+      const activity = activityFor(snapshot, agent.agent_id);
+      const value = `${agent.state}:${agent.task}:${agent.max_commands ?? 8}:${agent.timeout_ms ?? 300_000}:${agent.usage?.total_tokens ?? "pending"}:${agent.completion?.outcome ?? "pending"}:${agentReceipts.join(",")}:${activity?.state_updated_at ?? "unknown"}:${activity?.log_updated_at ?? "none"}`;
       if (previous.get(key) === value) continue;
       previous.set(key, value);
       const review =
@@ -203,7 +211,7 @@ export function renderTeamChanges(
         ? `\n          summary=${compact(agent.completion.summary, 180)}`
         : "";
       lines.push(
-        `TIMELINE  ${agent.kind.toUpperCase()} ${agent.role}  ${agent.state.toUpperCase()}  status=${statusReason(agent, missingActions)}${review}\n          task=${compact(agent.task, 180)}${summary}\n          runtime=${agent.runtime} model=${agent.profile?.model ?? "default"} tools=${agent.model_tool_mode ?? "default"} bounds=commands:${agent.max_commands ?? 8} timeout_ms:${agent.timeout_ms ?? 300_000}\n          tokens=${agent.usage?.total_tokens ?? "pending"}/${agent.token_budget} input=${agent.usage?.input_tokens ?? "pending"} cached=${agent.usage?.cached_input_tokens ?? "pending"} output=${agent.usage?.output_tokens ?? "pending"} reasoning=${agent.usage?.reasoning_output_tokens ?? "pending"} accounting=${agent.usage?.source ?? "pending"}\n          required=${agent.required_actions.join(",") || "none"} missing=${missingActions.join(",") || "none"} receipts=${agentReceipts.join(",") || "none"} coordination=${agent.coordination_participant}\n          id=${agent.agent_id} parent=${agent.parent_agent_id ?? (agent.kind === "manager" ? "root" : "manager")}`,
+        `TIMELINE  ${agent.kind.toUpperCase()} ${agent.role}  ${agent.state.toUpperCase()}  status=${statusReason(agent, missingActions)}${review}\n          task=${compact(agent.task, 180)}${summary}\n          runtime=${agent.runtime} model=${agent.profile?.model ?? "default"} tools=${agent.model_tool_mode ?? "default"} bounds=commands:${agent.max_commands ?? 8} timeout_ms:${agent.timeout_ms ?? 300_000}\n          activity=last_change:${activity?.state_updated_at ?? "unknown"} log:${activity?.log_updated_at ?? "none"}\n          tokens=${agent.usage?.total_tokens ?? "pending"}/${agent.token_budget} input=${agent.usage?.input_tokens ?? "pending"} cached=${agent.usage?.cached_input_tokens ?? "pending"} output=${agent.usage?.output_tokens ?? "pending"} reasoning=${agent.usage?.reasoning_output_tokens ?? "pending"} accounting=${agent.usage?.source ?? "pending"}\n          required=${agent.required_actions.join(",") || "none"} missing=${missingActions.join(",") || "none"} receipts=${agentReceipts.join(",") || "none"} coordination=${agent.coordination_participant}\n          id=${agent.agent_id} parent=${agent.parent_agent_id ?? (agent.kind === "manager" ? "root" : "manager")}`,
       );
     }
     for (const plan of snapshot.plans ?? []) {
@@ -232,4 +240,8 @@ function statusReason(agent: AgentRecord, missingActions: readonly string[]): st
   if (agent.completion) return agent.completion.outcome;
   if (agent.state === "failed") return "failed:no-completion";
   return "completed:no-completion";
+}
+
+function activityFor(snapshot: TeamSnapshot, agentID: string): AgentActivity | undefined {
+  return snapshot.activity?.find((activity) => activity.agent_id === agentID);
 }

--- a/test/runtime/conversation-watch.test.ts
+++ b/test/runtime/conversation-watch.test.ts
@@ -295,6 +295,69 @@ test("watch status names only missing required receipts", () => {
   assert.doesNotMatch(changes, /status=waiting:policy\.profile,agent\.engage/u);
 });
 
+test("watch renders agent state and log activity when available", () => {
+  const changes = renderTeamChanges(
+    [
+      {
+        team: {
+          schema: 1,
+          team_id: "team-0eae0789-0d76-493a-9d89-2f44c9f819cd",
+          goal: "Observe a running worker",
+          workspace: "/tmp/project",
+          manager_runtime: "codex",
+          max_agents: 3,
+          max_depth: 2,
+          token_budget: 60_000,
+          state: "active",
+        },
+        agents: [
+          {
+            schema: 1,
+            agent_id: "worker-3dc1c6d1-ac73-4f39-9d48-301123385534",
+            kind: "worker",
+            coordination_agent: "agent-observer-61e1f378",
+            coordination_participant: "agent:observer-61e1f378",
+            team_id: "team-0eae0789-0d76-493a-9d89-2f44c9f819cd",
+            runtime: "codex",
+            role: "observer",
+            task: "Keep working",
+            depth: 1,
+            can_spawn: false,
+            token_budget: 18_000,
+            required_actions: [],
+            max_commands: 1,
+            timeout_ms: 180_000,
+            state: "running",
+          },
+        ],
+        receipts: [],
+        plans: [],
+        activity: [
+          {
+            agent_id: "worker-3dc1c6d1-ac73-4f39-9d48-301123385534",
+            state_updated_at: "2026-08-17T07:40:00.000Z",
+            log_updated_at: "2026-08-17T07:41:00.000Z",
+          },
+        ],
+        tokens: {
+          budget: 60_000,
+          allocated: 18_000,
+          observed: 0,
+          remaining: 60_000,
+          pending_agents: 1,
+          unaccounted_agents: 0,
+          exceeded_agents: 0,
+        },
+      },
+    ],
+    new Map(),
+  ).join("\n");
+  assert.match(
+    changes,
+    /activity=last_change:2026-08-17T07:40:00\.000Z log:2026-08-17T07:41:00\.000Z/u,
+  );
+});
+
 test("watch marks over-budget summaries as reviewable", () => {
   const changes = renderTeamChanges(
     [


### PR DESCRIPTION
Closes #234.

Adds lightweight operator activity hints to the conversation watcher:
- reads local agent state/log file mtimes without changing persisted team schemas;
- renders `activity=last_change:... log:...` on each `TIMELINE` row;
- includes activity timestamps in the watcher fingerprint so active logs can refresh the row.

Validation:
- node --import tsx --test test/runtime/conversation-watch.test.ts
- npm run typecheck
- npm run format:check
- npm run build
- smoke watcher against a completed SDK worker workspace
