### PR TITLE
Add Control Plane command center

### DIFF
--- a/.context/sessions/SESSION-2026-08-18-06-control-plane-command-center.md
+++ b/.context/sessions/SESSION-2026-08-18-06-control-plane-command-center.md
@@ -1,0 +1,30 @@
+# SESSION-2026-08-18-06 — Control Plane command center
+
+- Status: completed
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/254
+- Branch: `agent/control-plane-command-center`
+
+## Objective
+
+Make the Control Plane preview easier to read as an operator console: active managers, teams, task flow and latest communication should be visible without scanning raw logs.
+
+## Outcome
+
+- Added a read-only Command center section.
+- Rendered active managers, worker counts, token budget percentage, missing receipts, task flow and latest communication.
+- Kept live data redacted by deriving display state from `/api/teams/status`.
+- Added CSS guardrails for long IDs and messages: wrapping, clamping, responsive columns and max-width constraints.
+- Generated screenshots under `/tmp/yukh-control-plane-screenshots`.
+
+## Validation
+
+- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
+- `npm run format:check`
+- `npm run typecheck`
+- `npm run build`
+- `git diff --check`
+- Playwright screenshot capture with overflow detection.
+
+## Boundary
+
+Read-only UI only. No operational team start/stop/approve actions yet.

--- a/apps/control-plane-preview/static/index.html
+++ b/apps/control-plane-preview/static/index.html
@@ -22,9 +22,11 @@
       <aside class="sidebar" aria-label="Projects">
         <button class="primary">Start team</button>
         <nav>
-          <a class="active" href="#dashboard">Dashboard</a>
+          <a class="active" href="#dashboard">Command center</a>
           <a href="#topology">Runtime topology</a>
+          <a href="#managers">Managers</a>
           <a href="#teams">Teams</a>
+          <a href="#tasks">Tasks</a>
           <a href="#transcript">Transcript</a>
           <a href="#budgets">Budgets</a>
           <a href="#settings">Providers</a>
@@ -65,6 +67,41 @@
           <article class="metric card">
             <span>Provider mix</span><strong id="metric-providers">—</strong>
           </article>
+        </section>
+
+        <section class="card command-center-card" id="managers">
+          <div class="section-title">
+            <div>
+              <p class="eyebrow">Command center</p>
+              <h3>Managers, teams and work in motion</h3>
+            </div>
+            <span class="status-pill small"><span class="dot warn"></span>read only</span>
+          </div>
+          <div class="command-center">
+            <section class="manager-lane" aria-label="Active managers">
+              <div class="subsection-title">
+                <h4>Active managers</h4>
+                <span id="manager-count" class="muted">—</span>
+              </div>
+              <div id="manager-list" class="manager-list"></div>
+            </section>
+
+            <section class="task-lane" id="tasks" aria-label="Task flow">
+              <div class="subsection-title">
+                <h4>Task flow</h4>
+                <span class="muted">claim · run · evidence</span>
+              </div>
+              <div id="task-board" class="task-board"></div>
+            </section>
+
+            <section class="conversation-lane" aria-label="Team communication">
+              <div class="subsection-title">
+                <h4>Communication</h4>
+                <span class="muted">latest verified events</span>
+              </div>
+              <div id="conversation-feed" class="conversation-feed"></div>
+            </section>
+          </div>
         </section>
 
         <section class="card topology-card" id="topology">

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -38,6 +38,29 @@ const data = {
       ],
       plans: [{ plan_id: "plan-preview", state: "proposed", worker_count: 2, has_synthesis: true }],
       receipts_count: 1,
