### PR TITLE
fix: propagate preview runtime and add Yukh workflow plugin

### DIFF
--- a/apps/team-control/src/main.ts
+++ b/apps/team-control/src/main.ts
@@ -38,6 +38,7 @@ const profileEnvironment = {
       "YUKH_CODEX_WORKER_PROVIDER",
       "YUKH_CODEX_PYTHON_EXECUTABLE",
       "YUKH_COPILOT_WORKER_PROVIDER",
+      "YUKH_PREVIEW_RUNTIME",
     ]
       .filter((name) => process.env[name] !== undefined)
       .map((name) => [name, process.env[name]!] as const),

--- a/apps/team-preflight/src/approved-run.ts
+++ b/apps/team-preflight/src/approved-run.ts
@@ -62,6 +62,7 @@ function profileEnvironment(args: ApprovedRunArguments): Readonly<Record<string,
   if (process.env.YUKH_CODEX_PYTHON_EXECUTABLE)
     env.YUKH_CODEX_PYTHON_EXECUTABLE = process.env.YUKH_CODEX_PYTHON_EXECUTABLE;
   if (process.env.YUKH_COPILOT_WORKER_PROVIDER === "sdk") env.YUKH_COPILOT_WORKER_PROVIDER = "sdk";
+  if (process.env.YUKH_PREVIEW_RUNTIME) env.YUKH_PREVIEW_RUNTIME = process.env.YUKH_PREVIEW_RUNTIME;
   return env;
 }
 

--- a/apps/team-preflight/src/plan-execute.ts
+++ b/apps/team-preflight/src/plan-execute.ts
@@ -43,6 +43,7 @@ function profileEnvironment(args: ApprovedPlanRunArguments): Readonly<Record<str
   if (process.env.YUKH_CODEX_PYTHON_EXECUTABLE)
     env.YUKH_CODEX_PYTHON_EXECUTABLE = process.env.YUKH_CODEX_PYTHON_EXECUTABLE;
   if (process.env.YUKH_COPILOT_WORKER_PROVIDER === "sdk") env.YUKH_COPILOT_WORKER_PROVIDER = "sdk";
+  if (process.env.YUKH_PREVIEW_RUNTIME) env.YUKH_PREVIEW_RUNTIME = process.env.YUKH_PREVIEW_RUNTIME;
   return env;
 }
 

--- a/apps/team-worker/src/main.ts
+++ b/apps/team-worker/src/main.ts
@@ -115,6 +115,16 @@ const teamControlEnv = {
   ),
 };
 
+function runtimeEnv(): NodeJS.ProcessEnv {
+  return {
+    HOME: process.env.HOME ?? "",
+    PATH: process.env.PATH ?? "/usr/bin:/bin",
+    ...(process.env.YUKH_PREVIEW_RUNTIME
+      ? { YUKH_PREVIEW_RUNTIME: process.env.YUKH_PREVIEW_RUNTIME }
+      : {}),
+  };
+}
+
 const command =
   agent.runtime === "codex"
     ? required("YUKH_CODEX_EXECUTABLE")
@@ -216,7 +226,7 @@ async function coordination(
       cwd: workspace,
       shell: false,
       stdio: ["pipe", "pipe", "inherit"],
-      env: { HOME: process.env.HOME ?? "", PATH: process.env.PATH ?? "/usr/bin:/bin" },
+      env: runtimeEnv(),
     });
     const chunks: Buffer[] = [];
     child.stdout.on("data", (chunk: Buffer) => chunks.push(chunk));
@@ -300,7 +310,7 @@ const outcome = !joined
             detached: process.platform !== "win32",
             shell: false,
             stdio: ["ignore", "pipe", "pipe"],
-            env: { HOME: process.env.HOME ?? "", PATH: process.env.PATH ?? "/usr/bin:/bin" },
+            env: runtimeEnv(),
           });
           if (!child.stdout || !child.stderr) throw new Error("agent_output_unavailable");
           child.stdout.pipe(process.stdout);

