### PR TITLE
Document stale watcher status

### DIFF
--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -295,10 +295,13 @@ When the workspace contains a Yukh team, the same watcher also shows the
 operator timeline. Read `TEAM` first for the shared budget and number of
 agents, then each `TIMELINE` row for the current manager or worker state:
 `status=working` means active, `status=waiting:...` names the missing receipt or
-launch step, and terminal statuses such as `succeeded`, `agent_exit_nonzero` or
-`token_budget_exceeded` explain why the worker stopped. Token lines report
-observed usage against the assigned budget; `unaccounted=0` is the healthy
-state. `COORDINATOR` lines are local wake-up events, not model messages.
+launch step, and `status=stale:<seconds>s` means a running agent has no recent
+state or log activity. The stale threshold defaults to 120 seconds; override it
+with `YUKH_WATCH_STALE_AFTER_MS`. Terminal statuses such as `succeeded`,
+`agent_exit_nonzero` or `token_budget_exceeded` explain why the worker stopped.
+Token lines report observed usage against the assigned budget; `unaccounted=0`
+is the healthy state. `COORDINATOR` lines are local wake-up events, not model
+messages.
 
 The temporary local qualification profile starts Copilot with `--allow-all`, so
 it can use every tool, path and URL required to complete the exercise. Start it


### PR DESCRIPTION
Closes #238.

Documents the watcher stale marker:
- `status=stale:<seconds>s`;
- default 120-second threshold;
- `YUKH_WATCH_STALE_AFTER_MS` override.

Validation:
- npm run format:check
- git diff --check
