### PR TITLE
Add Control Plane manager detail

### DIFF
--- a/.context/sessions/SESSION-2026-08-18-05-control-plane-manager-detail.md
+++ b/.context/sessions/SESSION-2026-08-18-05-control-plane-manager-detail.md
@@ -1,0 +1,29 @@
+# SESSION-2026-08-18-05 — Control Plane manager detail preview
+
+- Status: completed
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/252
+- Branch: `agent/control-plane-manager-detail`
+
+## Objective
+
+Add a read-only Manager detail view that explains current orchestration from redacted team status.
+
+## Outcome
+
+- Extended `/api/teams/status` redacted agent summaries with required and missing action names.
+- Added Manager detail section to the preview UI.
+- Added mock/live rendering for manager, workers, plans and missing receipts.
+- Fixed topology SVG alignment and worker status pill layout.
+- Generated screenshots under `/tmp/yukh-control-plane-screenshots`.
+
+## Validation
+
+- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
+- `npm run format:check`
+- `npm run typecheck`
+- `npm run build`
+- `git diff --check`
+
+## Boundary
+
+Read-only UI/status only. No start/stop/approve controls, no Coordination/Projects/NATS/provider calls, no private goal/task/log exposure.

--- a/apps/control-plane-preview/src/team-status.ts
+++ b/apps/control-plane-preview/src/team-status.ts
@@ -38,6 +38,8 @@ export type ControlPlaneTeamSummary = {
     readonly coordination_participant: string;
     readonly token_budget: number;
     readonly observed_tokens: number;
+    readonly required_actions: readonly string[];
+    readonly missing_required_actions: readonly string[];
     readonly budget_outcome?: string;
     readonly completion_outcome?: string;
   }[];
@@ -82,6 +84,13 @@ export function createTeamStatus(store?: Pick<TeamStore, "teams">): ControlPlane
         coordination_participant: agent.coordination_participant,
         token_budget: agent.token_budget,
         observed_tokens: agent.usage?.total_tokens ?? 0,
+        required_actions: agent.required_actions,
+        missing_required_actions: status.receipts
+          .filter((receipt) => receipt.actor_agent_id === agent.agent_id)
+          .reduce(
+            (missing, receipt) => missing.filter((action) => action !== receipt.action),
+            [...agent.required_actions],
+          ),
         ...(agent.usage ? { budget_outcome: agent.usage.budget_outcome } : {}),
         ...(agent.completion ? { completion_outcome: agent.completion.outcome } : {}),
       })),

--- a/apps/control-plane-preview/static/index.html
+++ b/apps/control-plane-preview/static/index.html
@@ -78,7 +78,12 @@
 
           <div class="topology-layout">
             <figure class="topology-map" aria-label="Yukh suite runtime topology">
-              <svg viewBox="0 0 900 360" role="img" aria-labelledby="topology-title topology-desc">
+              <svg
+                viewBox="0 0 900 360"
+                preserveAspectRatio="xMidYMin meet"
+                role="img"
+                aria-labelledby="topology-title topology-desc"
+              >
                 <title id="topology-title">
                   Yukh Projects, MCP, Coordination, and JetStream topology
                 </title>
@@ -177,6 +182,17 @@
             </div>
             <div id="budget-panel"></div>
           </article>
+        </section>
+
+        <section class="card manager-detail-card" id="manager-detail">
+          <div class="section-title">
+            <div>
+              <p class="eyebrow">Manager detail</p>
+              <h3>Current orchestration</h3>
+            </div>
+            <span class="status-pill small"><span class="dot warn"></span>read only</span>
+          </div>
+          <div id="manager-detail-panel" class="manager-detail"></div>
         </section>
 
         <section class="two-column wide-left">

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -10,23 +10,34 @@ const data = {
       agents: [
         {
           name: "manager",
+          kind: "manager",
           role: "product-engineering manager",
           provider: "Codex CLI",
           state: "planned",
+          required_actions: ["team.status", "agent.engage", "agent.await"],
+          missing_required_actions: ["agent.engage", "agent.await"],
         },
         {
           name: "frontend-worker",
+          kind: "worker",
           role: "UI implementer",
           provider: "Copilot SDK",
           state: "proposed",
+          required_actions: [],
+          missing_required_actions: [],
         },
         {
           name: "qa-worker",
+          kind: "worker",
           role: "runtime verifier",
           provider: "Codex SDK planned",
           state: "not launched",
+          required_actions: [],
+          missing_required_actions: [],
         },
       ],
+      plans: [{ plan_id: "plan-preview", state: "proposed", worker_count: 2, has_synthesis: true }],
+      receipts_count: 1,
     },
     {
       id: "team-task-board-smoke",
@@ -35,8 +46,18 @@ const data = {
       state: "complete",
       budget: { allocated: 80000, reserved: 55000, used: 31200 },
       agents: [
-        { name: "agent-b", role: "frontend worker", provider: "Copilot CLI", state: "answered" },
+        {
+          name: "agent-b",
+          kind: "worker",
+          role: "frontend worker",
+          provider: "Copilot CLI",
+          state: "answered",
+          required_actions: [],
+          missing_required_actions: [],
+        },
       ],
+      plans: [],
+      receipts_count: 2,
     },
   ],
   topology: [
@@ -136,6 +157,9 @@ const teamGoal = (team) => team.goal ?? `goal ${team.goal_digest.slice(0, 19)}鈥
 const teamMode = (team) => team.mode ?? team.manager_runtime ?? "manager runtime";
 const agentName = (agent) => agent.name ?? `${agent.kind}:${agent.role}`;
 const agentProvider = (agent) => agent.provider ?? agent.runtime;
+const teamManager = (team) =>
+  team.agents.find((agent) => agent.kind === "manager") ?? team.agents[0];
+const teamWorkers = (team) => team.agents.filter((agent) => agent !== teamManager(team));
 const activeTeams = teams.filter((team) => !["complete", "stopped"].includes(team.state));
 const agents = teams.flatMap((team) => team.agents);
 const used = teams.reduce(
@@ -217,6 +241,60 @@ byId("budget-panel").innerHTML = teams
     `;
   })
   .join("");