+      tasks: [
+        {
+          id: "YKP-CP-252",
+          title: "Expose manager detail without leaking private task bodies",
+          owner: "manager",
+          state: "review",
+          priority: "high",
+        },
+        {
+          id: "YKP-CP-253",
+          title: "Design command center overview for operators",
+          owner: "frontend-worker",
+          state: "in_progress",
+          priority: "high",
+        },
+        {
+          id: "YKP-CP-254",
+          title: "Add provider/model configuration after read-only flow is understandable",
+          owner: "delivery-manager",
+          state: "ready",
+          priority: "medium",
+        },
+      ],
     },
     {
       id: "team-task-board-smoke",
@@ -58,6 +81,15 @@ const data = {
       ],
       plans: [],
       receipts_count: 2,
+      tasks: [
+        {
+          id: "YKP-SMOKE-001",
+          title: "Verify coordinator launches a worker and validates the answer receipt",
+          owner: "agent-b",
+          state: "done",
+          priority: "medium",
+        },
+      ],
     },
   ],
   topology: [
@@ -157,9 +189,50 @@ const teamGoal = (team) => team.goal ?? `goal ${team.goal_digest.slice(0, 19)}�
 const teamMode = (team) => team.mode ?? team.manager_runtime ?? "manager runtime";
 const agentName = (agent) => agent.name ?? `${agent.kind}:${agent.role}`;
 const agentProvider = (agent) => agent.provider ?? agent.runtime;
+const agentStateClass = (state) =>
+  ["answered", "completed", "done"].includes(state) ? "ok" : "warn";
 const teamManager = (team) =>
   team.agents.find((agent) => agent.kind === "manager") ?? team.agents[0];
 const teamWorkers = (team) => team.agents.filter((agent) => agent !== teamManager(team));
+const taskStateRank = { ready: 0, in_progress: 1, review: 2, done: 3 };
+const teamTasks = (team) =>
+  team.tasks ?? [
+    ...(team.plans ?? []).map((plan) => ({
+      id: plan.plan_id,
+      title: `Plan ${plan.state} with ${plan.worker_count} proposed workers`,
+      owner: teamManager(team)?.role ?? "manager",
+      state: plan.state === "approved" ? "in_progress" : "ready",
+      priority: "medium",
+    })),
+    ...teamWorkers(team).map((worker) => ({
+      id: worker.agent_id,
+      title: `${worker.role} worker lifecycle`,
+      owner: agentName(worker),
+      state: worker.state === "completed" || worker.state === "answered" ? "done" : "in_progress",
+      priority: "medium",
+    })),
+  ];
+const allTasks = teams
+  .flatMap((team) => teamTasks(team).map((task) => ({ ...task, team_id: teamId(team) })))
+  .sort((a, b) => (taskStateRank[a.state] ?? 9) - (taskStateRank[b.state] ?? 9));
+const conversations = [
+  ...data.transcript.map((event) => ({
+    id: event.eventId,
+    label: `${event.from} → ${event.to}`,
+    state: event.kind,
+    body: event.body,
+  })),
+  ...teams.flatMap((team) =>
+    (team.agents ?? [])
+      .filter((agent) => (agent.missing_required_actions ?? []).length > 0)
+      .map((agent) => ({
+        id: `${teamId(team)}:${agentName(agent)}:missing`,
+        label: `${agentName(agent)} · required actions`,
+        state: "missing",
+        body: `Missing ${agent.missing_required_actions.join(", ")}`,
+      })),
+  ),
+].slice(0, 5);
 const activeTeams = teams.filter((team) => !["complete", "stopped"].includes(team.state));
 const agents = teams.flatMap((team) => team.agents);
 const used = teams.reduce(
@@ -177,6 +250,74 @@ byId("metric-agents").textContent = String(agents.length);
 byId("metric-budget").textContent =
   allocated > 0 ? `${Math.round((used / allocated) * 100)}% used` : "no budget";
 byId("metric-providers").textContent = "CLI + SDK";
+
+byId("manager-count").textContent = `${activeTeams.length} active`;
+byId("manager-list").innerHTML = teams
+  .map((team) => {
+    const manager = teamManager(team);
+    const workers = teamWorkers(team);
+    const budget = teamBudget(team);
+    const budgetTotal = budget?.allocated ?? budget?.budget ?? 0;
+    const budgetUsed = budget?.used ?? budget?.observed ?? 0;
+    const percentage = budgetTotal > 0 ? Math.round((budgetUsed / budgetTotal) * 100) : 0;
+    const missing = manager?.missing_required_actions ?? [];
+    return `
+      <article class="manager-card">
+        <div class="manager-card-main">
+          <p class="eyebrow">${teamMode(team)}</p>
+          <h4>${manager?.role ?? "manager pending"}</h4>
+          <p class="muted clamp-2">${teamGoal(team)}</p>
+        </div>
+        <div class="manager-card-meta">
+          <span class="status-pill small"><span class="dot ${team.state === "complete" ? "ok" : "warn"}"></span>${team.state}</span>
+          <span>${workers.length} workers</span>
+          <span>${percentage}% budget</span>
+          <span>${missing.length === 0 ? "receipts ok" : `${missing.length} missing`}</span>
+        </div>
+      </article>
+    `;
+  })
+  .join("");
+
+byId("task-board").innerHTML = ["ready", "in_progress", "review", "done"]
+  .map((state) => {
+    const tasks = allTasks.filter((task) => task.state === state);
+    return `
+      <section class="task-column">
+        <div class="task-column-title">
+          <strong>${state.replaceAll("_", " ")}</strong>
+          <span>${tasks.length}</span>
+        </div>
+        ${tasks
+          .map(
+            (task) => `
+              <article class="task-card">
+                <span class="chip">${task.id}</span>
+                <h4>${task.title}</h4>
+                <p class="muted">${task.team_id} · ${task.owner}</p>
+                <span class="priority ${task.priority}">${task.priority}</span>
+              </article>
+            `,
+          )
+          .join("")}
+      </section>
+    `;
+  })
+  .join("");
+
+byId("conversation-feed").innerHTML = conversations
+  .map(
+    (event) => `
+      <article class="conversation-event">
+        <div>
+          <span class="chip">${event.state}</span>
+          <strong>${event.label}</strong>
+        </div>
+        <p class="muted clamp-2">${event.body}</p>
+      </article>
+    `,
+  )
+  .join("");
 
 const topology = await loadTopology();
 byId("topology-panels").innerHTML = topology
@@ -284,7 +425,7 @@ if (selectedTeam) {
                 <strong>${agent.role}</strong>
                 <span class="muted">${agentName(agent)} · ${agentProvider(agent)} · ${agent.coordination_participant ?? "coordination pending"}</span>
               </div>
-              <span class="status-pill small"><span class="dot ${["answered", "completed"].includes(agent.state) ? "ok" : "warn"}"></span>${agent.state}</span>
+              <span class="status-pill small"><span class="dot ${agentStateClass(agent.state)}"></span>${agent.state}</span>
             </article>
           `,
         )

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -21,6 +21,11 @@
 * {
   box-sizing: border-box;
 }
