### PR TITLE
Add Control Plane manager plan dry-run

### DIFF
--- a/.context/sessions/SESSION-2026-08-18-09-control-plane-plan-dry-run.md
+++ b/.context/sessions/SESSION-2026-08-18-09-control-plane-plan-dry-run.md
@@ -1,0 +1,30 @@
+# SESSION-2026-08-18-09 — Control Plane manager plan dry-run
+
+- Status: completed
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/260
+- Branch: `agent/control-plane-plan-dry-run`
+
+## Objective
+
+Add the first safe operational control to the Control Plane preview: create a manager plan preview without launching workers or making provider calls.
+
+## Outcome
+
+- Wired the New team form to a local dry-run preview.
+- Shows plan mode, provider, manager reserve, proposed workers, per-worker token budget and safety reserve.
+- Labels the result as `no workers launched`.
+- Escapes form-provided text before rendering.
+- Kept the preview visually contained in the narrow settings panel.
+
+## Validation
+
+- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
+- `npm run format:check`
+- `npm run typecheck`
+- `npm run build`
+- `git diff --check`
+- Playwright screenshot capture with dry-run submit, click exercise and overflow detection.
+
+## Boundary
+
+Preview-only. No worker launch, no provider call, no persisted team state and no Coordination/Projects write.

--- a/apps/control-plane-preview/static/index.html
+++ b/apps/control-plane-preview/static/index.html
@@ -262,27 +262,28 @@
                 <h3>New team</h3>
               </div>
             </div>
-            <form class="start-form">
+            <form class="start-form" id="manager-plan-form">
               <label
-                >Goal<textarea>
+                >Goal<textarea id="plan-goal">
 Improve the Yukh control plane with one bounded UI increment.</textarea>
               </label>
               <label
-                >Mode<select>
+                >Mode<select id="plan-mode">
                   <option>plan-first</option>
                   <option>delegate, explicit workers</option>
                 </select></label
               >
               <label
-                >Provider<select>
+                >Provider<select id="plan-provider">
                   <option>Copilot SDK workers</option>
                   <option>Codex manager CLI</option>
                   <option>Codex SDK, planned</option>
                 </select></label
               >
-              <label>Budget<input value="120000" inputmode="numeric" /></label>
-              <button type="button" class="primary">Create manager plan</button>
+              <label>Budget<input id="plan-budget" value="120000" inputmode="numeric" /></label>
+              <button type="submit" class="primary">Create manager plan</button>
             </form>
+            <div id="plan-preview" class="plan-preview" aria-live="polite"></div>
           </article>
         </section>
       </section>

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -151,6 +151,13 @@ const data = {
 };
 
 const byId = (id) => document.getElementById(id);