--- a/docs/guides/agent-github-workflow.md
+++ b/docs/guides/agent-github-workflow.md
@@ -1,0 +1,96 @@
+---
+title: Agent GitHub workflow
+description: How Yukh managers, workers and subagents should publish repository work.
+---
+
+# Agent GitHub workflow
+
+Yukh agents may produce work, but GitHub publication remains an explicit
+reviewable handoff.
+
+## Skills and tools
+
+The Yukh plugin carries the Yukh operating skills:
+
+- `yukh-agent-workflow` for manager, worker, subagent, budget and evidence
+  behavior;
+- `yukh-github-publication` for commit attribution and GitHub-compatible
+  publication.
+
+These skills are not a hard dependency on the GitHub plugin. When the GitHub
+plugin or GitHub workflow skill is available, use it as the authoritative
+publication workflow. When it is unavailable, use the Yukh safe local fallback
+and stop before unverified external GitHub mutation.
+
+## Roles
+
+- A **worker** edits files only inside its assigned scope.
+- A **subagent** follows the same rules as a worker, with a parent worker as
+  its delegating authority.
+- A **manager** classifies scope, budget, model, skills and acceptance evidence.
+- An **operator or publishing manager** commits, pushes and opens the pull
+  request after checking the diff.
+
+## Commit attribution
+
+Use truthful authorship:
+
+- If an agent directly generated the final file changes, set commit `Author` to
+  that agent.
+- If a manager or operator applied an agent's patch without changing it, keep
+  the agent as `Author` and the integrator as `Committer`.
+- If an agent only reviewed or verified work, keep the real implementer as
+  `Author` and add a `Verified-by` trailer for the agent.
+
+Recommended trailers:
+
+```text
+Generated-by: yukh <agent_id>
+Verified-by: yukh <agent_id>
+Team: <team_id>
+Coordination-agent: <coordination_agent>
+Token-observed: <observed>/<budget>
+Log: <workspace-relative-log-path>
+```
+
+Do not claim an agent authored a change it only validated.
+
+## Publish flow
+
+Follow the GitHub publish workflow:
+
+1. Inspect `git status -sb` and the exact diff.
+2. If unrelated changes are present, stage explicit paths only.
+3. Create an `agent/<description>` branch when starting from `main`.
+4. Commit with a terse subject and the trailers above.
+5. Run the smallest relevant validation already justified by the task.
+6. Push the branch.
+7. Open a draft pull request by default.
+
+The pull request body should state what changed, why, validation performed,
+the agent/team evidence and anything not yet verified.
+
+## Subagent behavior
+
+Subagents do not publish independently. They return bounded evidence to their
+parent:
+
+- files changed or patch summary;
+- validation command and result;
+- token usage if available;
+- log path or Coordination receipt;
+- explicit gaps.
+
+The parent worker or manager decides whether the result becomes part of a
+commit. A subagent's ID may appear in `Generated-by` only for the files it
+actually produced.
+
+## Fail closed
+
+Do not commit or push when:
+
+- the diff contains unrelated files;
+- author attribution is unclear;
+- token accounting is missing for a budgeted worker;
+- required receipts are missing;
+- validation was skipped without an explicit reason.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ and one denial, cleans up, then exits.
 
 - **Evaluate it:** run the [read-only demo](guides/read-only-demo.md).
 - **Inspect the process:** start the [inert gateway](how-to/run-inert-gateway.md).
+- **Publish agent work:** follow the [agent GitHub workflow](guides/agent-github-workflow.md).
 - **Integrate contracts:** use the [contract reference](reference/contracts.md).
 - **Review safety:** read the [security model](security/security-model.md).
 

--- a/plugins/yukh/.codex-plugin/plugin.json
+++ b/plugins/yukh/.codex-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "yukh",
+  "version": "0.1.0",
+  "description": "Yukh suite operating skills for agent teams, Coordination handoffs, budgeted work, and GitHub-compatible publication.",
+  "author": {
+    "name": "Nomed"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Yukh",
+    "shortDescription": "Operate Yukh agent teams safely.",
+    "longDescription": "Yukh provides operating skills for manager, worker, and subagent behavior across Yukh MCP, Coordination, token budgets, evidence, and GitHub-compatible publication.",
+    "developerName": "Nomed",
+    "category": "Productivity",
+    "capabilities": [],
+    "defaultPrompt": "Use the Yukh agent workflow: plan bounded work, preserve receipts and token evidence, and publish through the GitHub-compatible path when needed."
+  }
+}