+*,
+*::before,
+*::after {
+  min-width: 0;
+}
 body {
   margin: 0;
   min-height: 100vh;
@@ -38,6 +43,7 @@ textarea {
 h1,
 h2,
 h3,
+h4,
 p {
   margin: 0;
 }
@@ -57,6 +63,23 @@ h3 {
 h4 {
   font-size: 15px;
   margin: 0;
+}
+p,
+dd,
+span,
+strong,
+a,
+button,
+input,
+select,
+textarea {
+  overflow-wrap: anywhere;
+}
+.clamp-2 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
 }
 .topbar {
   align-items: center;
@@ -361,15 +384,18 @@ nav a:hover {
   border: 1px solid var(--line);
   border-radius: 999px;
   display: inline-flex;
+  flex-wrap: wrap;
   gap: 8px;
+  max-width: 100%;
   padding: 8px 11px;
-  white-space: nowrap;
+  white-space: normal;
 }
 .status-pill.small {
   font-size: 12px;
   padding: 6px 9px;
 }
 .dot {
+  flex: 0 0 auto;
   border-radius: 50%;
   display: inline-block;
   height: 9px;
@@ -386,6 +412,109 @@ nav a:hover {
 #budget-panel {
   display: grid;
   gap: 12px;
+}
+.command-center {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(280px, 0.9fr) minmax(0, 1.6fr) minmax(280px, 0.85fr);
+}
+.subsection-title {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+.manager-lane,
+.task-lane,
+.conversation-lane {
+  background: rgba(13, 18, 28, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 20px;
+  min-height: 100%;
+  padding: 14px;
+}
+.manager-list,
+.conversation-feed {
+  display: grid;
+  gap: 10px;
+}
+.manager-card,
+.conversation-event,
+.task-card {
+  background: var(--panel-2);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+}
+.manager-card {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+}
+.manager-card-main {
+  display: grid;
+  gap: 6px;
+}
+.manager-card-meta {
+  align-items: center;
+  color: var(--muted);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 12px;
+  gap: 8px;
+}
+.task-board {
+  align-items: start;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.task-column {
+  background: #0b1019;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  display: grid;
+  gap: 10px;
+  padding: 10px;
+}
+.task-column-title {
+  align-items: center;
+  color: var(--muted);
+  display: flex;
+  font-size: 12px;
+  gap: 8px;
+  justify-content: space-between;
+  text-transform: capitalize;
+}
+.task-card {
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+}
+.priority {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.priority.high {
+  color: var(--warn);
+}
+.priority.medium {
+  color: var(--accent-2);
+}
+.conversation-event {
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+}
+.conversation-event > div {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 .team-row,
 .event-row,
@@ -411,8 +540,13 @@ nav a:hover {
   border: 1px solid var(--line);
   border-radius: 999px;
   color: var(--muted);
+  display: inline-block;
   font-size: 12px;
+  line-height: 1.3;
+  max-width: 100%;
   padding: 5px 8px;
+  vertical-align: middle;
+  white-space: normal;
 }
 .chip.good {
   color: var(--accent);
@@ -482,10 +616,28 @@ textarea {
   .manager-grid,
   .manager-summary,
   .worker-table article,
+  .command-center,
   .metrics {
     grid-template-columns: 1fr;
   }
+  .task-board {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
   .hero-actions {
     flex-wrap: wrap;
+  }
+}
+@media (max-width: 640px) {
+  .shell {
+    padding: 14px;
+  }
+  .topbar,
+  .section-title,
+  .team-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .task-board {
+    grid-template-columns: 1fr;
   }
 }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -182,18 +182,15 @@ test("control plane preview exposes redacted live team status", async () => {
     assert.match(body.teams[0].goal_digest, /^sha-256:[a-f0-9]{64}$/u);
     assert.equal(body.teams[0].receipts_count, 1);
     assert.equal(body.teams[0].agents.length, 2);
-    assert.equal(body.teams[0].agents[0].kind, "manager");
-    assert.deepEqual(body.teams[0].agents[0].required_actions, [
-      "team.status",
-      "agent.engage",
-      "agent.await",
-    ]);
-    assert.deepEqual(body.teams[0].agents[0].missing_required_actions, [
-      "agent.engage",
-      "agent.await",
-    ]);
-    assert.equal(body.teams[0].agents[1].role, "frontend-worker");
-    assert.equal(body.teams[0].agents[1].state, "running");
+    const manager = body.teams[0].agents.find((item: { kind: string }) => item.kind === "manager");
+    const worker = body.teams[0].agents.find(
+      (item: { role: string }) => item.role === "frontend-worker",
+    );
+    assert.ok(manager);
+    assert.ok(worker);
+    assert.deepEqual(manager.required_actions, ["team.status", "agent.engage", "agent.await"]);
+    assert.deepEqual(manager.missing_required_actions, ["agent.engage", "agent.await"]);
+    assert.equal(worker.state, "running");
     assert.equal(body.teams[0].tokens.budget, 90_000);
     assert.equal(body.teams[0].tokens.allocated, 35_000);
 
@@ -213,6 +210,11 @@ test("control plane preview explains runtime topology without Mermaid", async ()
 
   assert.match(html, /Runtime topology/u);
   assert.match(html, /Who owns what/u);
+  assert.match(html, /Command center/u);
+  assert.match(html, /Managers, teams and work in motion/u);
+  assert.match(html, /Active managers/u);
+  assert.match(html, /Task flow/u);
+  assert.match(html, /Communication/u);
   assert.match(html, /Yukh Projects/u);
   assert.match(html, /Yukh MCP/u);
   assert.match(html, /Coordination/u);
@@ -222,7 +224,22 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /api\/topology\/status/u);
   assert.match(data, /api\/teams\/status/u);
   assert.match(data, /missing_required_actions/u);
+  assert.match(data, /task-board/u);
+  assert.match(data, /conversation-feed/u);
   assert.match(data, /YKP_WORK_EVENTS_V1/u);
   assert.match(data, /message is evidence, not work authority/u);
   assert.doesNotMatch(`${html}\n${data}`, /mermaid/iu);
+});
+
+test("control plane preview has bounded text containers for operator UI", async () => {
+  const css = await readFile("apps/control-plane-preview/static/styles.css", "utf8");
+
+  assert.match(css, /overflow-wrap: anywhere/u);
+  assert.match(css, /\.clamp-2/u);
+  assert.match(css, /max-width: 100%/u);
+  assert.match(css, /white-space: normal/u);
+  assert.match(css, /\.task-board/u);
+  assert.match(css, /\.manager-card/u);
+  assert.match(css, /\.conversation-event/u);
+  assert.match(css, /@media \(max-width: 640px\)/u);
 });


### PR DESCRIPTION
## What changed

- Added a read-only Command center to the Control Plane preview.
- Shows active managers, worker count, budget percentage, missing receipts, task flow and latest communication.
- Derives live display state from redacted `/api/teams/status` data.
- Added CSS guardrails so long IDs, status labels and messages stay inside their containers.

## Why

The preview looked more like a dashboard than a control plane. Operators need to see who is orchestrating, what teams exist, what work is moving and what agents are saying without reading raw logs.

## Validation

- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- Playwright screenshot capture with overflow detection

## Boundary

Read-only UI only. Start/stop/approve/configure controls are intentionally left for the next increment.

Closes #254.
