### PR TITLE
Add Control Plane team detail

### DIFF
--- a/.context/sessions/SESSION-2026-08-18-07-control-plane-team-detail.md
+++ b/.context/sessions/SESSION-2026-08-18-07-control-plane-team-detail.md
@@ -1,0 +1,30 @@
+# SESSION-2026-08-18-07 — Control Plane team detail
+
+- Status: completed
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/256
+- Branch: `agent/control-plane-team-detail`
+
+## Objective
+
+Add a read-only team detail panel so an operator can inspect plan state, next required action, worker token usage and timeline without reading raw logs.
+
+## Outcome
+
+- Added Team detail section to the Control Plane preview.
+- Rendered selected team summary, next required action, plan records, worker token bars and timeline.
+- Reused redacted `/api/teams/status` data for live state.
+- Preserved UI containment for long team IDs, worker IDs and event details.
+- Generated `/tmp/yukh-control-plane-screenshots/team-detail.png` with overflow detection.
+
+## Validation
+
+- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
+- `npm run format:check`
+- `npm run typecheck`
+- `npm run build`
+- `git diff --check`
+- Playwright screenshot capture with overflow detection.
+
+## Boundary
+
+Read-only UI only. No interactive team selection, start/stop, approval, provider configuration or persisted event drill-down yet.

--- a/apps/control-plane-preview/static/index.html
+++ b/apps/control-plane-preview/static/index.html
@@ -104,6 +104,17 @@
           </div>
         </section>
 
+        <section class="card team-detail-card" id="team-detail">
+          <div class="section-title">
+            <div>
+              <p class="eyebrow">Team detail</p>
+              <h3>Plan, workers, tokens and next action</h3>
+            </div>
+            <span class="status-pill small"><span class="dot warn"></span>operator view</span>
+          </div>
+          <div id="team-detail-panel" class="team-detail"></div>
+        </section>
+
         <section class="card topology-card" id="topology">
           <div class="section-title">
             <div>

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -215,6 +215,12 @@ const teamTasks = (team) =>
 const allTasks = teams
   .flatMap((team) => teamTasks(team).map((task) => ({ ...task, team_id: teamId(team) })))
   .sort((a, b) => (taskStateRank[a.state] ?? 9) - (taskStateRank[b.state] ?? 9));
