### PR TITLE
feat: add control plane preview

### DIFF
--- a/.context/sessions/SESSION-2026-08-18-01-projects-handoff-adapter.md
+++ b/.context/sessions/SESSION-2026-08-18-01-projects-handoff-adapter.md
@@ -1,0 +1,43 @@
+# SESSION-2026-08-18-01 — Projects handoff adapter
+
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/245
+- Pull request: https://github.com/nomed/yukh-mcp/pull/244
+- Status: In progress
+
+## Objective
+
+Consume the provider-neutral manager orchestration handoff emitted by
+`yukh-projects` and map it to bounded local Yukh team manager startup.
+
+## Work completed
+
+- Added a closed parser for `yukh-projects-manager-orchestration-handoff-v1`.
+- Added `yukh team start-from-handoff`.
+- Added dry-run support for preview/control-plane use.
+- Mapped MCP/control-plane handoff routes to the existing accounted
+  `team start` manager path.
+
+## Evidence and validation
+
+- `npm run typecheck`
+- `node --import tsx --test test/runtime/team-start-handoff.test.ts`
+- `npm run test:runtime` outside sandbox because loopback listener tests require
+  binding to `127.0.0.1`.
+
+## Decisions discovered
+
+`yukh-projects` remains the governance/admission layer. It does not call MCP,
+Codex, Copilot, SDKs, or CLIs. `yukh-mcp` is the local adapter that may consume
+the admitted handoff and start a bounded manager through existing team-control
+runtime supervision.
+
+## Context impact
+
+Future control-plane work should call `yukh team start-from-handoff` or the same
+handoff mapping function instead of reinterpreting Projects admission records.
+
+## Risks and unresolved work
+
+- The adapter currently supports `mcp` and `control_plane` routes only.
+- SDK-specific Codex/Copilot session startup remains behind the existing team
+  worker runtime path.

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -1,0 +1,107 @@
+import { createServer, type Server } from "node:http";
+import { readFile } from "node:fs/promises";
+import { dirname, join, normalize } from "node:path";
+import { fileURLToPath } from "node:url";
+
+type ControlPlaneOptions = {
+  readonly host: string;
+  readonly port: number;
+  readonly staticRoot?: string;
+};
+
+const CONTENT_TYPES = new Map([
+  ["index.html", "text/html; charset=utf-8"],
+  ["styles.css", "text/css; charset=utf-8"],
+  ["mock-data.js", "text/javascript; charset=utf-8"],
+]);
+
+export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
+  const options = { host: "127.0.0.1", port: 7345 } as {
+    host: string;
+    port: number;
+    staticRoot?: string;
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === "--host" && next) {
+      options.host = next;
+      i += 1;
+    } else if (arg === "--port" && next) {
+      const port = Number.parseInt(next, 10);
+      if (!Number.isInteger(port) || port < 0 || port > 65_535) {
+        throw new TypeError("invalid control plane port");
+      }
+      options.port = port;
+      i += 1;
+    } else if (arg === "--static-root" && next) {
+      options.staticRoot = next;
+      i += 1;
+    } else {
+      throw new TypeError("invalid control plane arguments");
+    }
+  }
+  return options;
+}
+
+export function defaultStaticRoot(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return normalize(join(here, "..", "static"));
+}
+
+function requestedFile(url = "/"): string | null {
+  const path = new URL(url, "http://127.0.0.1").pathname;
+  if (path === "/" || path === "/index.html") return "index.html";
+  if (path === "/styles.css") return "styles.css";
+  if (path === "/mock-data.js") return "mock-data.js";
+  return null;
+}
+
+export function createControlPlaneServer(staticRoot = defaultStaticRoot()): Server {
+  return createServer(async (request, response) => {
+    const file = requestedFile(request.url);
+    if (!file) {
+      response.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+      response.end("not found\n");
+      return;
+    }
+    try {
+      const body = await readFile(join(staticRoot, file));
+      response.writeHead(200, {
+        "cache-control": "no-store",
+        "content-type": CONTENT_TYPES.get(file) ?? "application/octet-stream",
+      });
+      response.end(body);
+    } catch {
+      response.writeHead(500, { "content-type": "text/plain; charset=utf-8" });
+      response.end("control plane preview asset unavailable\n");
+    }
+  });
+}
+
+export async function startControlPlane(options: ControlPlaneOptions): Promise<Server> {
+  const server = createControlPlaneServer(options.staticRoot);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(options.port, options.host, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  return server;
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+  const options = parseArguments(argv);
+  const server = await startControlPlane(options);
+  const address = server.address();
+  const port = typeof address === "object" && address !== null ? address.port : options.port;
+  process.stdout.write(
+    `Yukh Control Plane preview: http://${options.host}:${port}\n` +
+      "Static mock UI only: no runtime mutations are exposed.\n",
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/apps/control-plane-preview/static/index.html
+++ b/apps/control-plane-preview/static/index.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Yukh Control Plane Preview</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <header class="topbar">
+      <div class="brand">
+        <span class="logo" aria-hidden="true">Y</span>
+        <div>
+          <p class="eyebrow">Yukh suite</p>
+          <h1>Control Plane</h1>
+        </div>
+      </div>
+      <div class="status-pill"><span class="dot ok"></span>Local preview</div>
+    </header>
+
+    <main class="shell">
+      <aside class="sidebar" aria-label="Projects">
+        <button class="primary">Start team</button>
+        <nav>
+          <a class="active" href="#dashboard">Dashboard</a>
+          <a href="#teams">Teams</a>
+          <a href="#transcript">Transcript</a>
+          <a href="#budgets">Budgets</a>
+          <a href="#settings">Providers</a>
+        </nav>
+        <section class="card compact">
+          <p class="eyebrow">Current workspace</p>
+          <strong id="workspace-name">yukh-task-board</strong>
+          <span class="muted">/Users/nomed/Code/yulh-workspace/yukh-task-board</span>
+        </section>
+      </aside>
+
+      <section class="content" id="dashboard">
+        <section class="hero card">
+          <div>
+            <p class="eyebrow">Manager-first run</p>
+            <h2>Use Yukh without manual agent ping-pong.</h2>
+            <p>
+              Start from a goal, inspect the manager plan, approve delegation only when budget,
+              worker roles and provider choices are clear.
+            </p>
+          </div>
+          <div class="hero-actions">
+            <button class="primary">New plan-first run</button>
+            <button class="secondary">Open latest logs</button>
+          </div>
+        </section>
+
+        <section class="grid metrics" aria-label="Run summary">
+          <article class="metric card">
+            <span>Active teams</span><strong id="metric-teams">—</strong>
+          </article>
+          <article class="metric card">
+            <span>Running agents</span><strong id="metric-agents">—</strong>
+          </article>
+          <article class="metric card">
+            <span>Token budget</span><strong id="metric-budget">—</strong>
+          </article>
+          <article class="metric card">
+            <span>Provider mix</span><strong id="metric-providers">—</strong>
+          </article>
+        </section>
+
+        <section class="two-column" id="teams">
+          <article class="card">
+            <div class="section-title">
+              <div>
+                <p class="eyebrow">Teams</p>
+                <h3>Live work</h3>
+              </div>
+              <span class="muted">mock data</span>
+            </div>
+            <div id="team-list" class="team-list"></div>
+          </article>
+
+          <article class="card" id="budgets">
+            <div class="section-title">
+              <div>
+                <p class="eyebrow">Budget</p>
+                <h3>Token control</h3>
+              </div>
+              <span class="status-pill small"><span class="dot warn"></span>reviewable</span>
+            </div>
+            <div id="budget-panel"></div>
+          </article>
+        </section>
+
+        <section class="two-column wide-left">
+          <article class="card" id="transcript">
+            <div class="section-title">
+              <div>
+                <p class="eyebrow">Coordination</p>
+                <h3>Verified transcript</h3>
+              </div>
+              <button class="secondary small-button">Full bodies</button>
+            </div>
+            <div id="transcript-list" class="transcript"></div>
+          </article>
+
+          <article class="card" id="settings">
+            <div class="section-title">
+              <div>
+                <p class="eyebrow">Start</p>
+                <h3>New team</h3>
+              </div>
+            </div>
+            <form class="start-form">
+              <label
+                >Goal<textarea>
+Improve the Yukh control plane with one bounded UI increment.</textarea>
+              </label>
+              <label
+                >Mode<select>
+                  <option>plan-first</option>
+                  <option>delegate, explicit workers</option>
+                </select></label
+              >
+              <label
+                >Provider<select>
+                  <option>Copilot SDK workers</option>
+                  <option>Codex manager CLI</option>
+                  <option>Codex SDK, planned</option>
+                </select></label
+              >
+              <label>Budget<input value="120000" inputmode="numeric" /></label>
+              <button type="button" class="primary">Create manager plan</button>
+            </form>
+          </article>
+        </section>
+      </section>
+    </main>
+
+    <script type="module" src="./mock-data.js"></script>
+  </body>
+</html>

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -1,0 +1,135 @@
+const data = {
+  workspace: "yukh-task-board",
+  teams: [
+    {
+      id: "team-manager-preview",
+      goal: "Improve the Yukh control plane with one bounded UI increment.",
+      mode: "plan-first",
+      state: "waiting for approval",
+      budget: { allocated: 120000, reserved: 40000, used: 18420 },
+      agents: [
+        {
+          name: "manager",
+          role: "product-engineering manager",
+          provider: "Codex CLI",
+          state: "planned",
+        },
+        {
+          name: "frontend-worker",
+          role: "UI implementer",
+          provider: "Copilot SDK",
+          state: "proposed",
+        },
+        {
+          name: "qa-worker",
+          role: "runtime verifier",
+          provider: "Codex SDK planned",
+          state: "not launched",
+        },
+      ],
+    },
+    {
+      id: "team-task-board-smoke",
+      goal: "Verify automatic Coordination handoff.",
+      mode: "delegate",
+      state: "complete",
+      budget: { allocated: 80000, reserved: 55000, used: 31200 },
+      agents: [
+        { name: "agent-b", role: "frontend worker", provider: "Copilot CLI", state: "answered" },
+      ],
+    },
+  ],
+  transcript: [
+    {
+      time: "12:31:18",
+      kind: "question",
+      from: "agent:a",
+      to: "agent:b",
+      body: "Confirm that the coordinator launched you and report the question event id.",
+      eventId: "01a00fb4-71a3-7b10-9b1f-0dc8f6d3fcd6",
+    },
+    {
+      time: "12:32:02",
+      kind: "answer",
+      from: "agent:b",
+      to: "agent:a",
+      body: "Confirmed. The coordinator launched me through Yukh Coordination.",
+      eventId: "01a00fb7-2a0e-7a21-a5f2-preview",
+    },
+    {
+      time: "12:32:03",
+      kind: "coordinator",
+      from: "coordinator",
+      to: "observer",
+      body: "Answer verified. The worker response is linked to the original question and receipt.",
+      eventId: "lifecycle:answer-verified",
+    },
+  ],
+};
+
+const byId = (id) => document.getElementById(id);
+const activeTeams = data.teams.filter((team) => team.state !== "complete");
+const agents = data.teams.flatMap((team) => team.agents);
+const used = data.teams.reduce((sum, team) => sum + team.budget.used, 0);
+const allocated = data.teams.reduce((sum, team) => sum + team.budget.allocated, 0);
+
+byId("workspace-name").textContent = data.workspace;
+byId("metric-teams").textContent = String(activeTeams.length);
+byId("metric-agents").textContent = String(agents.length);
+byId("metric-budget").textContent = `${Math.round((used / allocated) * 100)}% used`;
+byId("metric-providers").textContent = "CLI + SDK";
+
+byId("team-list").innerHTML = data.teams
+  .map(
+    (team) => `
+      <article class="team-row">
+        <div>
+          <p class="eyebrow">${team.mode}</p>
+          <h3>${team.id}</h3>
+          <p class="muted">${team.goal}</p>
+          <div class="agent-stack">
+            ${team.agents
+              .map(
+                (agent) =>
+                  `<span class="chip ${agent.state === "answered" ? "good" : ""}">${agent.name}: ${agent.provider}</span>`,
+              )
+              .join("")}
+          </div>
+        </div>
+        <span class="status-pill small"><span class="dot ${team.state === "complete" ? "ok" : "warn"}"></span>${team.state}</span>
+      </article>
+    `,
+  )
+  .join("");
+
+byId("budget-panel").innerHTML = data.teams
+  .map((team) => {
+    const percentage = Math.round((team.budget.used / team.budget.allocated) * 100);
+    return `
+      <article class="budget-row">
+        <div class="section-title">
+          <strong>${team.id}</strong>
+          <span class="muted">${team.budget.used.toLocaleString()} / ${team.budget.allocated.toLocaleString()}</span>
+        </div>
+        <div class="bar" aria-label="${percentage}% token budget used"><span style="width: ${percentage}%"></span></div>
+        <span class="muted">Reserved: ${team.budget.reserved.toLocaleString()} tokens</span>
+      </article>
+    `;
+  })
+  .join("");
+
+byId("transcript-list").innerHTML = data.transcript
+  .map(
+    (event) => `
+      <article class="event-row ${event.kind}">
+        <div class="event-meta">
+          <span>${event.time}</span>
+          <span>${event.from} → ${event.to}</span>
+          <span>${event.kind}</span>
+          <span>${event.eventId}</span>
+        </div>
+        <p>${event.body}</p>
+      </article>
+    `,
+  )
+  .join("");

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -1,0 +1,335 @@
+:root {
+  color-scheme: dark;
+  --bg: #0b0d12;
+  --panel: #121722;
+  --panel-2: #171e2b;
+  --line: #273142;
+  --text: #eef3fb;
+  --muted: #93a1b5;
+  --accent: #77f0b2;
+  --accent-2: #8cb5ff;
+  --warn: #ffd166;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top left, rgba(119, 240, 178, 0.11), transparent 30rem),
+    radial-gradient(circle at top right, rgba(140, 181, 255, 0.11), transparent 28rem), var(--bg);
+  color: var(--text);
+}
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+h1,
+h2,
+h3,
+p {
+  margin: 0;
+}
+h1 {
+  font-size: 22px;
+}
+h2 {
+  font-size: clamp(28px, 4vw, 48px);
+  letter-spacing: -0.04em;
+  line-height: 0.98;
+  margin-bottom: 14px;
+  max-width: 760px;
+}
+h3 {
+  font-size: 18px;
+}
+.topbar {
+  align-items: center;
+  background: rgba(11, 13, 18, 0.86);
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  justify-content: space-between;
+  padding: 18px 28px;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+.brand {
+  align-items: center;
+  display: flex;
+  gap: 14px;
+}
+.logo {
+  align-items: center;
+  background: #05070a;
+  border: 1px solid #2d384a;
+  border-radius: 14px;
+  color: var(--accent);
+  display: grid;
+  font-weight: 800;
+  height: 44px;
+  place-items: center;
+  width: 44px;
+}
+.eyebrow {
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+}
+.muted {
+  color: var(--muted);
+}
+.shell {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: 260px minmax(0, 1fr);
+  padding: 24px;
+}
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+nav {
+  background: rgba(18, 23, 34, 0.8);
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  padding: 8px;
+}
+nav a {
+  border-radius: 14px;
+  color: var(--muted);
+  display: block;
+  padding: 11px 12px;
+  text-decoration: none;
+}
+nav a.active,
+nav a:hover {
+  background: var(--panel-2);
+  color: var(--text);
+}
+.content {
+  display: grid;
+  gap: 18px;
+}
+.card {
+  background: rgba(18, 23, 34, 0.82);
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.22);
+  padding: 20px;
+}
+.compact {
+  display: grid;
+  gap: 4px;
+}
+.hero {
+  align-items: end;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  min-height: 230px;
+  padding: 30px;
+}
+.hero p {
+  color: var(--muted);
+  max-width: 680px;
+}
+.hero-actions {
+  display: flex;
+  gap: 10px;
+}
+.primary,
+.secondary {
+  border: 0;
+  border-radius: 14px;
+  cursor: default;
+  font-weight: 800;
+  padding: 11px 14px;
+}
+.primary {
+  background: var(--accent);
+  color: #06110c;
+}
+.secondary {
+  background: #202938;
+  color: var(--text);
+}
+.small-button {
+  padding: 8px 10px;
+}
+.grid {
+  display: grid;
+  gap: 14px;
+}
+.metrics {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+.metric {
+  display: grid;
+  gap: 8px;
+}
+.metric span {
+  color: var(--muted);
+  font-size: 13px;
+}
+.metric strong {
+  font-size: 28px;
+}
+.two-column {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(0, 1.1fr) minmax(340px, 0.9fr);
+}
+.wide-left {
+  grid-template-columns: minmax(0, 1.35fr) minmax(340px, 0.65fr);
+}
+.section-title {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+.status-pill {
+  align-items: center;
+  background: #172033;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  display: inline-flex;
+  gap: 8px;
+  padding: 8px 11px;
+}
+.status-pill.small {
+  font-size: 12px;
+  padding: 6px 9px;
+}
+.dot {
+  border-radius: 50%;
+  display: inline-block;
+  height: 9px;
+  width: 9px;
+}
+.dot.ok {
+  background: var(--accent);
+}
+.dot.warn {
+  background: var(--warn);
+}
+.team-list,
+.transcript,
+#budget-panel {
+  display: grid;
+  gap: 12px;
+}
+.team-row,
+.event-row,
+.budget-row {
+  background: var(--panel-2);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 18px;
+  padding: 14px;
+}
+.team-row {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+.agent-stack {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+.chip {
+  background: #0d121c;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 12px;
+  padding: 5px 8px;
+}
+.chip.good {
+  color: var(--accent);
+}
+.event-row {
+  border-left: 3px solid var(--accent-2);
+}
+.event-row.answer {
+  border-left-color: var(--accent);
+}
+.event-row.coordinator {
+  border-left-color: var(--warn);
+}
+.event-meta {
+  color: var(--muted);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 12px;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.budget-row {
+  display: grid;
+  gap: 10px;
+}
+.bar {
+  background: #0a0f18;
+  border-radius: 999px;
+  height: 10px;
+  overflow: hidden;
+}
+.bar span {
+  background: linear-gradient(90deg, var(--accent), var(--accent-2));
+  display: block;
+  height: 100%;
+}
+.start-form {
+  display: grid;
+  gap: 14px;
+}
+label {
+  color: var(--muted);
+  display: grid;
+  gap: 7px;
+  font-size: 13px;
+}
+input,
+select,
+textarea {
+  background: #0d121c;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  color: var(--text);
+  min-width: 0;
+  padding: 11px 12px;
+}
+textarea {
+  min-height: 118px;
+  resize: vertical;
+}
+@media (max-width: 980px) {
+  .shell,
+  .hero,
+  .two-column,
+  .wide-left,
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+  .hero-actions {
+    flex-wrap: wrap;
+  }
+}

--- a/apps/team-start/src/handoff-main.ts
+++ b/apps/team-start/src/handoff-main.ts
@@ -1,0 +1,160 @@
+import { readFileSync, realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseProjectsManagerOrchestrationHandoff, startManagerFromHandoff } from "./handoff.js";
+
+interface CliArguments {
+  readonly handoffPath: string;
+  readonly workspace: string;
+  readonly goal?: string;
+  readonly launcher: string;
+  readonly codex: string;
+  readonly copilot: string;
+  readonly dryRun: boolean;
+  readonly format: "json" | "text";
+  readonly model?: string;
+  readonly skills?: readonly string[];
+  readonly allowDynamicWorkers: boolean;
+  readonly codexModels?: string;
+  readonly copilotModels?: string;
+  readonly codexSkills?: string;
+  readonly copilotSkills?: string;
+  readonly copilotWorkerProvider?: "sdk" | "cli";
+}
+
+function required(value: string | undefined, name: string): string {
+  if (!value) throw new TypeError(`missing ${name}`);
+  return value;
+}
+
+function boolean(value: string | undefined): boolean {
+  return value === "true" || value === "1";
+}
+
+function list(value: string | undefined): readonly string[] | undefined {
+  return value ? value.split(",").filter(Boolean) : undefined;
+}
+
+function executable(value: string): string {
+  return realpathSync(value);
+}
+
+export function parseHandoffArguments(argv: readonly string[]): CliArguments {
+  const values = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!name?.startsWith("--") || value === undefined || value.startsWith("--"))
+      throw new TypeError("invalid team handoff arguments");
+    values.set(name.slice(2), value);
+  }
+  const format = values.get("format") ?? "text";
+  if (format !== "json" && format !== "text") throw new TypeError("invalid output format");
+  const copilotWorkerProvider = values.get("copilot-worker-provider");
+  if (
+    copilotWorkerProvider !== undefined &&
+    copilotWorkerProvider !== "sdk" &&
+    copilotWorkerProvider !== "cli"
+  )
+    throw new TypeError("invalid copilot worker provider");
+  const goal = values.get("goal");
+  const model = values.get("model");
+  const skills = list(values.get("skills"));
+  const codexModels = values.get("codex-models") ?? process.env.YUKH_CODEX_MODELS;
+  const copilotModels = values.get("copilot-models") ?? process.env.YUKH_COPILOT_MODELS;
+  const codexSkills = values.get("codex-skills") ?? process.env.YUKH_CODEX_SKILLS;
+  const copilotSkills = values.get("copilot-skills") ?? process.env.YUKH_COPILOT_SKILLS;
+  return {
+    handoffPath: realpathSync(resolve(required(values.get("handoff"), "--handoff"))),
+    workspace: realpathSync(resolve(values.get("workspace") ?? process.cwd())),
+    ...(goal ? { goal } : {}),
+    launcher: executable(
+      required(
+        values.get("launcher") ?? process.env.YUKH_COORDINATION_LAUNCHER,
+        "--launcher or YUKH_COORDINATION_LAUNCHER",
+      ),
+    ),
+    codex: executable(
+      required(
+        values.get("codex") ?? process.env.YUKH_CODEX_EXECUTABLE,
+        "--codex or YUKH_CODEX_EXECUTABLE",
+      ),
+    ),
+    copilot: executable(
+      required(
+        values.get("copilot") ?? process.env.YUKH_COPILOT_EXECUTABLE,
+        "--copilot or YUKH_COPILOT_EXECUTABLE",
+      ),
+    ),
+    dryRun: boolean(values.get("dry-run")),
+    format,
+    ...(model ? { model } : {}),
+    ...(skills ? { skills } : {}),
+    allowDynamicWorkers:
+      boolean(values.get("allow-dynamic-workers")) ||
+      process.env.YUKH_ENABLE_UNSAFE_DYNAMIC_WORKERS === "1",
+    ...(codexModels ? { codexModels } : {}),
+    ...(copilotModels ? { copilotModels } : {}),
+    ...(codexSkills ? { codexSkills } : {}),
+    ...(copilotSkills ? { copilotSkills } : {}),
+    ...(copilotWorkerProvider ? { copilotWorkerProvider } : {}),
+  };
+}
+
+function text(output: ReturnType<typeof startManagerFromHandoff>): string {
+  if (output.dry_run) {
+    return [
+      "Yukh handoff accepted",
+      `Handoff: ${output.handoff_id}`,
+      `Runtime: ${output.mapped_start.runtime}`,
+      `Role: ${output.mapped_start.role}`,
+      `Model: ${output.mapped_start.model}`,
+      `Skills: ${output.mapped_start.skills.join(",") || "(none)"}`,
+      `Budget: manager=${output.mapped_start.manager_budget} team=${output.mapped_start.team_budget}`,
+      "Dry run: no manager process started",
+    ].join("\n");
+  }
+  return [
+    "Yukh manager started from Projects handoff",
+    `Handoff: ${output.handoff_id}`,
+    `Team: ${output.team.team_id}`,
+    `Manager: ${output.manager.agent_id} (${output.manager.runtime}/${output.manager.role})`,
+    `Runtime pid: ${output.runtime.pid}`,
+    `Runtime log: ${output.runtime.log}`,
+    "",
+    "Commands",
+    `- watch: ${output.watch_command}`,
+    `- status: ${output.status_command}`,
+  ].join("\n");
+}
+
+function isMain(): boolean {
+  return !!process.argv[1] && realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
+}
+
+export function main(argv: readonly string[] = process.argv.slice(2)): void {
+  try {
+    const cli = parseHandoffArguments(argv);
+    const handoff = parseProjectsManagerOrchestrationHandoff(readFileSync(cli.handoffPath, "utf8"));
+    const output = startManagerFromHandoff({
+      ...cli,
+      handoff,
+      goal:
+        cli.goal ??
+        `Start admitted Yukh work ${handoff.work_item_id} from Projects handoff ${handoff.handoff_id}`,
+    });
+    process.stdout.write(`${cli.format === "json" ? JSON.stringify(output) : text(output)}\n`);
+  } catch (error) {
+    process.stdout.write(
+      `${JSON.stringify({
+        schema: 1,
+        status: "error",
+        command: "team start-from-handoff",
+        code: error instanceof Error ? error.message : "team_start_from_handoff_failed",
+      })}\n`,
+    );
+    process.exitCode = 1;
+  }
+}
+
+if (isMain()) main();

--- a/apps/team-start/src/handoff.ts
+++ b/apps/team-start/src/handoff.ts
@@ -1,0 +1,334 @@
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import type { AgentRuntime } from "../../../packages/team-control/src/store.js";
+import { parseArguments, startManager, type Arguments } from "./main.js";
+
+export interface ProjectsManagerOrchestrationHandoff {
+  readonly schema: "yukh-projects-manager-orchestration-handoff-v1";
+  readonly handoff_id: string;
+  readonly phase: "ready_for_external_orchestrator";
+  readonly boundary: "external_orchestrator";
+  readonly transport: "mcp" | "sdk" | "cli" | "control_plane";
+  readonly adapter_id: string;
+  readonly capability: string;
+  readonly plan_id: string;
+  readonly admission_event_id: string;
+  readonly admission_event_digest: string;
+  readonly admission_command_digest: string;
+  readonly admission_outcome: "appended" | "replayed";
+  readonly namespace_id: string;
+  readonly project_id: string;
+  readonly run_id: string;
+  readonly work_item_id: string;
+  readonly manager_subject_id: string;
+  readonly worker_subject_id: string;
+  readonly role: string;
+  readonly model_family: "codex" | "copilot";
+  readonly model_capability: string;
+  readonly skill_count: number;
+  readonly acceptance_count: number;
+  readonly evidence_count: number;
+  readonly task_digest: string;
+  readonly budgets: {
+    readonly max_turns: number;
+    readonly max_input_tokens: number;
+    readonly max_output_tokens: number;
+    readonly max_wall_clock_seconds: number;
+  };
+  readonly activation: {
+    readonly max_ticks: number;
+    readonly max_acknowledgements: number;
+    readonly max_idle_ticks: number;
+  };
+  readonly orchestration_request_digest: string;
+  readonly instruction: {
+    readonly kind: "start_admitted_agent_session";
+    readonly policy: "external_orchestrator_must_enforce_budget_and_skill_limits";
+    readonly private_task_body_included: false;
+    readonly provider_call_authorized_here: false;
+  };
+}
+
+export interface HandoffStartArguments {
+  readonly workspace: string;
+  readonly handoff: ProjectsManagerOrchestrationHandoff;
+  readonly goal: string;
+  readonly launcher: string;
+  readonly codex: string;
+  readonly copilot: string;
+  readonly dryRun: boolean;
+  readonly format: "json" | "text";
+  readonly model?: string;
+  readonly skills?: readonly string[];
+  readonly allowDynamicWorkers: boolean;
+  readonly codexModels?: string;
+  readonly copilotModels?: string;
+  readonly codexSkills?: string;
+  readonly copilotSkills?: string;
+  readonly copilotWorkerProvider?: "sdk" | "cli";
+}
+
+const digest = /^sha-256:[0-9a-f]{64}$/u;
+const uuid7 = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const opaque = /^[a-z][a-z0-9_-]{0,31}:[A-Za-z0-9][A-Za-z0-9._~-]{0,127}$/u;
+const token = /^[a-z][a-z0-9_-]{0,63}$/u;
+const modelToken = /^[a-z0-9][a-z0-9._:-]{0,63}$/u;
+
+function record(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function exact(value: Record<string, unknown>, required: readonly string[]): void {
+  const keys = Object.keys(value);
+  if (
+    required.some((key) => !Object.hasOwn(value, key)) ||
+    keys.some((key) => !required.includes(key))
+  ) {
+    throw new TypeError("invalid handoff");
+  }
+}
+
+function positive(value: unknown, maximum: number): value is number {
+  return Number.isSafeInteger(value) && Number(value) > 0 && Number(value) <= maximum;
+}
+
+function assertDigest(value: unknown): asserts value is `sha-256:${string}` {
+  if (typeof value !== "string" || !digest.test(value)) throw new TypeError("invalid handoff");
+}
+
+export function parseProjectsManagerOrchestrationHandoff(
+  source: string | ProjectsManagerOrchestrationHandoff,
+): ProjectsManagerOrchestrationHandoff {
+  const value = typeof source === "string" ? JSON.parse(source) : source;
+  if (!record(value)) throw new TypeError("invalid handoff");
+  exact(value, [
+    "schema",
+    "handoff_id",
+    "issued_at",
+    "phase",
+    "boundary",
+    "transport",
+    "adapter_id",
+    "capability",
+    "plan_id",
+    "plan_digest",
+    "admission_event_id",
+    "admission_event_digest",
+    "admission_command_digest",
+    "admission_outcome",
+    "namespace_id",
+    "project_id",
+    "run_id",
+    "work_item_id",
+    "manager_subject_id",
+    "worker_subject_id",
+    "role",
+    "model_family",
+    "model_capability",
+    "skill_count",
+    "acceptance_count",
+    "evidence_count",
+    "task_digest",
+    "budgets",
+    "activation",
+    "orchestration_request_digest",
+    "instruction",
+  ]);
+  if (
+    value.schema !== "yukh-projects-manager-orchestration-handoff-v1" ||
+    value.phase !== "ready_for_external_orchestrator" ||
+    value.boundary !== "external_orchestrator" ||
+    !["mcp", "sdk", "cli", "control_plane"].includes(String(value.transport)) ||
+    !token.test(String(value.adapter_id)) ||
+    value.capability !== "agent_session_start" ||
+    typeof value.handoff_id !== "string" ||
+    !uuid7.test(value.handoff_id) ||
+    typeof value.plan_id !== "string" ||
+    !uuid7.test(value.plan_id) ||
+    (value.admission_outcome !== "appended" && value.admission_outcome !== "replayed") ||
+    typeof value.model_family !== "string" ||
+    !["codex", "copilot"].includes(value.model_family) ||
+    typeof value.role !== "string" ||
+    !token.test(value.role.replaceAll("_", "-")) ||
+    typeof value.model_capability !== "string" ||
+    !token.test(value.model_capability)
+  ) {
+    throw new TypeError("invalid handoff");
+  }
+  for (const key of [
+    "plan_digest",
+    "admission_event_digest",
+    "admission_command_digest",
+    "task_digest",
+    "orchestration_request_digest",
+  ])
+    assertDigest(value[key]);
+  for (const key of [
+    "namespace_id",
+    "project_id",
+    "run_id",
+    "work_item_id",
+    "manager_subject_id",
+    "worker_subject_id",
+  ])
+    if (typeof value[key] !== "string" || !opaque.test(value[key]))
+      throw new TypeError("invalid handoff");
+  if (!record(value.budgets)) throw new TypeError("invalid handoff");
+  exact(value.budgets, [
+    "max_turns",
+    "max_input_tokens",
+    "max_output_tokens",
+    "max_wall_clock_seconds",
+  ]);
+  if (
+    !positive(value.budgets.max_turns, 32) ||
+    !positive(value.budgets.max_input_tokens, 250_000) ||
+    !positive(value.budgets.max_output_tokens, 250_000) ||
+    !positive(value.budgets.max_wall_clock_seconds, 14_400)
+  ) {
+    throw new TypeError("invalid handoff");
+  }
+  if (!record(value.activation)) throw new TypeError("invalid handoff");
+  exact(value.activation, ["max_ticks", "max_acknowledgements", "max_idle_ticks"]);
+  if (
+    !positive(value.activation.max_ticks, 64) ||
+    !positive(value.activation.max_acknowledgements, 256) ||
+    !positive(value.activation.max_idle_ticks, value.activation.max_ticks)
+  ) {
+    throw new TypeError("invalid handoff");
+  }
+  if (
+    !positive(value.skill_count, 16) ||
+    !positive(value.acceptance_count, 16) ||
+    !positive(value.evidence_count, 16) ||
+    !record(value.instruction) ||
+    value.instruction.kind !== "start_admitted_agent_session" ||
+    value.instruction.policy !== "external_orchestrator_must_enforce_budget_and_skill_limits" ||
+    value.instruction.private_task_body_included !== false ||
+    value.instruction.provider_call_authorized_here !== false
+  ) {
+    throw new TypeError("invalid handoff");
+  }
+  return value as unknown as ProjectsManagerOrchestrationHandoff;
+}
+
+export function defaultSkillsForHandoff(
+  handoff: ProjectsManagerOrchestrationHandoff,
+): readonly string[] {
+  if (handoff.skill_count === 0) return [];
+  if (handoff.role.includes("frontend")) return ["frontend"];
+  if (handoff.role.includes("backend"))
+    return ["api-design", "testing"].slice(0, handoff.skill_count);
+  if (handoff.role.includes("qa")) return ["testing"];
+  if (handoff.role.includes("documentation")) return ["documentation"];
+  if (handoff.role.includes("product")) return ["product", "testing"].slice(0, handoff.skill_count);
+  return ["testing"].slice(0, handoff.skill_count);
+}
+
+export function teamStartArgumentsFromHandoff(input: HandoffStartArguments): Arguments {
+  const handoff = parseProjectsManagerOrchestrationHandoff(input.handoff);
+  if (handoff.transport !== "mcp" && handoff.transport !== "control_plane")
+    throw new TypeError("handoff transport not supported by local team start");
+  if (handoff.adapter_id !== "yukh_mcp" && handoff.adapter_id !== "yukh_control_plane")
+    throw new TypeError("handoff adapter not supported by local team start");
+  const role = handoff.role.replaceAll("_", "-");
+  const runtime = handoff.model_family as AgentRuntime;
+  const model = input.model ?? "default";
+  if (!modelToken.test(model)) throw new TypeError("invalid model");
+  const skills = input.skills ?? defaultSkillsForHandoff(handoff);
+  const managerBudget = Math.max(
+    1_000,
+    handoff.budgets.max_input_tokens + handoff.budgets.max_output_tokens,
+  );
+  const teamBudget = Math.max(managerBudget, managerBudget * 2);
+  return parseArguments([
+    "--workspace",
+    realpathSync(resolve(input.workspace)),
+    "--goal",
+    input.goal,
+    "--mode",
+    "delegate",
+    "--runtime",
+    runtime,
+    "--role",
+    role,
+    "--mission",
+    `Start admitted ${role} session from handoff ${handoff.handoff_id}`,
+    "--model",
+    model,
+    "--skills",
+    skills.join(","),
+    "--instructions",
+    [
+      "Act as the admitted Yukh manager for this handoff.",
+      "Use only bounded Yukh team tools.",
+      "Respect the admitted budgets and activation limits.",
+      "Do not widen provider, filesystem, shell or credential authority.",
+      `Handoff: ${handoff.handoff_id}`,
+      `Admission event: ${handoff.admission_event_id}`,
+      `Task digest: ${handoff.task_digest}`,
+    ].join(" "),
+    "--task",
+    `Start and coordinate the admitted work item ${handoff.work_item_id} for ${role}. Keep output concise and evidence-oriented. The private task body is intentionally not included in this handoff.`,
+    "--team-budget",
+    String(teamBudget),
+    "--manager-budget",
+    String(managerBudget),
+    "--max-agents",
+    String(Math.max(2, Math.min(8, handoff.activation.max_acknowledgements))),
+    "--max-depth",
+    "2",
+    "--max-commands",
+    String(Math.min(32, handoff.activation.max_acknowledgements)),
+    "--timeout-ms",
+    String(Math.min(900_000, handoff.budgets.max_wall_clock_seconds * 1_000)),
+    "--allow-dynamic-workers",
+    String(input.allowDynamicWorkers),
+    "--launcher",
+    input.launcher,
+    "--codex",
+    input.codex,
+    "--copilot",
+    input.copilot,
+    ...(input.codexModels ? ["--codex-models", input.codexModels] : []),
+    ...(input.copilotModels ? ["--copilot-models", input.copilotModels] : []),
+    ...(input.codexSkills ? ["--codex-skills", input.codexSkills] : []),
+    ...(input.copilotSkills ? ["--copilot-skills", input.copilotSkills] : []),
+    ...(input.copilotWorkerProvider
+      ? ["--copilot-worker-provider", input.copilotWorkerProvider]
+      : []),
+    "--format",
+    input.format,
+  ]);
+}
+
+export function startManagerFromHandoff(input: HandoffStartArguments) {
+  const args = teamStartArgumentsFromHandoff(input);
+  if (input.dryRun) {
+    return {
+      schema: 1 as const,
+      status: "ok" as const,
+      command: "team start-from-handoff",
+      dry_run: true as const,
+      handoff_id: input.handoff.handoff_id,
+      mapped_start: {
+        runtime: args.runtime,
+        role: args.role,
+        model: args.model,
+        skills: args.skills,
+        mode: args.mode,
+        team_budget: args.teamBudget,
+        manager_budget: args.managerBudget,
+        max_agents: args.maxAgents,
+        max_commands: args.maxCommands,
+        timeout_ms: args.timeoutMs,
+      },
+    };
+  }
+  const output = startManager(args);
+  return {
+    ...output,
+    command: "team start-from-handoff" as const,
+    handoff_id: input.handoff.handoff_id,
+  };
+}

--- a/bin/yukh.mjs
+++ b/bin/yukh.mjs
@@ -13,6 +13,10 @@ if (process.argv[2] === "conversation" && process.argv[3] === "watch") {
   process.argv.splice(2, 2);
   const { main } = await import("../dist/apps/team-start/src/main.js");
   main(process.argv.slice(2));
+} else if (process.argv[2] === "control" && process.argv[3] === "start") {
+  process.argv.splice(2, 2);
+  const { main } = await import("../dist/apps/control-plane-preview/src/main.js");
+  main(process.argv.slice(2));
 } else if (process.argv[2] === "team" && process.argv[3] === "preflight-engage") {
   process.argv.splice(2, 2);
   await import("../dist/apps/team-preflight/src/main.js");
@@ -36,7 +40,7 @@ if (process.argv[2] === "conversation" && process.argv[3] === "watch") {
     "usage: yukh conversation watch [--full] [--verbose]\n       yukh suite baseline [--workspace path] [--format json|text]\n       yukh team serve\n       yukh team propose [--preset suite-qualification|suite-readonly-verifier|micro-doc-edit|micro-code-edit] [--role backend-reviewer] [--work-profile implementation] [--worker-budget N] [--worker-max-commands N] [--worker-timeout-ms N]\n       yukh team preflight-engage [--preset suite-qualification|suite-readonly-verifier|micro-doc-edit|micro-code-edit] [--role backend-reviewer] [--work-profile implementation] [--worker-budget N] [--worker-max-commands N] [--worker-timeout-ms N] [--format json|text] [--output preflight.json]\n       yukh team run-approved --preflight file --approved-digest sha-256:... [--allow-micro-launch true] [--format json|text]\n" +
       "       yukh team start --goal text [--workspace path] [--mode plan-first|delegate] [--runtime codex|copilot] [--team-budget N] [--manager-budget N] [--format json|text]\n" +
       "       yukh team run-plan-approved --team team-... --plan plan-... --approved-digest sha-256:... [--format json|text]\n" +
-      "       yukh team status --team team-... [--workspace path] [--format json|text]\n       yukh team stop --team team-... [--workspace path] [--format json|text]\n",
+      "       yukh team status --team team-... [--workspace path] [--format json|text]\n       yukh team stop --team team-... [--workspace path] [--format json|text]\n       yukh control start [--host 127.0.0.1] [--port 7345]\n",
   );
   process.exitCode = 2;
 }

--- a/bin/yukh.mjs
+++ b/bin/yukh.mjs
@@ -13,6 +13,10 @@ if (process.argv[2] === "conversation" && process.argv[3] === "watch") {
   process.argv.splice(2, 2);
   const { main } = await import("../dist/apps/team-start/src/main.js");
   main(process.argv.slice(2));
+} else if (process.argv[2] === "team" && process.argv[3] === "start-from-handoff") {
+  process.argv.splice(2, 2);
+  const { main } = await import("../dist/apps/team-start/src/handoff-main.js");
+  main(process.argv.slice(2));
 } else if (process.argv[2] === "control" && process.argv[3] === "start") {
   process.argv.splice(2, 2);
   const { main } = await import("../dist/apps/control-plane-preview/src/main.js");
@@ -39,6 +43,7 @@ if (process.argv[2] === "conversation" && process.argv[3] === "watch") {
   process.stderr.write(
     "usage: yukh conversation watch [--full] [--verbose]\n       yukh suite baseline [--workspace path] [--format json|text]\n       yukh team serve\n       yukh team propose [--preset suite-qualification|suite-readonly-verifier|micro-doc-edit|micro-code-edit] [--role backend-reviewer] [--work-profile implementation] [--worker-budget N] [--worker-max-commands N] [--worker-timeout-ms N]\n       yukh team preflight-engage [--preset suite-qualification|suite-readonly-verifier|micro-doc-edit|micro-code-edit] [--role backend-reviewer] [--work-profile implementation] [--worker-budget N] [--worker-max-commands N] [--worker-timeout-ms N] [--format json|text] [--output preflight.json]\n       yukh team run-approved --preflight file --approved-digest sha-256:... [--allow-micro-launch true] [--format json|text]\n" +
       "       yukh team start --goal text [--workspace path] [--mode plan-first|delegate] [--runtime codex|copilot] [--team-budget N] [--manager-budget N] [--format json|text]\n" +
+      "       yukh team start-from-handoff --handoff file [--workspace path] [--goal text] [--dry-run true] [--allow-dynamic-workers true] [--format json|text]\n" +
       "       yukh team run-plan-approved --team team-... --plan plan-... --approved-digest sha-256:... [--format json|text]\n" +
       "       yukh team status --team team-... [--workspace path] [--format json|text]\n       yukh team stop --team team-... [--workspace path] [--format json|text]\n       yukh control start [--host 127.0.0.1] [--port 7345]\n",
   );

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsc --project tsconfig.build.json && node --input-type=module --eval \"import { cpSync } from 'node:fs'; cpSync('contracts', 'dist/contracts', { recursive: true });\"",
+    "build": "tsc --project tsconfig.build.json && node --input-type=module --eval \"import { cpSync } from 'node:fs'; cpSync('contracts', 'dist/contracts', { recursive: true }); cpSync('apps/control-plane-preview/static', 'dist/apps/control-plane-preview/static', { recursive: true });\"",
     "start": "node dist/apps/gateway/src/main.js",
     "dev": "tsx apps/gateway/src/main.ts",
     "demo": "tsx apps/demo/src/main.ts",

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  createControlPlaneServer,
+  parseArguments,
+} from "../../apps/control-plane-preview/src/main.js";
+
+test("control plane preview parses bounded local server options", () => {
+  assert.deepEqual(parseArguments([]), { host: "127.0.0.1", port: 7345 });
+  assert.deepEqual(parseArguments(["--host", "127.0.0.1", "--port", "0"]), {
+    host: "127.0.0.1",
+    port: 0,
+  });
+  assert.throws(() => parseArguments(["--port", "70000"]), /invalid control plane port/u);
+  assert.throws(() => parseArguments(["--open"]), /invalid control plane arguments/u);
+});
+
+test("control plane preview serves only fixed static assets", async () => {
+  const root = await mkdtemp(join(tmpdir(), "yukh-control-plane-preview-"));
+  await writeFile(join(root, "index.html"), "<h1>Control</h1>");
+  await writeFile(join(root, "styles.css"), "body{}");
+  await writeFile(join(root, "mock-data.js"), "export {};");
+
+  const server = createControlPlaneServer(root);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  try {
+    const address = server.address();
+    if (typeof address !== "object" || address === null) {
+      throw new TypeError("expected TCP server address");
+    }
+    const base = `http://127.0.0.1:${address.port}`;
+
+    const index = await fetch(`${base}/`);
+    assert.equal(index.status, 200);
+    assert.match(await index.text(), /Control/u);
+
+    const denied = await fetch(`${base}/../package.json`);
+    assert.equal(denied.status, 404);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});

--- a/test/runtime/team-start-handoff.test.ts
+++ b/test/runtime/team-start-handoff.test.ts
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { parseHandoffArguments } from "../../apps/team-start/src/handoff-main.js";
+import {
+  parseProjectsManagerOrchestrationHandoff,
+  startManagerFromHandoff,
+  teamStartArgumentsFromHandoff,
+} from "../../apps/team-start/src/handoff.js";
+
+const digest = `sha-256:${"c".repeat(64)}`;
+
+function handoff(overrides = {}) {
+  return {
+    schema: "yukh-projects-manager-orchestration-handoff-v1",
+    handoff_id: "01900000-0000-7000-8000-000000000300",
+    issued_at: "2026-08-18T05:00:00.000Z",
+    phase: "ready_for_external_orchestrator",
+    boundary: "external_orchestrator",
+    transport: "mcp",
+    adapter_id: "yukh_mcp",
+    capability: "agent_session_start",
+    plan_id: "01900000-0000-7000-8000-000000000301",
+    plan_digest: digest,
+    admission_event_id: "01900000-0000-7000-8000-000000000302",
+    admission_event_digest: digest,
+    admission_command_digest: digest,
+    admission_outcome: "appended",
+    namespace_id: "namespace:example",
+    project_id: "project:example",
+    run_id: "run:example",
+    work_item_id: "work-item:example",
+    manager_subject_id: "subject:manager",
+    worker_subject_id: "subject:worker",
+    role: "backend_developer",
+    model_family: "codex",
+    model_capability: "coding-agent",
+    skill_count: 2,
+    acceptance_count: 2,
+    evidence_count: 1,
+    task_digest: digest,
+    budgets: {
+      max_turns: 4,
+      max_input_tokens: 12_000,
+      max_output_tokens: 4_000,
+      max_wall_clock_seconds: 600,
+    },
+    activation: {
+      max_ticks: 8,
+      max_acknowledgements: 12,
+      max_idle_ticks: 1,
+    },
+    orchestration_request_digest: digest,
+    instruction: {
+      kind: "start_admitted_agent_session",
+      policy: "external_orchestrator_must_enforce_budget_and_skill_limits",
+      private_task_body_included: false,
+      provider_call_authorized_here: false,
+    },
+    ...overrides,
+  };
+}
+
+test("parses a Projects handoff and maps it to bounded team start arguments", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "yukh-team-handoff-map-"));
+  try {
+    const parsed = parseProjectsManagerOrchestrationHandoff(JSON.stringify(handoff()));
+    const args = teamStartArgumentsFromHandoff({
+      workspace,
+      handoff: parsed,
+      goal: "Use admitted backend developer",
+      launcher: "/usr/bin/true",
+      codex: "/usr/bin/true",
+      copilot: "/usr/bin/true",
+      dryRun: true,
+      format: "json",
+      allowDynamicWorkers: true,
+      codexModels: "default",
+      copilotModels: "default",
+      codexSkills: "api-design,testing",
+    });
+    assert.equal(args.mode, "delegate");
+    assert.equal(args.runtime, "codex");
+    assert.equal(args.role, "backend-developer");
+    assert.deepEqual(args.skills, ["api-design", "testing"]);
+    assert.equal(args.managerBudget, 16_000);
+    assert.equal(args.teamBudget, 32_000);
+    assert.equal(args.maxCommands, 12);
+    assert.equal(args.timeoutMs, 600_000);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("dry-run accepts handoff without launching a manager", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "yukh-team-handoff-dry-"));
+  try {
+    const parsed = parseProjectsManagerOrchestrationHandoff(JSON.stringify(handoff()));
+    const output = startManagerFromHandoff({
+      workspace,
+      handoff: parsed,
+      goal: "Use admitted backend developer",
+      launcher: "/usr/bin/true",
+      codex: "/usr/bin/true",
+      copilot: "/usr/bin/true",
+      dryRun: true,
+      format: "json",
+      allowDynamicWorkers: true,
+      codexModels: "default",
+      copilotModels: "default",
+      codexSkills: "api-design,testing",
+    });
+    assert.equal(output.status, "ok");
+    assert.equal(output.command, "team start-from-handoff");
+    assert.equal(output.dry_run, true);
+    assert.equal(output.handoff_id, "01900000-0000-7000-8000-000000000300");
+    assert.equal(output.mapped_start.runtime, "codex");
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("rejects unsupported handoff route and provider-call authorization", () => {
+  assert.throws(
+    () =>
+      teamStartArgumentsFromHandoff({
+        workspace: process.cwd(),
+        handoff: parseProjectsManagerOrchestrationHandoff(
+          JSON.stringify(handoff({ transport: "sdk", adapter_id: "codex_sdk" })),
+        ),
+        goal: "Rejected",
+        launcher: "/usr/bin/true",
+        codex: "/usr/bin/true",
+        copilot: "/usr/bin/true",
+        dryRun: true,
+        format: "json",
+        allowDynamicWorkers: true,
+      }),
+    /handoff transport not supported/u,
+  );
+  assert.throws(
+    () =>
+      parseProjectsManagerOrchestrationHandoff(
+        JSON.stringify(
+          handoff({
+            instruction: {
+              kind: "start_admitted_agent_session",
+              policy: "external_orchestrator_must_enforce_budget_and_skill_limits",
+              private_task_body_included: false,
+              provider_call_authorized_here: true,
+            },
+          }),
+        ),
+      ),
+    /invalid handoff/u,
+  );
+});
+
+test("CLI parser loads paths and keeps dry-run explicit", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "yukh-team-handoff-cli-"));
+  const handoffPath = join(workspace, "handoff.json");
+  await writeFile(handoffPath, JSON.stringify(handoff()));
+  try {
+    const args = parseHandoffArguments([
+      "--workspace",
+      workspace,
+      "--handoff",
+      handoffPath,
+      "--launcher",
+      "/usr/bin/true",
+      "--codex",
+      "/usr/bin/true",
+      "--copilot",
+      "/usr/bin/true",
+      "--dry-run",
+      "true",
+      "--format",
+      "json",
+    ]);
+    assert.equal(args.workspace, workspace);
+    assert.equal(args.handoffPath, handoffPath);
+    assert.equal(args.dryRun, true);
+    assert.equal(args.format, "json");
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Cosa cambia

Aggiunge una prima Control Plane preview locale e statica per rendere visibile il modello operativo Yukh senza passare dal ping-pong manuale tra agenti.

Include:

- nuovo comando `yukh control start [--host 127.0.0.1] [--port 7345]`;
- server statico locale con asset allowlistati (`index.html`, `styles.css`, `mock-data.js`);
- mock UI con dashboard, team, transcript Coordination, budget/token e form start team;
- copia degli asset statici in `dist` durante `npm run build`;
- test runtime mirato per parsing e static serving fail-closed su path non previsti.

## Perché

Il CLI resta utile, ma non basta come esperienza principale. Questa preview crea una base concreta da aprire nel browser e discutere prima di collegarla ai comandi reali `team status`, `conversation watch`, `team start`, `stop` e approvazioni.

## Sicurezza / scope

È read-only/mock: non espone mutazioni runtime, non aggiunge capability pubbliche e non cambia Coordination o authorization boundary.

## Validazione

- `npx prettier --check bin/yukh.mjs package.json apps/control-plane-preview/src/main.ts apps/control-plane-preview/static/index.html apps/control-plane-preview/static/styles.css apps/control-plane-preview/static/mock-data.js test/runtime/control-plane-preview.test.ts`
- `npm run typecheck`
- `npm run build`
- `node --import tsx --test test/runtime/control-plane-preview.test.ts` fuori sandbox, perché apre socket `127.0.0.1`
- `node --import tsx --test test/runtime/team-start-cli.test.ts`