### PR TITLE
Show Control Plane runtime topology

### DIFF
--- a/.context/sessions/SESSION-2026-08-18-02-control-plane-runtime-topology.md
+++ b/.context/sessions/SESSION-2026-08-18-02-control-plane-runtime-topology.md
@@ -1,0 +1,30 @@
+# SESSION-2026-08-18-02 — Control Plane runtime topology preview
+
+- Status: completed
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/246
+- Branch: `agent/control-plane-runtime-topology`
+
+## Objective
+
+Make the local Control Plane preview explain how Yukh Projects, Yukh MCP,
+Yukh Coordination, managers, workers and NATS JetStream relate, without adding
+live runtime wiring or deployment authority.
+
+## Outcome
+
+- Added a `Runtime topology` section to the Control Plane preview.
+- Added an inline SVG topology map rather than Mermaid.
+- Added mock topology panel data for Projects governance, orchestration,
+  Coordination and JetStream runtime ownership.
+- Added a regression test that verifies the preview explains Projects, MCP,
+  Coordination, JetStream and the evidence-not-authority rule.
+
+The view is static preview data only. It does not read live Projects,
+Coordination, NATS, manager or worker state.
+
+## Validation
+
+- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
+- `npm run format:check`
+- `npm run typecheck`
+- `git diff --check`

--- a/apps/control-plane-preview/static/index.html
+++ b/apps/control-plane-preview/static/index.html
@@ -23,6 +23,7 @@
         <button class="primary">Start team</button>
         <nav>
           <a class="active" href="#dashboard">Dashboard</a>
+          <a href="#topology">Runtime topology</a>
           <a href="#teams">Teams</a>
           <a href="#transcript">Transcript</a>
           <a href="#budgets">Budgets</a>
@@ -64,6 +65,94 @@
           <article class="metric card">
             <span>Provider mix</span><strong id="metric-providers">—</strong>
           </article>
+        </section>
+
+        <section class="card topology-card" id="topology">
+          <div class="section-title">
+            <div>
+              <p class="eyebrow">Runtime topology</p>
+              <h3>Who owns what</h3>
+            </div>
+            <span class="status-pill small"><span class="dot ok"></span>preview model</span>
+          </div>
+
+          <div class="topology-layout">
+            <figure class="topology-map" aria-label="Yukh suite runtime topology">
+              <svg viewBox="0 0 900 360" role="img" aria-labelledby="topology-title topology-desc">
+                <title id="topology-title">
+                  Yukh Projects, MCP, Coordination, and JetStream topology
+                </title>
+                <desc id="topology-desc">
+                  Projects admits governed work, MCP starts managers and workers, Coordination
+                  carries messages, and Projects plus Coordination use isolated JetStream storage
+                  areas.
+                </desc>
+                <defs>
+                  <marker
+                    id="arrow"
+                    viewBox="0 0 10 10"
+                    refX="8"
+                    refY="5"
+                    markerWidth="7"
+                    markerHeight="7"
+                    orient="auto-start-reverse"
+                  >
+                    <path d="M 0 0 L 10 5 L 0 10 z"></path>
+                  </marker>
+                </defs>
+
+                <rect class="plane projects" x="34" y="48" width="230" height="116" rx="22"></rect>
+                <text class="node-title" x="62" y="90">Yukh Projects</text>
+                <text class="node-copy" x="62" y="118">work items · claims · roadmap</text>
+                <text class="node-copy" x="62" y="142">authoritative governance</text>
+
+                <rect class="plane mcp" x="335" y="48" width="230" height="116" rx="22"></rect>
+                <text class="node-title" x="363" y="90">Yukh MCP</text>
+                <text class="node-copy" x="363" y="118">manager · workers · tools</text>
+                <text class="node-copy" x="363" y="142">budgeted orchestration</text>
+
+                <rect
+                  class="plane coordination"
+                  x="636"
+                  y="48"
+                  width="230"
+                  height="116"
+                  rx="22"
+                ></rect>
+                <text class="node-title" x="664" y="90">Coordination</text>
+                <text class="node-copy" x="664" y="118">join · ask · answer · replay</text>
+                <text class="node-copy" x="664" y="142">verified transcript</text>
+
+                <rect class="plane nats" x="186" y="236" width="528" height="82" rx="24"></rect>
+                <text class="node-title" x="218" y="274">NATS JetStream runtime</text>
+                <text class="node-copy" x="218" y="300">
+                  shared physical service, isolated logical streams and buckets
+                </text>
+
+                <path class="flow" d="M264 106 H335" marker-end="url(#arrow)"></path>
+                <text class="flow-label" x="276" y="92">handoff</text>
+
+                <path class="flow" d="M565 106 H636" marker-end="url(#arrow)"></path>
+                <text class="flow-label" x="576" y="92">messages</text>
+
+                <path
+                  class="flow soft"
+                  d="M149 164 C149 214 305 210 318 236"
+                  marker-end="url(#arrow)"
+                ></path>
+                <text class="flow-label" x="122" y="206">YKP_WORK_EVENTS_V1</text>
+
+                <path
+                  class="flow soft"
+                  d="M751 164 C751 214 601 210 585 236"
+                  marker-end="url(#arrow)"
+                ></path>
+                <text class="flow-label" x="635" y="206">transcript stream</text>
+              </svg>
+            </figure>
+
+            <div class="topology-panels" id="topology-panels"></div>
+          </div>
         </section>
 
         <section class="two-column" id="teams">

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -39,6 +39,36 @@ const data = {
       ],
     },
   ],