+const tokenBudget = (agent) => agent.token_budget ?? 0;
+const observedTokens = (agent) => agent.observed_tokens ?? 0;
+const tokenPercent = (agent) =>
+  tokenBudget(agent) > 0
+    ? Math.min(100, Math.round((observedTokens(agent) / tokenBudget(agent)) * 100))
+    : 0;
 const conversations = [
   ...data.transcript.map((event) => ({
     id: event.eventId,
@@ -388,7 +394,32 @@ if (selectedTeam) {
   const manager = teamManager(selectedTeam);
   const workers = teamWorkers(selectedTeam);
   const plans = selectedTeam.plans ?? [];
+  const tasks = teamTasks(selectedTeam);
   const missing = manager?.missing_required_actions ?? [];
+  const nextAction =
+    missing[0] ?? (plans.length > 0 ? "approve or revise manager plan" : "inspect latest evidence");
+  const timeline = [
+    {
+      label: "team created",
+      detail: `${teamMode(selectedTeam)} · ${selectedTeam.state}`,
+      state: "done",
+    },
+    ...plans.map((plan) => ({
+      label: `plan ${plan.state}`,
+      detail: `${plan.worker_count} workers · synthesis ${plan.has_synthesis ? "present" : "missing"}`,
+      state: plan.state,
+    })),
+    ...tasks.slice(0, 4).map((task) => ({
+      label: task.title,
+      detail: `${task.state} · owner ${task.owner}`,
+      state: task.state,
+    })),
+    {
+      label: missing.length === 0 ? "required actions satisfied" : "required action pending",
+      detail: missing.length === 0 ? "manager receipts complete" : missing.join(", "),
+      state: missing.length === 0 ? "done" : "waiting",
+    },
+  ];
   byId("manager-detail-panel").innerHTML = `
     <article class="manager-summary">
       <div>
@@ -432,9 +463,95 @@ if (selectedTeam) {
         .join("")}
     </div>
   `;
+  byId("team-detail-panel").innerHTML = `
+    <article class="detail-hero">
+      <div>
+        <p class="eyebrow">${teamId(selectedTeam)}</p>
+        <h3>${manager?.role ?? "manager pending"} coordinating ${workers.length} workers</h3>
+        <p class="muted clamp-2">${teamGoal(selectedTeam)}</p>
+      </div>
+      <div class="next-action">
+        <span>Next required action</span>
+        <strong>${nextAction}</strong>
+      </div>
+    </article>
+
+    <div class="detail-grid">
+      <section class="detail-panel">
+        <div class="subsection-title">
+          <h4>Plan</h4>
+          <span class="muted">${plans.length} records</span>
+        </div>
+        <div class="plan-list">
+          ${
+            plans.length === 0
+              ? '<p class="muted">No plan recorded yet.</p>'
+              : plans
+                  .map(
+                    (plan) => `
+                      <article>
+                        <span class="chip">${plan.plan_id}</span>
+                        <strong>${plan.state}</strong>
+                        <p class="muted">${plan.worker_count} workers · synthesis ${plan.has_synthesis ? "present" : "missing"}</p>
+                      </article>
+                    `,
+                  )
+                  .join("")
+          }
+        </div>
+      </section>
+
+      <section class="detail-panel">
+        <div class="subsection-title">
+          <h4>Worker tokens</h4>
+          <span class="muted">${workers.length} workers</span>
+        </div>
+        <div class="token-list">
+          ${[manager, ...workers]
+            .filter(Boolean)
+            .map(
+              (agent) => `
+                <article>
+                  <div>
+                    <strong>${agent.role}</strong>
+                    <p class="muted">${agentName(agent)} · ${agentProvider(agent)} · ${observedTokens(agent).toLocaleString()} / ${tokenBudget(agent).toLocaleString()} tokens</p>
+                  </div>
+                  <div class="bar" aria-label="${tokenPercent(agent)}% token budget used"><span style="width: ${tokenPercent(agent)}%"></span></div>
+                </article>
+              `,
+            )
+            .join("")}
+        </div>
+      </section>
+
+      <section class="detail-panel timeline-panel">
+        <div class="subsection-title">
+          <h4>Timeline</h4>
+          <span class="muted">${timeline.length} events</span>
+        </div>
+        <div class="timeline">
+          ${timeline
+            .map(
+              (event) => `
+                <article>
+                  <span class="timeline-dot ${event.state === "done" ? "ok" : "warn"}"></span>
+                  <div>
+                    <strong>${event.label}</strong>
+                    <p class="muted">${event.detail}</p>
+                  </div>
+                </article>
+              `,
+            )
+            .join("")}
+        </div>
+      </section>
+    </div>
+  `;
 } else {
   byId("manager-detail-panel").innerHTML =
     '<p class="muted">No team state yet. Start from a manager plan to populate this view.</p>';
+  byId("team-detail-panel").innerHTML =
+    '<p class="muted">No team selected yet. Start from a manager plan to populate this view.</p>';
 }
 
 byId("transcript-list").innerHTML = data.transcript

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -321,6 +321,83 @@ nav a:hover {
   display: grid;
   gap: 14px;
 }
+.team-detail {
+  display: grid;
+  gap: 16px;
+}
+.detail-hero {
+  align-items: stretch;
+  background: var(--panel-2);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 20px;
+  display: grid;
+  gap: 14px;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 0.38fr);
+  padding: 16px;
+}
+.next-action {
+  background: linear-gradient(135deg, rgba(255, 209, 102, 0.12), transparent 55%), #0d121c;
+  border: 1px solid rgba(255, 209, 102, 0.24);
+  border-radius: 16px;
+  display: grid;
+  gap: 7px;
+  padding: 14px;
+}
+.next-action span {
+  color: var(--warn);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.detail-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: minmax(260px, 0.8fr) minmax(300px, 1fr) minmax(300px, 1fr);
+}
+.detail-panel {
+  background: rgba(13, 18, 28, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 20px;
+  padding: 14px;
+}
+.plan-list,
+.token-list,
+.timeline {
+  display: grid;
+  gap: 10px;
+}
+.plan-list article,
+.token-list article {
+  background: var(--panel-2);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+  display: grid;
+  gap: 9px;
+  padding: 12px;
+}
+.timeline {
+  position: relative;
+}
+.timeline article {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: auto minmax(0, 1fr);
+  padding: 2px 0 12px;
+}
+.timeline-dot {
+  border-radius: 50%;
+  display: inline-block;
+  height: 11px;
+  margin-top: 4px;
+  width: 11px;
+}
+.timeline-dot.ok {
+  background: var(--accent);
+}
+.timeline-dot.warn {
+  background: var(--warn);
+}
 .manager-summary {
   align-items: center;
   background: var(--panel-2);
@@ -615,6 +692,8 @@ textarea {
   .topology-layout,
   .manager-grid,
   .manager-summary,
+  .detail-hero,
+  .detail-grid,
   .worker-table article,
   .command-center,
   .metrics {

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -215,6 +215,8 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(html, /Active managers/u);
   assert.match(html, /Task flow/u);
   assert.match(html, /Communication/u);
+  assert.match(html, /Team detail/u);
+  assert.match(html, /Plan, workers, tokens and next action/u);
   assert.match(html, /Yukh Projects/u);
   assert.match(html, /Yukh MCP/u);
   assert.match(html, /Coordination/u);
@@ -226,6 +228,10 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /missing_required_actions/u);
   assert.match(data, /task-board/u);
   assert.match(data, /conversation-feed/u);
+  assert.match(data, /team-detail-panel/u);
+  assert.match(data, /Next required action/u);
+  assert.match(data, /Worker tokens/u);
+  assert.match(data, /Timeline/u);
   assert.match(data, /YKP_WORK_EVENTS_V1/u);
   assert.match(data, /message is evidence, not work authority/u);
   assert.doesNotMatch(`${html}\n${data}`, /mermaid/iu);
@@ -241,5 +247,8 @@ test("control plane preview has bounded text containers for operator UI", async 
   assert.match(css, /\.task-board/u);
   assert.match(css, /\.manager-card/u);
   assert.match(css, /\.conversation-event/u);
+  assert.match(css, /\.team-detail/u);
+  assert.match(css, /\.detail-grid/u);
+  assert.match(css, /\.timeline/u);
   assert.match(css, /@media \(max-width: 640px\)/u);
 });


### PR DESCRIPTION
## What changed

- Added a read-only Team detail section to the Control Plane preview.
- Shows selected team summary, next required action, plan records, worker token bars and timeline.
- Reuses redacted `/api/teams/status` live data when available.
- Extends UI containment checks for long team IDs, worker IDs and event details.

## Why

The command center explains the overall run, but an operator also needs one focused place to inspect what a manager/team is currently doing and what action is required next.

## Validation

- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- Playwright screenshot capture with overflow detection

## Boundary

Read-only UI only. Interactive team selection, approvals, provider configuration and persisted event drill-down remain future work.

Closes #256.
