### PR TITLE
Expose Control Plane team status

### DIFF
--- a/.context/sessions/SESSION-2026-08-18-04-control-plane-team-status.md
+++ b/.context/sessions/SESSION-2026-08-18-04-control-plane-team-status.md
@@ -1,0 +1,38 @@
+# SESSION-2026-08-18-04 — Control Plane live team status
+
+- Status: completed
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/250
+- Branch: `agent/control-plane-topology-status`
+
+## Objective
+
+Expose the first safe live Control Plane status: local team supervisor state,
+without exposing private goals, task text, logs, credentials, provider output
+or mutable operations.
+
+## Outcome
+
+- Added `apps/control-plane-preview/src/team-status.ts`.
+- Added `GET /api/teams/status` to the local preview server.
+- Added optional `--workspace` plus `YUKH_CONVERSATION_WORKSPACE` /
+  `YUKH_TEAM_WORKSPACE` discovery for local team state.
+- Updated the preview UI to load live team summaries and fall back to static
+  mock teams.
+- Returned only redacted team summaries: identifiers, manager runtime/role,
+  goal digest, agent roles/states/runtime, Coordination participant, aggregate
+  token counters, receipt count and plan status.
+- Rejected non-GET methods with `405` and left unknown API paths as `404`.
+
+## Validation
+
+- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
+- `npm run format:check`
+- `npm run typecheck`
+- `npm run build`
+- `git diff --check`
+
+## Boundary
+
+This increment reads local `.yukh/teams` state through the existing TeamStore
+shape. It does not start, stop, approve, inspect logs, contact Coordination,
+contact Projects, contact NATS, invoke providers or expose secrets.

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -2,12 +2,15 @@ import { createServer, type Server } from "node:http";
 import { readFile } from "node:fs/promises";
 import { dirname, join, normalize } from "node:path";
 import { fileURLToPath } from "node:url";