+const escapeHtml = (value) =>
+  String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
 const topologyStateLabel = (state) => state.replaceAll("_", " ");
 const loadTopology = async () => {
   try {
@@ -600,3 +607,70 @@ byId("transcript-list").innerHTML = data.transcript
     `,
   )
   .join("");
+
+const suggestWorkers = (goal) => {
+  const normalized = goal.toLowerCase();
+  const roles = [
+    normalized.includes("ui") || normalized.includes("control plane")
+      ? "frontend-control-plane-worker"
+      : "implementation-worker",
+    normalized.includes("test") || normalized.includes("verify")
+      ? "qa-verification-worker"
+      : "runtime-verification-worker",
+  ];
+  return [...new Set(roles)];
+};
+
+const renderPlanPreview = ({ goal, mode, provider, budget }) => {
+  const safeBudget = Number.isFinite(budget) && budget > 0 ? Math.floor(budget) : 0;
+  const managerReserve = Math.floor(safeBudget * 0.25);
+  const workerReserve = Math.floor(safeBudget * 0.55);
+  const safetyReserve = Math.max(0, safeBudget - managerReserve - workerReserve);
+  const workers = suggestWorkers(goal);
+  const perWorker = workers.length > 0 ? Math.floor(workerReserve / workers.length) : 0;
+
+  byId("plan-preview").innerHTML = `
+    <article class="preview-card">
+      <div class="section-title">
+        <div>
+          <p class="eyebrow">Dry-run manager plan</p>
+          <h4>${escapeHtml(mode)}</h4>
+        </div>
+        <span class="status-pill small"><span class="dot warn"></span>no workers launched</span>
+      </div>
+      <p class="muted clamp-2">${escapeHtml(goal)}</p>
+      <div class="preview-grid">
+        <article>
+          <span>Manager</span>
+          <strong>${escapeHtml(provider)}</strong>
+          <p class="muted">${managerReserve.toLocaleString()} tokens reserved for plan, synthesis and receipts.</p>
+        </article>
+        <article>
+          <span>Workers proposed</span>
+          <strong>${workers.length}</strong>
+          <p class="muted">${workers.map((worker) => `${worker}: ${perWorker.toLocaleString()}`).join(" · ")}</p>
+        </article>
+        <article>
+          <span>Safety reserve</span>
+          <strong>${safetyReserve.toLocaleString()}</strong>
+          <p class="muted">Held back until operator approval.</p>
+        </article>
+      </div>
+      <ol class="preview-steps">
+        <li>Review goal, budget split and proposed workers.</li>
+        <li>Approve or edit the plan before any provider call.</li>
+        <li>Launch workers only after receipts and limits are visible.</li>
+      </ol>
+    </article>
+  `;
+};
+
+byId("manager-plan-form").addEventListener("submit", (event) => {
+  event.preventDefault();
+  renderPlanPreview({
+    goal: byId("plan-goal").value.trim() || "Untitled Yukh manager plan",
+    mode: byId("plan-mode").value,
+    provider: byId("plan-provider").value,
+    budget: Number.parseInt(byId("plan-budget").value.replaceAll(/[^\d]/g, ""), 10),
+  });
+});

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -684,6 +684,47 @@ nav a:hover {
   display: grid;
   gap: 14px;
 }
+.plan-preview {
+  margin-top: 16px;
+}
+.preview-card {
+  background: linear-gradient(135deg, rgba(119, 240, 178, 0.1), transparent 42%), #0d121c;
+  border: 1px solid rgba(119, 240, 178, 0.24);
+  border-radius: 18px;
+  display: grid;
+  gap: 14px;
+  padding: 14px;
+}
+.preview-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+#settings .preview-grid {
+  grid-template-columns: 1fr;
+}
+.preview-grid article {
+  background: var(--panel-2);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+  display: grid;
+  gap: 7px;
+  padding: 12px;
+}
+.preview-grid span {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.preview-steps {
+  color: var(--muted);
+  display: grid;
+  gap: 7px;
+  margin: 0;
+  padding-left: 20px;
+}
 label {
   color: var(--muted);
   display: grid;
@@ -716,6 +757,7 @@ textarea {
   .detail-grid,
   .worker-table article,
   .command-center,
+  .preview-grid,
   .metrics {
     grid-template-columns: 1fr;
   }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -217,6 +217,8 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(html, /Communication/u);
   assert.match(html, /Team detail/u);
   assert.match(html, /Plan, workers, tokens and next action/u);
+  assert.match(html, /manager-plan-form/u);
+  assert.match(html, /plan-preview/u);
   assert.match(html, /Yukh Projects/u);
   assert.match(html, /Yukh MCP/u);
   assert.match(html, /Coordination/u);
@@ -230,6 +232,9 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /conversation-feed/u);
   assert.match(data, /team-detail-panel/u);
   assert.match(data, /renderTeamDetail/u);
+  assert.match(data, /renderPlanPreview/u);
+  assert.match(data, /Dry-run manager plan/u);
+  assert.match(data, /no workers launched/u);
   assert.match(data, /data-team-id/u);
   assert.match(data, /aria-current/u);
   assert.match(data, /Next required action/u);
@@ -256,5 +261,7 @@ test("control plane preview has bounded text containers for operator UI", async 
   assert.match(css, /\.team-detail/u);
   assert.match(css, /\.detail-grid/u);
   assert.match(css, /\.timeline/u);
+  assert.match(css, /\.plan-preview/u);
+  assert.match(css, /\.preview-grid/u);
   assert.match(css, /@media \(max-width: 640px\)/u);
 });


### PR DESCRIPTION
## What changed

- Wired the Control Plane “New team” form to create a local dry-run manager plan preview.
- Shows plan mode, provider, manager reserve, proposed workers, per-worker token split and safety reserve.
- Explicitly labels the result as `no workers launched`.
- Escapes form-provided text before rendering.
- Keeps the preview contained in the narrow settings panel.

## Why

This is the first safe operational control: it lets an operator inspect a manager plan before any provider call, worker launch or token spend.

## Validation

- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- Playwright screenshot capture with dry-run submit, click exercise and overflow detection

## Boundary

Preview-only. No worker launch, no provider call, no persisted team state and no Coordination/Projects write.

Closes #260.