+  topology: [
+    {
+      name: "Projects governance",
+      owner: "yukh-projects",
+      state: "ready for handoff",
+      writes: "YKP_WORK_EVENTS_V1 and rebuildable KV projections",
+      rule: "Admits claims, leases, budgets, roadmap and result evidence.",
+    },
+    {
+      name: "Orchestration",
+      owner: "yukh-mcp / Control Plane",
+      state: "preview",
+      writes: "team state, action receipts and worker lifecycle",
+      rule: "Consumes Projects handoffs and starts bounded managers or workers.",
+    },
+    {
+      name: "Agent communication",
+      owner: "yukh-coordination",
+      state: "local preview",
+      writes: "Coordination transcript and receipt store",
+      rule: "Carries join, ask, answer and replay. A message is evidence, not work authority.",
+    },
+    {
+      name: "JetStream runtime",
+      owner: "NATS",
+      state: "shared service",
+      writes: "separate stream and bucket namespaces",
+      rule: "May be one physical runtime, never one shared logical contract.",
+    },
+  ],
   transcript: [
     {
       time: "12:31:18",
@@ -78,6 +108,26 @@ byId("metric-teams").textContent = String(activeTeams.length);
 byId("metric-agents").textContent = String(agents.length);
 byId("metric-budget").textContent = `${Math.round((used / allocated) * 100)}% used`;
 byId("metric-providers").textContent = "CLI + SDK";
+
+byId("topology-panels").innerHTML = data.topology
+  .map(
+    (node) => `
+      <article class="topology-node">
+        <div class="section-title">
+          <div>
+            <p class="eyebrow">${node.owner}</p>
+            <h4>${node.name}</h4>
+          </div>
+          <span class="status-pill small"><span class="dot ${node.state.includes("ready") ? "ok" : "warn"}"></span>${node.state}</span>
+        </div>
+        <dl>
+          <div><dt>Writes</dt><dd>${node.writes}</dd></div>
+          <div><dt>Rule</dt><dd>${node.rule}</dd></div>
+        </dl>
+      </article>
+    `,
+  )
+  .join("");
 
 byId("team-list").innerHTML = data.teams
   .map(

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -54,6 +54,10 @@ h2 {
 h3 {
   font-size: 18px;
 }
+h4 {
+  font-size: 15px;
+  margin: 0;
+}
 .topbar {
   align-items: center;
   background: rgba(11, 13, 18, 0.86);
@@ -198,6 +202,98 @@ nav a:hover {
 .wide-left {
   grid-template-columns: minmax(0, 1.35fr) minmax(340px, 0.65fr);
 }
+.topology-layout {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(0, 1.35fr) minmax(320px, 0.65fr);
+}
+.topology-map {
+  background:
+    linear-gradient(135deg, rgba(119, 240, 178, 0.09), transparent 38%),
+    linear-gradient(315deg, rgba(140, 181, 255, 0.09), transparent 42%), #0d121c;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 22px;
+  margin: 0;
+  min-height: 280px;
+  padding: 12px;
+}
+.topology-map svg {
+  display: block;
+  height: 100%;
+  min-height: 260px;
+  width: 100%;
+}
+.plane {
+  stroke-width: 1.5;
+}
+.plane.projects {
+  fill: rgba(119, 240, 178, 0.11);
+  stroke: rgba(119, 240, 178, 0.6);
+}
+.plane.mcp {
+  fill: rgba(140, 181, 255, 0.12);
+  stroke: rgba(140, 181, 255, 0.65);
+}
+.plane.coordination {
+  fill: rgba(255, 209, 102, 0.1);
+  stroke: rgba(255, 209, 102, 0.62);
+}
+.plane.nats {
+  fill: rgba(255, 255, 255, 0.06);
+  stroke: rgba(255, 255, 255, 0.18);
+}
+.node-title {
+  fill: var(--text);
+  font-size: 24px;
+  font-weight: 800;
+}
+.node-copy,
+.flow-label {
+  fill: var(--muted);
+  font-size: 15px;
+}
+.flow {
+  fill: none;
+  marker-end: url("#arrow");
+  stroke: var(--accent-2);
+  stroke-linecap: round;
+  stroke-width: 3;
+}
+.flow.soft {
+  stroke: rgba(119, 240, 178, 0.7);
+  stroke-dasharray: 7 7;
+}
+#arrow path {
+  fill: var(--accent-2);
+}
+.topology-panels {
+  display: grid;
+  gap: 12px;
+}
+.topology-node {
+  background: var(--panel-2);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 18px;
+  padding: 14px;
+}
+.topology-node .section-title {
+  gap: 12px;
+}
+.topology-node dl {
+  display: grid;
+  gap: 9px;
+  margin: 0;
+}
+.topology-node dt {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.topology-node dd {
+  margin: 2px 0 0;
+}
 .section-title {
   align-items: center;
   display: flex;
@@ -326,6 +422,7 @@ textarea {
   .hero,
   .two-column,
   .wide-left,
+  .topology-layout,
   .metrics {
     grid-template-columns: 1fr;
   }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -50,4 +50,19 @@ test("control plane preview serves only fixed static assets", async () => {
       server.close((error) => (error ? reject(error) : resolve()));
     });
   }
+});
+
+test("control plane preview explains runtime topology without Mermaid", async () => {
+  const html = await readFile("apps/control-plane-preview/static/index.html", "utf8");
+  const data = await readFile("apps/control-plane-preview/static/mock-data.js", "utf8");
+
+  assert.match(html, /Runtime topology/u);
+  assert.match(html, /Who owns what/u);
+  assert.match(html, /Yukh Projects/u);
+  assert.match(html, /Yukh MCP/u);
+  assert.match(html, /Coordination/u);
+  assert.match(html, /NATS JetStream runtime/u);
+  assert.match(data, /YKP_WORK_EVENTS_V1/u);
+  assert.match(data, /message is evidence, not work authority/u);
+  assert.doesNotMatch(`${html}\n${data}`, /mermaid/iu);
 });


### PR DESCRIPTION
## Summary

- adds a Runtime topology section to the local Control Plane preview
- shows Projects, Yukh MCP, Coordination and NATS JetStream as separate ownership planes
- uses inline SVG, not Mermaid, for the topology map
- adds mock ownership/health panels and a regression test for the topology copy
- records session evidence for issue #246

## Context

Closes #246.

This is a static UI/UX increment only. It does not add live NATS, Projects,
Coordination, manager or worker reads; it does not change any public MCP API or
deployment authority.

## Validation

- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