+import { TeamStore } from "../../../packages/team-control/src/store.js";
+import { createTeamStatus } from "./team-status.js";
 import { createTopologyStatus } from "./topology-status.js";
 
 type ControlPlaneOptions = {
   readonly host: string;
   readonly port: number;
   readonly staticRoot?: string;
+  readonly workspace?: string;
 };
 
 const CONTENT_TYPES = new Map([
@@ -17,12 +20,14 @@ const CONTENT_TYPES = new Map([
 ]);
 
 const API_TOPOLOGY_STATUS_PATH = "/api/topology/status";
+const API_TEAM_STATUS_PATH = "/api/teams/status";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
     host: string;
     port: number;
     staticRoot?: string;
+    workspace?: string;
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -39,6 +44,9 @@ export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
       i += 1;
     } else if (arg === "--static-root" && next) {
       options.staticRoot = next;
+      i += 1;
+    } else if (arg === "--workspace" && next) {
+      options.workspace = next;
       i += 1;
     } else {
       throw new TypeError("invalid control plane arguments");
@@ -60,8 +68,29 @@ function requestedFile(url = "/"): string | null {
   return null;
 }
 
-export function createControlPlaneServer(staticRoot = defaultStaticRoot()): Server {
+export function createControlPlaneServer(
+  staticRoot = defaultStaticRoot(),
+  options: { readonly teamStore?: Pick<TeamStore, "teams"> } = {},
+): Server {
   return createServer(async (request, response) => {
+    if (request.url && new URL(request.url, "http://127.0.0.1").pathname === API_TEAM_STATUS_PATH) {
+      if (request.method !== "GET") {
+        response.writeHead(405, {
+          allow: "GET",
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+        return;
+      }
+      response.writeHead(200, {
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify(createTeamStatus(options.teamStore)));
+      return;
+    }
+
     if (
       request.url &&
       new URL(request.url, "http://127.0.0.1").pathname === API_TOPOLOGY_STATUS_PATH
@@ -104,7 +133,11 @@ export function createControlPlaneServer(staticRoot = defaultStaticRoot()): Serv
 }
 
 export async function startControlPlane(options: ControlPlaneOptions): Promise<Server> {
-  const server = createControlPlaneServer(options.staticRoot);
+  const workspace =
+    options.workspace ?? process.env.YUKH_CONVERSATION_WORKSPACE ?? process.env.YUKH_TEAM_WORKSPACE;
+  const server = createControlPlaneServer(options.staticRoot, {
+    ...(workspace ? { teamStore: new TeamStore(workspace) } : {}),
+  });
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
     server.listen(options.port, options.host, () => {

--- a/apps/control-plane-preview/src/team-status.ts
+++ b/apps/control-plane-preview/src/team-status.ts
@@ -1,0 +1,90 @@
+import { createHash } from "node:crypto";
+import type { TeamStore } from "../../../packages/team-control/src/store.js";
+
+export type ControlPlaneTeamStatus = {
+  readonly schema: "yukh-control-plane-team-status-v1";
+  readonly source: "local-team-store" | "unconfigured";
+  readonly teams: readonly ControlPlaneTeamSummary[];
+};
+
+export type ControlPlaneTeamSummary = {
+  readonly team_id: string;
+  readonly state: string;
+  readonly manager_runtime: string;
+  readonly manager_role?: string;
+  readonly goal_digest: `sha-256:${string}`;
+  readonly tokens: {
+    readonly budget: number;
+    readonly allocated: number;
+    readonly observed: number;
+    readonly remaining: number;
+    readonly pending_agents: number;
+    readonly unaccounted_agents: number;
+    readonly exceeded_agents: number;
+  };
+  readonly receipts_count: number;
+  readonly plans: readonly {
+    readonly plan_id: string;
+    readonly state: string;
+    readonly worker_count: number;
+    readonly has_synthesis: boolean;
+  }[];
+  readonly agents: readonly {
+    readonly agent_id: string;
+    readonly kind: string;
+    readonly role: string;
+    readonly runtime: string;
+    readonly state: string;
+    readonly coordination_participant: string;
+    readonly token_budget: number;
+    readonly observed_tokens: number;
+    readonly budget_outcome?: string;
+    readonly completion_outcome?: string;
+  }[];
+};
+
+function digest(value: string): `sha-256:${string}` {
+  return `sha-256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+export function createTeamStatus(store?: Pick<TeamStore, "teams">): ControlPlaneTeamStatus {
+  if (!store) {
+    return {
+      schema: "yukh-control-plane-team-status-v1",
+      source: "unconfigured",
+      teams: [],
+    };
+  }
+
+  return {
+    schema: "yukh-control-plane-team-status-v1",
+    source: "local-team-store",
+    teams: store.teams().map((status) => ({
+      team_id: status.team.team_id,
+      state: status.team.state,
+      manager_runtime: status.team.manager_runtime,
+      ...(status.team.manager_role ? { manager_role: status.team.manager_role } : {}),
+      goal_digest: digest(status.team.goal),
+      tokens: status.tokens,
+      receipts_count: status.receipts.length,
+      plans: status.plans.map((plan) => ({
+        plan_id: plan.plan_id,
+        state: plan.state,
+        worker_count: plan.worker_agent_ids.length,
+        has_synthesis: plan.synthesis_agent_id !== undefined,
+      })),
+      agents: status.agents.map((agent) => ({
+        agent_id: agent.agent_id,
+        kind: agent.kind,
+        role: agent.role,
+        runtime: agent.runtime,
+        state: agent.state,
+        coordination_participant: agent.coordination_participant,
+        token_budget: agent.token_budget,
+        observed_tokens: agent.usage?.total_tokens ?? 0,
+        ...(agent.usage ? { budget_outcome: agent.usage.budget_outcome } : {}),
+        ...(agent.completion ? { completion_outcome: agent.completion.outcome } : {}),
+      })),
+    })),
+  };
+}

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -115,16 +115,43 @@ const loadTopology = async () => {
     return data.topology;
   }
 };
+const loadTeams = async () => {
+  try {
+    const response = await fetch("./api/teams/status", { cache: "no-store" });
+    if (!response.ok) return data.teams;
+    const status = await response.json();
+    if (status?.schema !== "yukh-control-plane-team-status-v1" || !Array.isArray(status.teams)) {
+      return data.teams;
+    }
+    return status.teams;
+  } catch {
+    return data.teams;
+  }
+};
 
-const activeTeams = data.teams.filter((team) => team.state !== "complete");
-const agents = data.teams.flatMap((team) => team.agents);
-const used = data.teams.reduce((sum, team) => sum + team.budget.used, 0);
-const allocated = data.teams.reduce((sum, team) => sum + team.budget.allocated, 0);
+const teams = await loadTeams();
+const teamBudget = (team) => team.budget ?? team.tokens;
+const teamId = (team) => team.id ?? team.team_id;
+const teamGoal = (team) => team.goal ?? `goal ${team.goal_digest.slice(0, 19)}…`;
+const teamMode = (team) => team.mode ?? team.manager_runtime ?? "manager runtime";
+const agentName = (agent) => agent.name ?? `${agent.kind}:${agent.role}`;
+const agentProvider = (agent) => agent.provider ?? agent.runtime;
+const activeTeams = teams.filter((team) => !["complete", "stopped"].includes(team.state));
+const agents = teams.flatMap((team) => team.agents);
+const used = teams.reduce(
+  (sum, team) => sum + (teamBudget(team)?.used ?? teamBudget(team)?.observed ?? 0),
+  0,
+);
+const allocated = teams.reduce(
+  (sum, team) => sum + (teamBudget(team)?.allocated ?? teamBudget(team)?.budget ?? 0),
+  0,
+);
 
 byId("workspace-name").textContent = data.workspace;
 byId("metric-teams").textContent = String(activeTeams.length);
 byId("metric-agents").textContent = String(agents.length);
-byId("metric-budget").textContent = `${Math.round((used / allocated) * 100)}% used`;
+byId("metric-budget").textContent =
+  allocated > 0 ? `${Math.round((used / allocated) * 100)}% used` : "no budget";
 byId("metric-providers").textContent = "CLI + SDK";
 
 const topology = await loadTopology();
@@ -148,19 +175,19 @@ byId("topology-panels").innerHTML = topology
   )
   .join("");
 
-byId("team-list").innerHTML = data.teams
+byId("team-list").innerHTML = teams
   .map(
     (team) => `
       <article class="team-row">
         <div>
-          <p class="eyebrow">${team.mode}</p>
-          <h3>${team.id}</h3>
-          <p class="muted">${team.goal}</p>
+          <p class="eyebrow">${teamMode(team)}</p>
+          <h3>${teamId(team)}</h3>
+          <p class="muted">${teamGoal(team)}</p>
           <div class="agent-stack">
             ${team.agents
               .map(
                 (agent) =>
-                  `<span class="chip ${agent.state === "answered" ? "good" : ""}">${agent.name}: ${agent.provider}</span>`,
+                  `<span class="chip ${["answered", "completed"].includes(agent.state) ? "good" : ""}">${agentName(agent)}: ${agentProvider(agent)}</span>`,
               )
               .join("")}
           </div>
@@ -171,17 +198,21 @@ byId("team-list").innerHTML = data.teams
   )
   .join("");
 
-byId("budget-panel").innerHTML = data.teams
+byId("budget-panel").innerHTML = teams
   .map((team) => {
-    const percentage = Math.round((team.budget.used / team.budget.allocated) * 100);
+    const budget = teamBudget(team);
+    const budgetTotal = budget?.allocated ?? budget?.budget ?? 0;
+    const budgetUsed = budget?.used ?? budget?.observed ?? 0;
+    const budgetReserved = budget?.reserved ?? budget?.allocated ?? 0;
+    const percentage = budgetTotal > 0 ? Math.round((budgetUsed / budgetTotal) * 100) : 0;
     return `
       <article class="budget-row">
         <div class="section-title">
-          <strong>${team.id}</strong>
-          <span class="muted">${team.budget.used.toLocaleString()} / ${team.budget.allocated.toLocaleString()}</span>
+          <strong>${teamId(team)}</strong>
+          <span class="muted">${budgetUsed.toLocaleString()} / ${budgetTotal.toLocaleString()}</span>
         </div>
         <div class="bar" aria-label="${percentage}% token budget used"><span style="width: ${percentage}%"></span></div>
-        <span class="muted">Reserved: ${team.budget.reserved.toLocaleString()} tokens</span>
+        <span class="muted">Reserved: ${budgetReserved.toLocaleString()} tokens</span>
       </article>
     `;
   })

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -7,6 +7,7 @@ import {
   createControlPlaneServer,
   parseArguments,
 } from "../../apps/control-plane-preview/src/main.js";
+import { TeamStore } from "../../packages/team-control/src/store.js";
 
 test("control plane preview parses bounded local server options", () => {
   assert.deepEqual(parseArguments([]), { host: "127.0.0.1", port: 7345 });
@@ -93,6 +94,80 @@ test("control plane preview exposes closed read-only topology status", async () 
 
     const unknownApi = await fetch(`${base}/api/topology/secrets`);
     assert.equal(unknownApi.status, 404);
+
+    const teams = await fetch(`${base}/api/teams/status`);
+    assert.equal(teams.status, 200);
+    const empty = await teams.json();
+    assert.equal(empty.schema, "yukh-control-plane-team-status-v1");
+    assert.equal(empty.source, "unconfigured");
+    assert.deepEqual(empty.teams, []);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("control plane preview exposes redacted live team status", async () => {
+  const root = await mkdtemp(join(tmpdir(), "yukh-control-plane-preview-team-"));
+  await writeFile(join(root, "index.html"), "<h1>Control</h1>");
+  await writeFile(join(root, "styles.css"), "body{}");
+  await writeFile(join(root, "mock-data.js"), "export {};");
+
+  const workspace = await mkdtemp(join(tmpdir(), "yukh-control-plane-workspace-"));
+  const store = new TeamStore(workspace);
+  const team = store.create(
+    "Deliver sensitive-but-redacted control-plane work",
+    "codex",
+    4,
+    2,
+    90_000,
+    { role: "delivery-manager", mission: "Coordinate a bounded increment" },
+  );
+  const agent = store.spawn(team.team_id, {
+    runtime: "copilot",
+    role: "frontend-worker",
+    task: "Implement sensitive UI task text",
+    token_budget: 20_000,
+    max_commands: 0,
+    timeout_ms: 60_000,
+  });
+  store.transition(team.team_id, agent.agent_id, "running");
+
+  const server = createControlPlaneServer(root, { teamStore: store });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  try {
+    const address = server.address();
+    if (typeof address !== "object" || address === null) {
+      throw new TypeError("expected TCP server address");
+    }
+    const base = `http://127.0.0.1:${address.port}`;
+
+    const response = await fetch(`${base}/api/teams/status`);
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("cache-control"), "no-store");
+    const body = await response.json();
+    assert.equal(body.schema, "yukh-control-plane-team-status-v1");
+    assert.equal(body.source, "local-team-store");
+    assert.equal(body.teams.length, 1);
+    assert.equal(body.teams[0].team_id, team.team_id);
+    assert.equal(body.teams[0].manager_role, "delivery-manager");
+    assert.match(body.teams[0].goal_digest, /^sha-256:[a-f0-9]{64}$/u);
+    assert.equal(body.teams[0].agents.length, 1);
+    assert.equal(body.teams[0].agents[0].role, "frontend-worker");
+    assert.equal(body.teams[0].agents[0].state, "running");
+    assert.equal(body.teams[0].tokens.budget, 90_000);
+    assert.equal(body.teams[0].tokens.allocated, 20_000);
+
+    const serialized = JSON.stringify(body);
+    assert.doesNotMatch(serialized, /sensitive-but-redacted|sensitive UI task/iu);
+    assert.doesNotMatch(serialized, /secret|credential|private/iu);
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
@@ -111,6 +186,7 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(html, /Coordination/u);
   assert.match(html, /NATS JetStream runtime/u);
   assert.match(data, /api\/topology\/status/u);
+  assert.match(data, /api\/teams\/status/u);
   assert.match(data, /YKP_WORK_EVENTS_V1/u);
   assert.match(data, /message is evidence, not work authority/u);
   assert.doesNotMatch(`${html}\n${data}`, /mermaid/iu);


### PR DESCRIPTION
## Summary

- adds `GET /api/teams/status` to the local Control Plane preview
- reads local TeamStore state only when a workspace is configured
- redacts goal/task text and exposes only digest, identifiers, roles, states, aggregate token counters, receipt counts and plan states
- updates the UI to load live team summaries with mock fallback
- covers unconfigured state, live redaction, read-only method handling and static UI wiring
- records session evidence for issue #250

## Context

Closes #250.

This is read-only local preview status. It does not start, stop, approve, call
Coordination, call Projects, call NATS, inspect logs, invoke providers or expose
credentials.

## Validation

- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
