### PR TITLE
Make Control Plane detail selectable

### DIFF
--- a/.context/sessions/SESSION-2026-08-18-08-control-plane-interactive-detail.md
+++ b/.context/sessions/SESSION-2026-08-18-08-control-plane-interactive-detail.md
@@ -1,0 +1,30 @@
+# SESSION-2026-08-18-08 — Control Plane interactive detail
+
+- Status: completed
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/258
+- Branch: `agent/control-plane-interactive-detail`
+
+## Objective
+
+Make the Team detail panel selectable from manager, team and task cards while keeping the preview read-only.
+
+## Outcome
+
+- Added selectable manager, team and task cards with `data-team-id`.
+- Added click and keyboard selection for updating the Team detail panel.
+- Added visible selected/focus styling.
+- Preserved bounded text behavior for long team IDs, worker IDs and event details.
+- Generated screenshots under `/tmp/yukh-control-plane-screenshots`.
+
+## Validation
+
+- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
+- `npm run format:check`
+- `npm run typecheck`
+- `npm run build`
+- `git diff --check`
+- Playwright screenshot capture with overflow detection and click exercise.
+
+## Boundary
+
+Read-only UI only. No persisted selection, routing, start/stop, approval or provider configuration yet.

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -241,6 +241,7 @@ const conversations = [
 ].slice(0, 5);
 const activeTeams = teams.filter((team) => !["complete", "stopped"].includes(team.state));
 const agents = teams.flatMap((team) => team.agents);
