### PR TITLE
Mark stale running agents in watcher

### DIFF
--- a/apps/conversation-watch/src/main.ts
+++ b/apps/conversation-watch/src/main.ts
@@ -33,6 +33,7 @@ const lifecyclePath = workspace
 const present = new Set<string>();
 const teamView = new Map<string, string>();
 const teamStore = workspace ? new TeamStore(workspace) : undefined;
+const staleAfterMs = integer(process.env.YUKH_WATCH_STALE_AFTER_MS, 120_000);
 let unavailable = false;
 let lastReplayFailure = "";
 
@@ -109,6 +110,7 @@ for (;;) {
 }
 
 function withActivity(workspace: string, snapshots: readonly TeamSnapshot[]): TeamSnapshot[] {
+  const observedAt = new Date().toISOString();
   return snapshots.map((snapshot) => ({
     ...snapshot,
     activity: snapshot.agents.map((agent): AgentActivity => {
@@ -117,6 +119,8 @@ function withActivity(workspace: string, snapshots: readonly TeamSnapshot[]): Te
         agent_id: agent.agent_id,
         ...mtime(join(root, `${agent.agent_id}.json`), "state_updated_at"),
         ...mtime(join(root, `${agent.agent_id}.log`), "log_updated_at"),
+        stale_after_ms: staleAfterMs,
+        observed_at: observedAt,
       };
     }),
   }));
@@ -131,4 +135,12 @@ function mtime(path: string, key: "state_updated_at" | "log_updated_at"): Partia
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return {};
     throw error;
   }
+}
+
+function integer(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1_000 || parsed > 86_400_000)
+    throw new TypeError("invalid watcher configuration");
+  return parsed;
 }

--- a/packages/conversation-watch/src/watch.ts
+++ b/packages/conversation-watch/src/watch.ts
@@ -50,6 +50,8 @@ export interface AgentActivity {
   readonly agent_id: string;
   readonly state_updated_at?: string;
   readonly log_updated_at?: string;
+  readonly stale_after_ms?: number;
+  readonly observed_at?: string;
 }
 
 const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
@@ -199,7 +201,8 @@ export function renderTeamChanges(
         (action) => !agentReceipts.includes(action),
       );
       const activity = activityFor(snapshot, agent.agent_id);
-      const value = `${agent.state}:${agent.task}:${agent.max_commands ?? 8}:${agent.timeout_ms ?? 300_000}:${agent.usage?.total_tokens ?? "pending"}:${agent.completion?.outcome ?? "pending"}:${agentReceipts.join(",")}:${activity?.state_updated_at ?? "unknown"}:${activity?.log_updated_at ?? "none"}`;
+      const status = statusReason(agent, missingActions, activity);
+      const value = `${agent.state}:${agent.task}:${agent.max_commands ?? 8}:${agent.timeout_ms ?? 300_000}:${agent.usage?.total_tokens ?? "pending"}:${agent.completion?.outcome ?? "pending"}:${agentReceipts.join(",")}:${status}:${activity?.state_updated_at ?? "unknown"}:${activity?.log_updated_at ?? "none"}`;
       if (previous.get(key) === value) continue;
       previous.set(key, value);
       const review =