--- a/plugins/yukh/skills/yukh-agent-workflow/SKILL.md
+++ b/plugins/yukh/skills/yukh-agent-workflow/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: yukh-agent-workflow
+description: Use when operating Yukh manager, worker, or subagent teams; assigning roles, models, skills, budgets, receipts, and evidence; or developing the Yukh suite with Yukh itself.
+---
+
+# Yukh Agent Workflow
+
+Use this skill when a task asks Codex to operate through Yukh, create or guide
+Yukh managers/workers/subagents, or develop the Yukh suite with Yukh itself.
+
+## Core rule
+
+Yukh gives agents capability, not custody. A manager may compose bounded work,
+but repository mutation and external publication remain explicit, reviewable
+handoffs.
+
+## Manager behavior
+
+Before engaging a worker, the manager must define:
+
+- role and responsibility;
+- runtime and model from the available allowlist;
+- required skills, omitting unavailable skills rather than inventing them;
+- token budget, command limit, runtime timeout and tool mode;
+- exact task scope and acceptance evidence;
+- whether the worker may spawn subagents.
+
+Prefer the smallest useful team. Do not create agents merely to mirror an org
+chart. If one bounded worker is enough, use one worker.
+
+## Worker behavior
+
+A worker must:
+
+- stay inside the assigned scope;
+- use only authorized tools and context;
+- keep output compact;
+- report token usage when available;
+- report log path, Coordination receipt, or other evidence;
+- fail closed when required receipts, budget accounting, or permissions are
+  missing.
+
+Workers do not publish independently unless explicitly assigned the publishing
+role.
+
+## Subagent behavior
+
+Subagents inherit the parent task boundary. They return bounded evidence to the
+parent:
+
+- files changed or patch summary;
+- validation command and result;
+- token usage if available;
+- log path or Coordination receipt;
+- explicit gaps.
+
+A parent worker or manager decides whether subagent output becomes part of a
+commit. Subagents may be credited only for work they actually produced.
+
+## Self-development baseline
+
+When using Yukh on the Yukh suite itself, prefer this order:
+
+1. read-only baseline probe;
+2. bounded diff classification;
+3. one micro implementation or documentation increment;
+4. focused validation;
+5. GitHub-compatible publication.
+
+Never start with a broad implementation team if the repo state, budget, model
+catalog, runtime, or Coordination health is unknown.
+
+## Token discipline
+
+Preflight before launch when possible. If the CLI runtime has a measured token
+floor, do not launch below that floor. Prefer SDK/lean runtimes for cheap
+workers once qualified. Token overrun is a hard failure, not a warning.
+
+## Authorship evidence
+
+Use truthful attribution:
+
+- agent generated final file changes: agent may be commit `Author`;
+- manager/operator applied an unchanged agent patch: agent may be `Author`,
+  integrator is `Committer`;
+- agent only verified: use `Verified-by`, not `Author`.
+
+Recommended evidence trailers:
+
+```text
+Generated-by: yukh <agent_id>
+Verified-by: yukh <agent_id>
+Team: <team_id>
+Coordination-agent: <coordination_agent>
+Token-observed: <observed>/<budget>
+Log: <workspace-relative-log-path>
+```
+
+Do not claim an agent authored a change it only validated.
+

