### PR TITLE
Expose Control Plane topology status

### DIFF
--- a/.context/sessions/SESSION-2026-08-18-03-control-plane-topology-status.md
+++ b/.context/sessions/SESSION-2026-08-18-03-control-plane-topology-status.md
@@ -1,0 +1,32 @@
+# SESSION-2026-08-18-03 — Control Plane topology status endpoint
+
+- Status: completed
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/248
+- Branch: `agent/control-plane-topology-status`
+
+## Objective
+
+Expose a small read-only topology/status endpoint for the local Control Plane
+preview so the UI can consume server-owned topology data before live Projects,
+Coordination, NATS or manager wiring is added.
+
+## Outcome
+
+- Added `apps/control-plane-preview/src/topology-status.ts` with a closed
+  static-preview status model.
+- Added `GET /api/topology/status` to the preview server.
+- Rejected non-GET methods on that endpoint with `405` and `Allow: GET`.
+- Updated the static UI to fetch the endpoint and fall back to local mock data.
+- Added regression coverage for endpoint shape, no-store caching, read-only
+  method handling, unknown API paths, and topology copy.
+
+The endpoint is static preview data only. It does not read live storage, logs,
+credentials, provider output, manager state or worker state.
+
+## Validation
+
+- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
+- `npm run format:check`
+- `npm run typecheck`
+- `npm run build`
+- `git diff --check`

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -2,6 +2,7 @@ import { createServer, type Server } from "node:http";
 import { readFile } from "node:fs/promises";
 import { dirname, join, normalize } from "node:path";
 import { fileURLToPath } from "node:url";