@@ -211,7 +214,7 @@ export function renderTeamChanges(
         ? `\n          summary=${compact(agent.completion.summary, 180)}`
         : "";
       lines.push(
-        `TIMELINE  ${agent.kind.toUpperCase()} ${agent.role}  ${agent.state.toUpperCase()}  status=${statusReason(agent, missingActions)}${review}\n          task=${compact(agent.task, 180)}${summary}\n          runtime=${agent.runtime} model=${agent.profile?.model ?? "default"} tools=${agent.model_tool_mode ?? "default"} bounds=commands:${agent.max_commands ?? 8} timeout_ms:${agent.timeout_ms ?? 300_000}\n          activity=last_change:${activity?.state_updated_at ?? "unknown"} log:${activity?.log_updated_at ?? "none"}\n          tokens=${agent.usage?.total_tokens ?? "pending"}/${agent.token_budget} input=${agent.usage?.input_tokens ?? "pending"} cached=${agent.usage?.cached_input_tokens ?? "pending"} output=${agent.usage?.output_tokens ?? "pending"} reasoning=${agent.usage?.reasoning_output_tokens ?? "pending"} accounting=${agent.usage?.source ?? "pending"}\n          required=${agent.required_actions.join(",") || "none"} missing=${missingActions.join(",") || "none"} receipts=${agentReceipts.join(",") || "none"} coordination=${agent.coordination_participant}\n          id=${agent.agent_id} parent=${agent.parent_agent_id ?? (agent.kind === "manager" ? "root" : "manager")}`,
+        `TIMELINE  ${agent.kind.toUpperCase()} ${agent.role}  ${agent.state.toUpperCase()}  status=${status}${review}\n          task=${compact(agent.task, 180)}${summary}\n          runtime=${agent.runtime} model=${agent.profile?.model ?? "default"} tools=${agent.model_tool_mode ?? "default"} bounds=commands:${agent.max_commands ?? 8} timeout_ms:${agent.timeout_ms ?? 300_000}\n          activity=last_change:${activity?.state_updated_at ?? "unknown"} log:${activity?.log_updated_at ?? "none"}\n          tokens=${agent.usage?.total_tokens ?? "pending"}/${agent.token_budget} input=${agent.usage?.input_tokens ?? "pending"} cached=${agent.usage?.cached_input_tokens ?? "pending"} output=${agent.usage?.output_tokens ?? "pending"} reasoning=${agent.usage?.reasoning_output_tokens ?? "pending"} accounting=${agent.usage?.source ?? "pending"}\n          required=${agent.required_actions.join(",") || "none"} missing=${missingActions.join(",") || "none"} receipts=${agentReceipts.join(",") || "none"} coordination=${agent.coordination_participant}\n          id=${agent.agent_id} parent=${agent.parent_agent_id ?? (agent.kind === "manager" ? "root" : "manager")}`,
       );
     }
     for (const plan of snapshot.plans ?? []) {
@@ -232,10 +235,14 @@ function compact(value: string, limit: number): string {
   return normalized.length > limit ? `${normalized.slice(0, limit - 1)}…` : normalized;
 }
 
-function statusReason(agent: AgentRecord, missingActions: readonly string[]): string {
+function statusReason(
+  agent: AgentRecord,
+  missingActions: readonly string[],
+  activity: AgentActivity | undefined,
+): string {
   if (agent.state === "defined")
     return missingActions.length > 0 ? `waiting:${missingActions.join(",")}` : "waiting:launch";
-  if (agent.state === "running") return "working";
+  if (agent.state === "running") return runningStatus(activity);
   if (agent.state === "stopped") return "stopped";
   if (agent.completion) return agent.completion.outcome;
   if (agent.state === "failed") return "failed:no-completion";
@@ -244,4 +251,15 @@ function statusReason(agent: AgentRecord, missingActions: readonly string[]): st
 
 function activityFor(snapshot: TeamSnapshot, agentID: string): AgentActivity | undefined {
   return snapshot.activity?.find((activity) => activity.agent_id === agentID);
+}
+
+function runningStatus(activity: AgentActivity | undefined): string {
+  if (!activity || activity.stale_after_ms === undefined || activity.observed_at === undefined)
+    return "working";
+  const observed = Date.parse(activity.observed_at);
+  const last = Date.parse(activity.log_updated_at ?? activity.state_updated_at ?? "");
+  if (!Number.isFinite(observed) || !Number.isFinite(last)) return "working";
+  const idleMs = observed - last;
+  if (idleMs <= activity.stale_after_ms) return "working";
+  return `stale:${Math.floor(idleMs / 1_000)}s`;
 }

--- a/test/runtime/conversation-watch.test.ts
+++ b/test/runtime/conversation-watch.test.ts
@@ -358,6 +358,87 @@ test("watch renders agent state and log activity when available", () => {
   );
 });
 
+test("watch marks stale running agents when activity is older than threshold", () => {
+  const base = {
+    team: {
+      schema: 1 as const,
+      team_id: "team-0eae0789-0d76-493a-9d89-2f44c9f819cd",
+      goal: "Observe a possibly stuck worker",
+      workspace: "/tmp/project",
+      manager_runtime: "codex" as const,
+      max_agents: 3,
+      max_depth: 2,
+      token_budget: 60_000,
+      state: "active" as const,
+    },
+    agents: [
+      {
+        schema: 1 as const,
+        agent_id: "worker-3dc1c6d1-ac73-4f39-9d48-301123385534",
+        kind: "worker" as const,
+        coordination_agent: "agent-observer-61e1f378" as const,
+        coordination_participant: "agent:observer-61e1f378" as const,
+        team_id: "team-0eae0789-0d76-493a-9d89-2f44c9f819cd",
+        runtime: "codex" as const,
+        role: "observer",
+        task: "Keep working",
+        depth: 1,
+        can_spawn: false,
+        token_budget: 18_000,
+        required_actions: [],
+        max_commands: 1,
+        timeout_ms: 180_000,
+        state: "running" as const,
+      },
+    ],
+    receipts: [],
+    plans: [],
+    tokens: {
+      budget: 60_000,
+      allocated: 18_000,
+      observed: 0,
+      remaining: 60_000,
+      pending_agents: 1,
+      unaccounted_agents: 0,
+      exceeded_agents: 0,
+    },
+  };
+  const fresh = renderTeamChanges(
+    [
+      {
+        ...base,
+        activity: [
+          {
+            agent_id: "worker-3dc1c6d1-ac73-4f39-9d48-301123385534",
+            log_updated_at: "2026-08-17T07:41:00.000Z",
+            observed_at: "2026-08-17T07:41:30.000Z",
+            stale_after_ms: 60_000,
+          },
+        ],
+      },
+    ],
+    new Map(),
+  ).join("\n");
+  const stale = renderTeamChanges(
+    [
+      {
+        ...base,
+        activity: [
+          {
+            agent_id: "worker-3dc1c6d1-ac73-4f39-9d48-301123385534",
+            log_updated_at: "2026-08-17T07:41:00.000Z",
+            observed_at: "2026-08-17T07:43:05.000Z",
+            stale_after_ms: 60_000,
+          },
+        ],
+      },
+    ],
+    new Map(),
+  ).join("\n");
+  assert.match(fresh, /status=working/u);
+  assert.match(stale, /status=stale:125s/u);
+});
+
 test("watch marks over-budget summaries as reviewable", () => {
   const changes = renderTeamChanges(
     [


### PR DESCRIPTION
Closes #236.

Adds a stale marker for running agents in `yukh conversation watch`:
- default threshold: 120 seconds;
- override: `YUKH_WATCH_STALE_AFTER_MS`;
- renders `status=stale:<seconds>s` only for `RUNNING` agents whose log/state activity is older than the threshold;
- keeps defined and terminal states unchanged.

Validation:
- node --import tsx --test test/runtime/conversation-watch.test.ts
- npm run typecheck
- npm run format:check
- npm run build
- smoke watcher against completed SDK worker workspace