--- a/plugins/yukh/skills/yukh-github-publication/SKILL.md
+++ b/plugins/yukh/skills/yukh-github-publication/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: yukh-github-publication
+description: "Use when publishing Yukh-generated or Yukh-verified work to GitHub: commit attribution, branch creation, push, draft pull request, and GitHub workflow compatibility."
+---
+
+# Yukh GitHub Publication
+
+Use this skill when Yukh-managed work needs to become a commit, branch, push or
+pull request.
+
+## Relationship to GitHub skills
+
+This skill is GitHub-aware but not GitHub-dependent.
+
+If a GitHub workflow skill or GitHub plugin tool is available, follow that
+workflow for GitHub operations. In particular, respect the publish flow that
+requires diff inspection, explicit staging, branch discipline, validation, push
+and draft pull request by default.
+
+If GitHub skills/tools are unavailable, use the safe local fallback below and
+stop before unverified external GitHub mutation.
+
+## Required publish flow
+
+1. Inspect `git status -sb` and the exact diff.
+2. If unrelated changes exist, stage explicit paths only.
+3. If starting from `main` or the default branch, create `agent/<description>`.
+4. Commit with a terse subject.
+5. Add truthful Yukh evidence trailers.
+6. Run the smallest relevant validation justified by the change.
+7. Push with tracking only after scope is clear.
+8. Open a draft pull request by default.
+
+The pull request body must state:
+
+- what changed;
+- why it changed;
+- validation performed;
+- agent/team evidence;
+- known gaps or skipped validation.
+
+## Attribution
+
+Set commit authorship by actual contribution:
+
+- `Author`: the agent or person that produced the final file changes.
+- `Committer`: the integrator that created the commit.
+- `Verified-by`: any agent that only checked the result.
+
+Never use an agent as `Author` when it only ran a read-only verification.
+
+## Safe local fallback
+
+When GitHub tools are not available:
+
+- inspect and stage locally;
+- create a local branch if needed;
+- create the local commit only when attribution and scope are clear;
+- do not push or open a pull request;
+- report the exact command sequence the operator should run in a GitHub-capable
+  environment.
+
+## Stop conditions
+
+Do not commit, push or open a PR when:
+
+- the diff contains unrelated files;
+- author attribution is unclear;
+- token accounting is missing for a budgeted worker;
+- required receipts are missing;
+- validation was skipped without an explicit reason;
+- GitHub repository or authentication state is ambiguous.

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -608,6 +608,54 @@ printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_inpu
   }
 });
 