+
+const selectedTeam = activeTeams[0] ?? teams[0];
+if (selectedTeam) {
+  const manager = teamManager(selectedTeam);
+  const workers = teamWorkers(selectedTeam);
+  const plans = selectedTeam.plans ?? [];
+  const missing = manager?.missing_required_actions ?? [];
+  byId("manager-detail-panel").innerHTML = `
+    <article class="manager-summary">
+      <div>
+        <p class="eyebrow">${teamMode(selectedTeam)}</p>
+        <h3>${manager ? `${manager.role} 路 ${agentProvider(manager)}` : "No manager registered"}</h3>
+        <p class="muted">${teamGoal(selectedTeam)}</p>
+      </div>
+      <span class="status-pill small"><span class="dot ${selectedTeam.state === "complete" ? "ok" : "warn"}"></span>${selectedTeam.state}</span>
+    </article>
+    <div class="manager-grid">
+      <article>
+        <span>Required receipts</span>
+        <strong>${manager?.required_actions?.length ?? 0}</strong>
+        <p class="muted">${missing.length === 0 ? "none missing" : `missing: ${missing.join(", ")}`}</p>
+      </article>
+      <article>
+        <span>Workers</span>
+        <strong>${workers.length}</strong>
+        <p class="muted">${workers.map((worker) => `${worker.role}: ${worker.state}`).join(" 路 ") || "none"}</p>
+      </article>
+      <article>
+        <span>Plans</span>
+        <strong>${plans.length}</strong>
+        <p class="muted">${plans.map((plan) => `${plan.state}, workers=${plan.worker_count}`).join(" 路 ") || "no plan"}</p>
+      </article>
+    </div>
+    <div class="worker-table">
+      ${[manager, ...workers]
+        .filter(Boolean)
+        .map(
+          (agent) => `
+            <article>
+              <div>
+                <strong>${agent.role}</strong>
+                <span class="muted">${agentName(agent)} 路 ${agentProvider(agent)} 路 ${agent.coordination_participant ?? "coordination pending"}</span>
+              </div>
+              <span class="status-pill small"><span class="dot ${["answered", "completed"].includes(agent.state) ? "ok" : "warn"}"></span>${agent.state}</span>
+            </article>
+          `,
+        )
+        .join("")}
+    </div>
+  `;
+} else {
+  byId("manager-detail-panel").innerHTML =
+    '<p class="muted">No team state yet. Start from a manager plan to populate this view.</p>';
+}
 
 byId("transcript-list").innerHTML = data.transcript
   .map(

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -294,6 +294,61 @@ nav a:hover {
 .topology-node dd {
   margin: 2px 0 0;
 }
+.manager-detail {
+  display: grid;
+  gap: 14px;
+}
+.manager-summary {
+  align-items: center;
+  background: var(--panel-2);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 18px;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 16px;
+}
+.manager-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+.manager-grid article {
+  background: #0d121c;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+}
+.manager-grid span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.manager-grid strong {
+  font-size: 26px;
+}
+.worker-table {
+  display: grid;
+  gap: 10px;
+}
+.worker-table article {
+  align-items: center;
+  background: var(--panel-2);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 12px 14px;
+}
+.worker-table article > div span {
+  display: block;
+  margin-top: 4px;
+}
 .section-title {
   align-items: center;
   display: flex;
@@ -308,6 +363,7 @@ nav a:hover {
   display: inline-flex;
   gap: 8px;
   padding: 8px 11px;
+  white-space: nowrap;
 }
 .status-pill.small {
   font-size: 12px;
@@ -423,6 +479,9 @@ textarea {
   .two-column,
   .wide-left,
   .topology-layout,
+  .manager-grid,
+  .manager-summary,
+  .worker-table article,
   .metrics {
     grid-template-columns: 1fr;
   }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -116,15 +116,36 @@ test("control plane preview exposes redacted live team status", async () => {
 
   const workspace = await mkdtemp(join(tmpdir(), "yukh-control-plane-workspace-"));
   const store = new TeamStore(workspace);
-  const team = store.create(
+  const managed = store.createManaged(
     "Deliver sensitive-but-redacted control-plane work",
     "codex",
     4,
     2,
     90_000,
-    { role: "delivery-manager", mission: "Coordinate a bounded increment" },
+    {
+      role: "delivery-manager",
+      profile: {
+        schema: 1,
+        mission: "Coordinate a bounded increment",
+        model: "gpt-5.6-sol",
+        skills: ["testing"],
+        instructions: "Keep output bounded and evidence-oriented.",
+      },
+      task: "Manage sensitive UI task text",
+      token_budget: 15_000,
+      required_actions: ["team.status", "agent.engage", "agent.await"],
+      max_commands: 0,
+      timeout_ms: 60_000,
+    },
   );
-  const agent = store.spawn(team.team_id, {
+  store.receipt(
+    managed.team.team_id,
+    "team.status",
+    managed.manager.agent_id,
+    managed.manager.agent_id,
+  );
+  const agent = store.spawn(managed.team.team_id, {
+    parent_agent_id: managed.manager.agent_id,
     runtime: "copilot",
     role: "frontend-worker",
     task: "Implement sensitive UI task text",
@@ -132,7 +153,7 @@ test("control plane preview exposes redacted live team status", async () => {
     max_commands: 0,
     timeout_ms: 60_000,
   });
-  store.transition(team.team_id, agent.agent_id, "running");
+  store.transition(managed.team.team_id, agent.agent_id, "running");
 
   const server = createControlPlaneServer(root, { teamStore: store });
   await new Promise<void>((resolve, reject) => {
@@ -156,17 +177,28 @@ test("control plane preview exposes redacted live team status", async () => {
     assert.equal(body.schema, "yukh-control-plane-team-status-v1");
     assert.equal(body.source, "local-team-store");
     assert.equal(body.teams.length, 1);
-    assert.equal(body.teams[0].team_id, team.team_id);
+    assert.equal(body.teams[0].team_id, managed.team.team_id);
     assert.equal(body.teams[0].manager_role, "delivery-manager");
     assert.match(body.teams[0].goal_digest, /^sha-256:[a-f0-9]{64}$/u);
-    assert.equal(body.teams[0].agents.length, 1);
-    assert.equal(body.teams[0].agents[0].role, "frontend-worker");
-    assert.equal(body.teams[0].agents[0].state, "running");
+    assert.equal(body.teams[0].receipts_count, 1);
+    assert.equal(body.teams[0].agents.length, 2);
+    assert.equal(body.teams[0].agents[0].kind, "manager");
+    assert.deepEqual(body.teams[0].agents[0].required_actions, [
+      "team.status",
+      "agent.engage",
+      "agent.await",
+    ]);
+    assert.deepEqual(body.teams[0].agents[0].missing_required_actions, [
+      "agent.engage",
+      "agent.await",
+    ]);
+    assert.equal(body.teams[0].agents[1].role, "frontend-worker");
+    assert.equal(body.teams[0].agents[1].state, "running");
     assert.equal(body.teams[0].tokens.budget, 90_000);
-    assert.equal(body.teams[0].tokens.allocated, 20_000);
+    assert.equal(body.teams[0].tokens.allocated, 35_000);
 
     const serialized = JSON.stringify(body);
-    assert.doesNotMatch(serialized, /sensitive-but-redacted|sensitive UI task/iu);
+    assert.doesNotMatch(serialized, /sensitive-but-redacted|sensitive UI task|Manage sensitive/iu);
     assert.doesNotMatch(serialized, /secret|credential|private/iu);
   } finally {
     await new Promise<void>((resolve, reject) => {
@@ -185,8 +217,11 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(html, /Yukh MCP/u);
   assert.match(html, /Coordination/u);
   assert.match(html, /NATS JetStream runtime/u);
+  assert.match(html, /Manager detail/u);
+  assert.match(html, /Current orchestration/u);
   assert.match(data, /api\/topology\/status/u);
   assert.match(data, /api\/teams\/status/u);
+  assert.match(data, /missing_required_actions/u);
   assert.match(data, /YKP_WORK_EVENTS_V1/u);
   assert.match(data, /message is evidence, not work authority/u);
   assert.doesNotMatch(`${html}\n${data}`, /mermaid/iu);


### PR DESCRIPTION
## What changed

- Added a read-only Manager detail section to the Control Plane preview.
- Extended `/api/teams/status` redacted agent summaries with required and missing action names.
- Rendered manager, workers, plan counters, receipts and missing required actions from live status data, with mock fallback.
- Fixed topology SVG alignment and worker status pill layout.

## Why

The preview showed budget and topology, but not who is orchestrating, which workers are involved, and what orchestration actions are still missing.

## Validation

- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## Boundary

Read-only preview only. No start/stop/approve controls, no Coordination/Projects/NATS/provider calls, and no private goal/task/log body exposure.

Closes #252.
