### PR TITLE
Make conversation worker launches observable

### DIFF
--- a/packages/conversation-coordinator/src/coordinator.ts
+++ b/packages/conversation-coordinator/src/coordinator.ts
@@ -7,7 +7,12 @@ import type {
 const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
 
 export interface AgentRunner {
-  run(agent: PreviewAgent, prompt: string): Promise<void>;
+  prepare?(
+    agent: PreviewAgent,
+    questionEventID: string,
+    turn: number,
+  ): { readonly log_path?: string };
+  run(agent: PreviewAgent, prompt: string, context?: { readonly log_path?: string }): Promise<void>;
 }
 
 export interface CoordinatorOptions {
@@ -38,6 +43,7 @@ export interface CoordinatorEvent {
     | "agent_error";
   readonly coordination_action?: "bootstrap" | "join" | "replay";
   readonly ykc_code?: string;
+  readonly agent_log_path?: string;
 }
 
 type RecordValue = { readonly event?: unknown };
@@ -116,12 +122,14 @@ export class ConversationCoordinator {
     if (!agent) return "idle";
     this.#attempted.add(question.id);
     this.#turns++;
-    this.#observe("agent_started", agent, question.id);
+    const runContext = this.#options.runner.prepare?.(agent, question.id, this.#turns);
+    this.#observe("agent_started", agent, question.id, undefined, runContext?.log_path);
     try {
       await this.#prepare(agent);
       await this.#options.runner.run(
         agent,
         `Use yukh-coordination for communication. Bootstrap if required, join, replay, and find question event ${question.id}. Complete the requested work with the available local tools inside the current workspace, including files, shell, dependencies, and tests. Then answer through yukh-coordination preserving work_uri, correlation_id, and question_event_id. If another peer action is required, publish one directed follow-up question with the same work_uri.`,
+        runContext,
       );
     } catch (error) {
       const known = [
@@ -154,6 +162,7 @@ export class ConversationCoordinator {
     agent: PreviewAgent,
     questionEventID: string,
     failureCode?: CoordinatorEvent["failure_code"],
+    logPath?: string,
   ) {
     this.#options.observe?.({
       schema: 1,
@@ -162,6 +171,7 @@ export class ConversationCoordinator {
       question_event_id: questionEventID,
       turn: this.#turns,
       ...(failureCode ? { failure_code: failureCode } : {}),
+      ...(logPath ? { agent_log_path: logPath } : {}),
     });
   }
 
@@ -190,16 +200,13 @@ export class ConversationCoordinator {
     const launcher = this.#options.launchers[agent];
     if (!launcher) throw new Error("agent_coordination_failed");
     const bootstrap = await launcher.invoke("session bootstrap");
-    if (bootstrap.status !== "ok") {
-      this.#observeCoordinationFailure("bootstrap", bootstrap.code);
-      throw new Error("agent_coordination_failed");
-    }
     const join = await launcher.invoke("session join", {
       capabilities: ["publish", "replay"],
       session_label: agent,
       status: "available",
     });
     if (join.status !== "ok") {
+      if (bootstrap.status !== "ok") this.#observeCoordinationFailure("bootstrap", bootstrap.code);
       this.#observeCoordinationFailure("join", join.code);
       throw new Error("agent_coordination_failed");
     }

--- a/packages/conversation-coordinator/src/runner.ts
+++ b/packages/conversation-coordinator/src/runner.ts
@@ -1,5 +1,5 @@
-import { lstatSync, realpathSync } from "node:fs";
-import { isAbsolute } from "node:path";
+import { closeSync, lstatSync, mkdirSync, openSync, realpathSync, writeSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
 import { spawn } from "node:child_process";
 import type { PreviewAgent } from "../../coordination-preview/src/launcher.js";
 import type { AgentRunner } from "./coordinator.js";
@@ -38,7 +38,21 @@ export function createAgentRunner(options: {
   if (!Number.isInteger(timeoutMs) || timeoutMs < 1_000 || timeoutMs > 900_000)
     throw new TypeError("invalid agent timeout");
   return {
-    run(agent: PreviewAgent, prompt: string): Promise<void> {
+    prepare(agent: PreviewAgent, questionEventID: string, turn: number) {
+      const directory = join(cwd, ".yukh", "conversation-agent-logs");
+      mkdirSync(directory, { recursive: true, mode: 0o700 });
+      return {
+        log_path: join(
+          directory,
+          `${new Date().toISOString().replaceAll(":", "-")}-turn-${turn}-${agent}-${questionEventID}.log`,
+        ),
+      };
+    },
+    run(
+      agent: PreviewAgent,
+      prompt: string,
+      context?: { readonly log_path?: string },
+    ): Promise<void> {
       if (prompt.length === 0 || prompt.length > 1_024)
         return Promise.reject(new TypeError("invalid prompt"));
       const command = agent === "agent-a" ? codex : copilot;
@@ -55,10 +69,13 @@ export function createAgentRunner(options: {
             ]
           : ["-p", prompt, "-s", "--no-ask-user", "--allow-all"];
       return new Promise((resolve, reject) => {
+        const log = context?.log_path ? openSync(context.log_path, "a", 0o600) : undefined;
+        if (log !== undefined)
+          writeSync(log, `agent=${agent}\ncommand=${command}\nargs=${JSON.stringify(args)}\n\n`);
         const child = spawn(command, args, {
           cwd,
           shell: false,
-          stdio: "ignore",
+          stdio: ["ignore", log ?? "ignore", log ?? "ignore"],
           env: { HOME: process.env.HOME ?? "", PATH: process.env.PATH ?? "/usr/bin:/bin" },
         });
         let settled = false;
@@ -66,6 +83,7 @@ export function createAgentRunner(options: {
           if (settled) return;
           settled = true;
           child.kill("SIGKILL");
+          if (log !== undefined) closeSync(log);
           reject(new Error(reason));
         };
         const timer = setTimeout(() => fail("agent_timed_out"), timeoutMs);
@@ -74,6 +92,7 @@ export function createAgentRunner(options: {
           clearTimeout(timer);
           if (settled) return;
           settled = true;
+          if (log !== undefined) closeSync(log);
           if (code === 0) resolve();
           else reject(new Error("agent_exit_nonzero"));
         });

--- a/packages/conversation-watch/src/watch.ts
+++ b/packages/conversation-watch/src/watch.ts
@@ -27,6 +27,7 @@ export interface LifecycleRecord {
   readonly failure_code?: string;
   readonly coordination_action?: string;
   readonly ykc_code?: string;
+  readonly agent_log_path?: string;
 }
 
 export interface TeamSnapshot {
@@ -162,6 +163,13 @@ export function lifecycleRecords(raw: string, after: number): LifecycleRecord[] 
       (record.ykc_code !== undefined && !/^YKC-[A-Z]+-[0-9]{3}$/u.test(record.ykc_code))
     )
       throw new Error("coordination_protocol_error");
+    if (
+      record.agent_log_path !== undefined &&
+      (typeof record.agent_log_path !== "string" ||
+        !record.agent_log_path.startsWith("/") ||
+        record.agent_log_path.length > 4_096)
+    )
+      throw new Error("coordination_protocol_error");
     return record;
   });
 }
@@ -175,7 +183,8 @@ export function renderLifecycle(record: LifecycleRecord): string {
     return `COORDINATOR  COORDINATION ${record.coordination_action?.toUpperCase() ?? "ACTION"} FAILED code=${record.ykc_code ?? "unknown"} — RETRYING`;
   const label = record.event.replaceAll("_", " ").toUpperCase();
   const failure = record.failure_code ? ` failure=${record.failure_code}` : "";
-  return `COORDINATOR  ${record.agent ?? "agent"}  ${label}  turn=${record.turn ?? "?"} question=${record.question_event_id ?? "?"}${failure}`;
+  const log = record.agent_log_path ? ` log=${record.agent_log_path}` : "";
+  return `COORDINATOR  ${record.agent ?? "agent"}  ${label}  turn=${record.turn ?? "?"} question=${record.question_event_id ?? "?"}${failure}${log}`;
 }
 
 export function renderTeamChanges(

--- a/test/runtime/conversation-coordinator.test.ts
+++ b/test/runtime/conversation-coordinator.test.ts
@@ -143,7 +143,7 @@ test("coordinator fails the agent before launch when target bootstrap is unavail
       if (command === "events replay") return replay(false);
       if (command === "session bootstrap")
         return { schema: 1, status: "error", command, code: "YKC-UNAVAILABLE-001" };
-      return { schema: 1, status: "ok", command, result: { event_id: answerId } };
+      return { schema: 1, status: "error", command, code: "YKC-AUTH-001" };
     },
   };
   const coordinator = new ConversationCoordinator({
@@ -154,7 +154,7 @@ test("coordinator fails the agent before launch when target bootstrap is unavail
     observe: (event) => lifecycle.push(event),
   });
   assert.equal(await coordinator.tick(), "handled");
-  assert.deepEqual(commands, ["events replay", "session bootstrap"]);
+  assert.deepEqual(commands, ["events replay", "session bootstrap", "session join"]);
   assert.deepEqual(lifecycle, [
     {
       schema: 1,
@@ -171,11 +171,69 @@ test("coordinator fails the agent before launch when target bootstrap is unavail
     },
     {
       schema: 1,
+      event: "coordinator_coordination_failed",
+      coordination_action: "join",
+      ykc_code: "YKC-AUTH-001",
+    },
+    {
+      schema: 1,
       event: "agent_failed",
       agent: "agent-b",
       question_event_id: questionId,
       turn: 1,
       failure_code: "agent_coordination_failed",
+    },
+  ]);
+});
+
+test("coordinator launches when repeated bootstrap fails but join succeeds", async () => {
+  const lifecycle: unknown[] = [];
+  const commands: string[] = [];
+  let launched = false;
+  let output = replay(false);
+  const launcher: CoordinationLauncher = {
+    invoke: async (command) => {
+      commands.push(command);
+      if (command === "events replay") return output;
+      if (command === "session bootstrap")
+        return { schema: 1, status: "error", command, code: "YKC-UNAVAILABLE-001" };
+      return { schema: 1, status: "ok", command, result: { event_id: answerId } };
+    },
+  };
+  const coordinator = new ConversationCoordinator({
+    launchers: { "agent-a": launcher, "agent-b": launcher },
+    runner: {
+      run: async () => {
+        launched = true;
+        output = replay(true);
+      },
+    },
+    maxTurns: 1,
+    lifetimeMs: 10_000,
+    observe: (event) => lifecycle.push(event),
+  });
+  assert.equal(await coordinator.tick(), "handled");
+  assert.equal(launched, true);
+  assert.deepEqual(commands, [
+    "events replay",
+    "session bootstrap",
+    "session join",
+    "events replay",
+  ]);
+  assert.deepEqual(lifecycle, [
+    {
+      schema: 1,
+      event: "agent_started",
+      agent: "agent-b",
+      question_event_id: questionId,
+      turn: 1,
+    },
+    {
+      schema: 1,
+      event: "answer_verified",
+      agent: "agent-b",
+      question_event_id: questionId,
+      turn: 1,
     },
   ]);
 });

--- a/test/runtime/conversation-watch.test.ts
+++ b/test/runtime/conversation-watch.test.ts
@@ -561,13 +561,14 @@ test("watch rejects malformed or unverified transcript records", () => {
 });
 
 test("watch renders closed coordinator lifecycle without message content", () => {
-  const raw = `${JSON.stringify({ schema: 1, event: "agent_started", agent: "agent-b", question_event_id: eventID, turn: 1 })}\n`;
+  const log = "/tmp/yukh-agent.log";
+  const raw = `${JSON.stringify({ schema: 1, event: "agent_started", agent: "agent-b", question_event_id: eventID, turn: 1, agent_log_path: log })}\n`;
   const records = lifecycleRecords(raw, 0);
   assert.equal(records.length, 1);
   assert.equal(lifecycleRecords(raw, 1).length, 0);
   assert.equal(
     renderLifecycle(records[0]!),
-    `COORDINATOR  agent-b  AGENT STARTED  turn=1 question=${eventID}`,
+    `COORDINATOR  agent-b  AGENT STARTED  turn=1 question=${eventID} log=${log}`,
   );
   assert.throws(() => lifecycleRecords('{"schema":1,"event":"unknown"}\n', 0));
   const failure = lifecycleRecords(


### PR DESCRIPTION
Closes #240.

Changes:
- treats `session join` as the final Coordination availability proof, so repeated non-idempotent bootstrap failures do not block already-joinable agents;
- writes worker stdout/stderr to `.yukh/conversation-agent-logs/...`;
- includes `agent_log_path` on `agent_started` lifecycle events;
- renders `log=/path` in `yukh conversation watch`.

Validation:
- npm run build
- npm run format:check
- git diff --check
- node --import tsx --test test/runtime/conversation-coordinator.test.ts test/runtime/conversation-watch.test.ts
- safe VPS smoke with fake worker: coordinator reached `answer_verified`; viewer rendered answer and agent log path.

Smoke artifacts:
- coordinator log: /tmp/yukh-agentic-cycle-logs-20260817T082331Z/coordinator.log
- viewer log: /tmp/yukh-agentic-cycle-logs-20260817T082331Z/viewer.log
- worker log: /tmp/yukh-agentic-cycle-workspace2/.yukh/conversation-agent-logs/2026-08-17T08-23-31.865Z-turn-1-agent-b-01a00eca-d7f9-79de-8fd2-567f63a9d2d8.log