+test("approved preflight forwards preview runtime to launched worker wrapper", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-approved-preview-runtime-")));
+  try {
+    const observedRuntime = join(root, "observed-preview-runtime.txt");
+    const worker = join(root, "worker.mjs");
+    const executable = join(root, "agent-cli");
+    const mcp = join(root, "coordination.mjs");
+    const teamControlMcp = join(root, "team-control.mjs");
+    const previewRuntime = join(root, "preview-runtime");
+    await writeFile(
+      worker,
+      `import {writeFileSync} from "node:fs"; writeFileSync(${JSON.stringify(observedRuntime)}, process.env.YUKH_PREVIEW_RUNTIME ?? "");`,
+    );
+    await writeFile(executable, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+    await writeFile(mcp, "", { mode: 0o600 });
+    await writeFile(teamControlMcp, "", { mode: 0o600 });
+    const store = new TeamStore(root);
+    const team = store.create("Launch worker", "codex");
+    const agent = store.spawn(team.team_id, {
+      runtime: "codex",
+      role: "backend-reviewer",
+      task: "Review backend",
+      token_budget: 120_000,
+    });
+    const supervisor = new TeamSupervisor({
+      node: process.execPath,
+      worker,
+      launcher: executable,
+      coordinationMcp: mcp,
+      teamControlMcp,
+      codex: executable,
+      copilot: executable,
+      workspace: root,
+      profileEnvironment: { YUKH_PREVIEW_RUNTIME: previewRuntime },
+    });
+    supervisor.launch(agent);
+    for (let attempt = 0; attempt < 50; attempt++) {
+      try {
+        if ((await readFile(observedRuntime, "utf8")) === previewRuntime) break;
+      } catch {}
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    assert.equal(await readFile(observedRuntime, "utf8"), previewRuntime);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("approved preflight blocks micro workers before provider launch without explicit opt-in", async () => {
   const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-approved-micro-block-")));
   try {
@@ -2027,6 +2075,67 @@ test("worker fails closed before agent launch when Coordination cannot join", as
     assert.equal(await new Promise<number | null>((resolve) => child.once("close", resolve)), 1);
     assert.equal(store.agent(team.team_id, agent.agent_id).state, "failed");
     await assert.rejects(readFile(marker), /ENOENT/u);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("worker forwards preview runtime to Coordination launcher", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-team-preview-runtime-")));
+  try {
+    const observed = join(root, "observed-preview-runtime");
+    const previewRuntime = join(root, "preview-runtime");
+    const executable = join(root, "agent-cli");
+    const launcher = join(root, "launcher");
+    const support = join(root, "support.mjs");
+    await writeFile(
+      executable,
+      `#!/bin/sh
+printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"runtime ok"}}'
+printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":20,"reasoning_output_tokens":5}}'
+`,
+      { mode: 0o700 },
+    );
+    await writeFile(
+      launcher,
+      `#!/bin/sh
+printf '%s' "$YUKH_PREVIEW_RUNTIME" > ${JSON.stringify(observed)}
+cat >/dev/null
+printf '{"schema":1,"status":"ok","command":"test"}\\n'
+`,
+      { mode: 0o700 },
+    );
+    await writeFile(support, "", { mode: 0o600 });
+    const store = new TeamStore(root);
+    const team = store.create("Forward preview runtime", "codex");
+    const agent = store.spawn(team.team_id, {
+      runtime: "codex",
+      role: "backend-reviewer",
+      task: "Verify preview runtime",
+      token_budget: 120_000,
+    });
+    const child = spawn(
+      process.execPath,
+      ["--import", tsxLoader, workerMain, team.team_id, agent.agent_id],
+      {
+        cwd: root,
+        stdio: "ignore",
+        env: {
+          HOME: process.env.HOME ?? "",
+          PATH: process.env.PATH ?? "/usr/bin:/bin",
+          YUKH_TEAM_WORKSPACE: root,
+          YUKH_COORDINATION_LAUNCHER: launcher,
+          YUKH_COORDINATION_MCP_MAIN: support,
+          YUKH_TEAM_CONTROL_MCP_MAIN: support,
+          YUKH_CODEX_EXECUTABLE: executable,
+          YUKH_COPILOT_EXECUTABLE: executable,
+          YUKH_PREVIEW_RUNTIME: previewRuntime,
+        },
+      },
+    );
+    assert.equal(await new Promise<number | null>((resolve) => child.once("close", resolve)), 0);
+    assert.equal(await readFile(observed, "utf8"), previewRuntime);
+    assert.equal(store.agent(team.team_id, agent.agent_id).state, "completed");
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## What changed

- Propagates `YUKH_PREVIEW_RUNTIME` through team-control approved runs, plan execution, worker bootstrap and provider launch paths.
- Adds tests proving preview runtime propagation at supervisor and worker launcher boundaries.
- Adds the local Yukh plugin with `yukh-agent-workflow` and `yukh-github-publication` skills.
- Documents the GitHub-compatible agent publication workflow and links it from the docs index.

## Why

Yukh workers on restricted runtimes such as rufy-worker cannot assume `$HOME/.yukh/local-preview` is writable. The manager/worker flow also needs first-class Yukh skills for manager, worker, subagent, attribution and GitHub publication behavior without making the suite hard-dependent on the GitHub plugin.

## Validation

- `node --import tsx --test test/runtime/team-control.test.ts`
- `npm run typecheck`
- `npm run build`
- Yukh plugin validation passed.
- `yukh-agent-workflow` skill validation passed.
- `yukh-github-publication` skill validation passed.
- Real Yukh self-development read-only worker completed successfully.

## Yukh evidence

- `Verified-by: yukh worker-adde5225-f35f-4672-a088-02bf5826ce90`
- `Team: team-5f0962ed-9da8-4d20-bb69-009456489147`
- `Coordination-agent: agent-suite-readonly-verifier-1b934dc6`
- `Token-observed: 29395/120000`
- `Log: .yukh/teams/team-5f0962ed-9da8-4d20-bb69-009456489147/agents/worker-adde5225-f35f-4672-a088-02bf5826ce90.log`

## Notes

Draft PR by default. The GitHub plugin workflow was consulted for staging, attribution, branch, validation and draft PR behavior.