+import { createTopologyStatus } from "./topology-status.js";
 
 type ControlPlaneOptions = {
   readonly host: string;
@@ -14,6 +15,8 @@ const CONTENT_TYPES = new Map([
   ["styles.css", "text/css; charset=utf-8"],
   ["mock-data.js", "text/javascript; charset=utf-8"],
 ]);
+
+const API_TOPOLOGY_STATUS_PATH = "/api/topology/status";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
@@ -59,6 +62,27 @@ function requestedFile(url = "/"): string | null {
 
 export function createControlPlaneServer(staticRoot = defaultStaticRoot()): Server {
   return createServer(async (request, response) => {
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_TOPOLOGY_STATUS_PATH
+    ) {
+      if (request.method !== "GET") {
+        response.writeHead(405, {
+          allow: "GET",
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+        return;
+      }
+      response.writeHead(200, {
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify(createTopologyStatus()));
+      return;
+    }
+
     const file = requestedFile(request.url);
     if (!file) {
       response.writeHead(404, { "content-type": "text/plain; charset=utf-8" });

--- a/apps/control-plane-preview/src/topology-status.ts
+++ b/apps/control-plane-preview/src/topology-status.ts
@@ -1,0 +1,59 @@
+export type TopologyStatus = {
+  readonly schema: "yukh-control-plane-topology-status-v1";
+  readonly generated_at: string;
+  readonly source: "static-preview";
+  readonly runtimes: readonly TopologyRuntime[];
+};
+
+export type TopologyRuntime = {
+  readonly id: "projects" | "orchestration" | "coordination" | "jetstream";
+  readonly name: string;
+  readonly owner: string;
+  readonly state: "ready_for_handoff" | "preview" | "local_preview" | "shared_service";
+  readonly writes: string;
+  readonly rule: string;
+};
+
+const runtimes: readonly TopologyRuntime[] = [
+  {
+    id: "projects",
+    name: "Projects governance",
+    owner: "yukh-projects",
+    state: "ready_for_handoff",
+    writes: "YKP_WORK_EVENTS_V1 and rebuildable KV projections",
+    rule: "Admits claims, leases, budgets, roadmap and result evidence.",
+  },
+  {
+    id: "orchestration",
+    name: "Orchestration",
+    owner: "yukh-mcp / Control Plane",
+    state: "preview",
+    writes: "team state, action receipts and worker lifecycle",
+    rule: "Consumes Projects handoffs and starts bounded managers or workers.",
+  },
+  {
+    id: "coordination",
+    name: "Agent communication",
+    owner: "yukh-coordination",
+    state: "local_preview",
+    writes: "Coordination transcript and receipt store",
+    rule: "Carries join, ask, answer and replay. A message is evidence, not work authority.",
+  },
+  {
+    id: "jetstream",
+    name: "JetStream runtime",
+    owner: "NATS",
+    state: "shared_service",
+    writes: "separate stream and bucket namespaces",
+    rule: "May be one physical runtime, never one shared logical contract.",
+  },
+];
+
+export function createTopologyStatus(now = new Date()): TopologyStatus {
+  return {
+    schema: "yukh-control-plane-topology-status-v1",
+    generated_at: now.toISOString(),
+    source: "static-preview",
+    runtimes,
+  };
+}

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -98,6 +98,24 @@ const data = {
 };
 
 const byId = (id) => document.getElementById(id);
+const topologyStateLabel = (state) => state.replaceAll("_", " ");
+const loadTopology = async () => {
+  try {
+    const response = await fetch("./api/topology/status", { cache: "no-store" });
+    if (!response.ok) return data.topology;
+    const status = await response.json();
+    if (
+      status?.schema !== "yukh-control-plane-topology-status-v1" ||
+      !Array.isArray(status.runtimes)
+    ) {
+      return data.topology;
+    }
+    return status.runtimes;
+  } catch {
+    return data.topology;
+  }
+};
+
 const activeTeams = data.teams.filter((team) => team.state !== "complete");
 const agents = data.teams.flatMap((team) => team.agents);
 const used = data.teams.reduce((sum, team) => sum + team.budget.used, 0);
@@ -109,7 +127,8 @@ byId("metric-agents").textContent = String(agents.length);
 byId("metric-budget").textContent = `${Math.round((used / allocated) * 100)}% used`;
 byId("metric-providers").textContent = "CLI + SDK";
 
-byId("topology-panels").innerHTML = data.topology
+const topology = await loadTopology();
+byId("topology-panels").innerHTML = topology
   .map(
     (node) => `
       <article class="topology-node">
@@ -118,7 +137,7 @@ byId("topology-panels").innerHTML = data.topology
             <p class="eyebrow">${node.owner}</p>
             <h4>${node.name}</h4>
           </div>
-          <span class="status-pill small"><span class="dot ${node.state.includes("ready") ? "ok" : "warn"}"></span>${node.state}</span>
+          <span class="status-pill small"><span class="dot ${node.state.includes("ready") ? "ok" : "warn"}"></span>${topologyStateLabel(node.state)}</span>
         </div>
         <dl>
           <div><dt>Writes</dt><dd>${node.writes}</dd></div>

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -52,6 +52,54 @@ test("control plane preview serves only fixed static assets", async () => {
   }
 });
 
+test("control plane preview exposes closed read-only topology status", async () => {
+  const root = await mkdtemp(join(tmpdir(), "yukh-control-plane-preview-api-"));
+  await writeFile(join(root, "index.html"), "<h1>Control</h1>");
+  await writeFile(join(root, "styles.css"), "body{}");
+  await writeFile(join(root, "mock-data.js"), "export {};");
+
+  const server = createControlPlaneServer(root);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  try {
+    const address = server.address();
+    if (typeof address !== "object" || address === null) {
+      throw new TypeError("expected TCP server address");
+    }
+    const base = `http://127.0.0.1:${address.port}`;
+
+    const status = await fetch(`${base}/api/topology/status`);
+    assert.equal(status.status, 200);
+    assert.equal(status.headers.get("cache-control"), "no-store");
+    const body = await status.json();
+    assert.equal(body.schema, "yukh-control-plane-topology-status-v1");
+    assert.equal(body.source, "static-preview");
+    assert.equal(body.runtimes.length, 4);
+    assert.deepEqual(
+      body.runtimes.map((runtime: { id: string }) => runtime.id),
+      ["projects", "orchestration", "coordination", "jetstream"],
+    );
+    assert.match(JSON.stringify(body), /YKP_WORK_EVENTS_V1/u);
+    assert.doesNotMatch(JSON.stringify(body), /token|secret|private|credential/iu);
+
+    const mutation = await fetch(`${base}/api/topology/status`, { method: "POST" });
+    assert.equal(mutation.status, 405);
+    assert.equal(mutation.headers.get("allow"), "GET");
+
+    const unknownApi = await fetch(`${base}/api/topology/secrets`);
+    assert.equal(unknownApi.status, 404);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
 test("control plane preview explains runtime topology without Mermaid", async () => {
   const html = await readFile("apps/control-plane-preview/static/index.html", "utf8");
   const data = await readFile("apps/control-plane-preview/static/mock-data.js", "utf8");
@@ -62,6 +110,7 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(html, /Yukh MCP/u);
   assert.match(html, /Coordination/u);
   assert.match(html, /NATS JetStream runtime/u);
+  assert.match(data, /api\/topology\/status/u);
   assert.match(data, /YKP_WORK_EVENTS_V1/u);
   assert.match(data, /message is evidence, not work authority/u);
   assert.doesNotMatch(`${html}\n${data}`, /mermaid/iu);


### PR DESCRIPTION
## Summary

- adds a closed read-only `/api/topology/status` endpoint to the local Control Plane preview
- keeps topology data server-owned and static-preview only
- updates the UI to fetch topology status with a local mock fallback
- covers endpoint shape, no-store caching, 405 on non-GET, unknown API paths, and topology copy
- records session evidence for issue #248

## Context

Closes #248.

This does not read live Projects, Coordination, NATS, manager, worker, provider
or credential state. It is a safe stepping stone toward live read-only status.

## Validation

- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