+let selectedTeamId = teamId(activeTeams[0] ?? teams[0] ?? { id: "" });
 const used = teams.reduce(
   (sum, team) => sum + (teamBudget(team)?.used ?? teamBudget(team)?.observed ?? 0),
   0,
@@ -268,7 +269,7 @@ byId("manager-list").innerHTML = teams
     const percentage = budgetTotal > 0 ? Math.round((budgetUsed / budgetTotal) * 100) : 0;
     const missing = manager?.missing_required_actions ?? [];
     return `
-      <article class="manager-card">
+      <article class="manager-card selectable" data-team-id="${teamId(team)}" role="button" tabindex="0" aria-controls="team-detail-panel">
         <div class="manager-card-main">
           <p class="eyebrow">${teamMode(team)}</p>
           <h4>${manager?.role ?? "manager pending"}</h4>
@@ -297,7 +298,7 @@ byId("task-board").innerHTML = ["ready", "in_progress", "review", "done"]
         ${tasks
           .map(
             (task) => `
-              <article class="task-card">
+              <article class="task-card selectable" data-team-id="${task.team_id}" role="button" tabindex="0" aria-controls="team-detail-panel">
                 <span class="chip">${task.id}</span>
                 <h4>${task.title}</h4>
                 <p class="muted">${task.team_id} · ${task.owner}</p>
@@ -349,7 +350,7 @@ byId("topology-panels").innerHTML = topology
 byId("team-list").innerHTML = teams
   .map(
     (team) => `
-      <article class="team-row">
+      <article class="team-row selectable" data-team-id="${teamId(team)}" role="button" tabindex="0" aria-controls="team-detail-panel">
         <div>
           <p class="eyebrow">${teamMode(team)}</p>
           <h3>${teamId(team)}</h3>
@@ -389,8 +390,50 @@ byId("budget-panel").innerHTML = teams
   })
   .join("");
 
-const selectedTeam = activeTeams[0] ?? teams[0];
-if (selectedTeam) {
+const setSelectedMarkers = () => {
+  document.querySelectorAll("[data-team-id]").forEach((element) => {
+    const active = element.getAttribute("data-team-id") === selectedTeamId;
+    element.classList.toggle("selected", active);
+    element.setAttribute("aria-current", active ? "true" : "false");
+  });
+};
+
+const timelineForTeam = (team, plans, tasks, missing) => [
+  {
+    label: "team created",
+    detail: `${teamMode(team)} · ${team.state}`,
+    state: "done",
+  },
+  ...plans.map((plan) => ({
+    label: `plan ${plan.state}`,
+    detail: `${plan.worker_count} workers · synthesis ${plan.has_synthesis ? "present" : "missing"}`,
+    state: plan.state,
+  })),
+  ...tasks.slice(0, 4).map((task) => ({
+    label: task.title,
+    detail: `${task.state} · owner ${task.owner}`,
+    state: task.state,
+  })),
+  {
+    label: missing.length === 0 ? "required actions satisfied" : "required action pending",
+    detail: missing.length === 0 ? "manager receipts complete" : missing.join(", "),
+    state: missing.length === 0 ? "done" : "waiting",
+  },
+];
+
+const renderTeamDetail = (id) => {
+  const selectedTeam = teams.find((team) => teamId(team) === id) ?? activeTeams[0] ?? teams[0];
+  selectedTeamId = selectedTeam ? teamId(selectedTeam) : "";
+  setSelectedMarkers();
+
+  if (!selectedTeam) {
+    byId("manager-detail-panel").innerHTML =
+      '<p class="muted">No team state yet. Start from a manager plan to populate this view.</p>';
+    byId("team-detail-panel").innerHTML =
+      '<p class="muted">No team selected yet. Start from a manager plan to populate this view.</p>';
+    return;
+  }
+
   const manager = teamManager(selectedTeam);
   const workers = teamWorkers(selectedTeam);
   const plans = selectedTeam.plans ?? [];
@@ -398,28 +441,8 @@ if (selectedTeam) {
   const missing = manager?.missing_required_actions ?? [];
   const nextAction =
     missing[0] ?? (plans.length > 0 ? "approve or revise manager plan" : "inspect latest evidence");
-  const timeline = [
-    {
-      label: "team created",
-      detail: `${teamMode(selectedTeam)} · ${selectedTeam.state}`,
-      state: "done",
-    },
-    ...plans.map((plan) => ({
-      label: `plan ${plan.state}`,
-      detail: `${plan.worker_count} workers · synthesis ${plan.has_synthesis ? "present" : "missing"}`,
-      state: plan.state,
-    })),
-    ...tasks.slice(0, 4).map((task) => ({
-      label: task.title,
-      detail: `${task.state} · owner ${task.owner}`,
-      state: task.state,
-    })),
-    {
-      label: missing.length === 0 ? "required actions satisfied" : "required action pending",
-      detail: missing.length === 0 ? "manager receipts complete" : missing.join(", "),
-      state: missing.length === 0 ? "done" : "waiting",
-    },
-  ];
+  const timeline = timelineForTeam(selectedTeam, plans, tasks, missing);
+
   byId("manager-detail-panel").innerHTML = `
     <article class="manager-summary">
       <div>
@@ -547,12 +570,20 @@ if (selectedTeam) {
       </section>
     </div>
   `;
-} else {
-  byId("manager-detail-panel").innerHTML =
-    '<p class="muted">No team state yet. Start from a manager plan to populate this view.</p>';
-  byId("team-detail-panel").innerHTML =
-    '<p class="muted">No team selected yet. Start from a manager plan to populate this view.</p>';
-}
+};
+
+document.querySelectorAll("[data-team-id]").forEach((element) => {
+  const select = () => renderTeamDetail(element.getAttribute("data-team-id") ?? "");
+  element.addEventListener("click", select);
+  element.addEventListener("keydown", (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      select();
+    }
+  });
+});
+
+renderTeamDetail(selectedTeamId);
 
 byId("transcript-list").innerHTML = data.transcript
   .map(

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -529,6 +529,26 @@ nav a:hover {
   gap: 12px;
   padding: 14px;
 }
+.selectable {
+  cursor: pointer;
+  outline: none;
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+.selectable:hover,
+.selectable:focus-visible,
+.selectable.selected {
+  border-color: rgba(119, 240, 178, 0.7);
+  box-shadow: 0 0 0 1px rgba(119, 240, 178, 0.22);
+}
+.selectable:focus-visible {
+  transform: translateY(-1px);
+}
+.selectable.selected {
+  background: linear-gradient(135deg, rgba(119, 240, 178, 0.11), transparent 48%), var(--panel-2);
+}
 .manager-card-main {
   display: grid;
   gap: 6px;

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -229,6 +229,9 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /task-board/u);
   assert.match(data, /conversation-feed/u);
   assert.match(data, /team-detail-panel/u);
+  assert.match(data, /renderTeamDetail/u);
+  assert.match(data, /data-team-id/u);
+  assert.match(data, /aria-current/u);
   assert.match(data, /Next required action/u);
   assert.match(data, /Worker tokens/u);
   assert.match(data, /Timeline/u);
@@ -246,6 +249,9 @@ test("control plane preview has bounded text containers for operator UI", async 
   assert.match(css, /white-space: normal/u);
   assert.match(css, /\.task-board/u);
   assert.match(css, /\.manager-card/u);
+  assert.match(css, /\.selectable/u);
+  assert.match(css, /\.selectable\.selected/u);
+  assert.match(css, /focus-visible/u);
   assert.match(css, /\.conversation-event/u);
   assert.match(css, /\.team-detail/u);
   assert.match(css, /\.detail-grid/u);


### PR DESCRIPTION
## What changed

- Made Control Plane manager, team and task cards selectable.
- Updating a card updates the Team detail panel in place.
- Added keyboard support and visible selected/focus styling.
- Kept the flow read-only and preserved bounded text behavior.

## Why

The detail panel existed, but it was still effectively static. Operators need to move from overview to the specific team/task they are inspecting without reading raw logs.

## Validation

- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- Playwright screenshot capture with overflow detection and click exercise

## Boundary

No persisted selection, routing, start/stop, approval or provider configuration yet.

Closes #258.
