### PR TITLE
Add Control Plane approve-plan preview

### DIFF
--- a/.context/sessions/SESSION-2026-08-18-10-control-plane-approve-plan-preview.md
+++ b/.context/sessions/SESSION-2026-08-18-10-control-plane-approve-plan-preview.md
@@ -1,0 +1,30 @@
+# SESSION-2026-08-18-10 — Control Plane approve-plan preview
+
+- Status: completed
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/262
+- Branch: `agent/control-plane-approve-plan-preview`
+
+## Objective
+
+Add a safe approve-plan step for the dry-run manager plan without launching workers or writing to external systems.
+
+## Outcome
+
+- Added `Approve plan preview` action to the dry-run plan card.
+- Updates status from `no workers launched` to `approved preview`.
+- Shows a local preview receipt.
+- Disables the approval button after use.
+- Keeps copy explicit: no provider call, no worker launch, no external write.
+
+## Validation
+
+- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
+- `npm run format:check`
+- `npm run typecheck`
+- `npm run build`
+- `git diff --check`
+- Playwright screenshot capture with dry-run submit, approve preview, click exercise and overflow detection.
+
+## Boundary
+
+Local browser preview only. No persistence, no provider call, no worker launch and no Coordination/Projects write.

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -628,15 +628,16 @@ const renderPlanPreview = ({ goal, mode, provider, budget }) => {
   const safetyReserve = Math.max(0, safeBudget - managerReserve - workerReserve);
   const workers = suggestWorkers(goal);
   const perWorker = workers.length > 0 ? Math.floor(workerReserve / workers.length) : 0;
+  const receiptId = `preview-receipt-${Date.now().toString(36)}`;
 
   byId("plan-preview").innerHTML = `
-    <article class="preview-card">
+    <article class="preview-card" data-preview-receipt-id="${receiptId}">
       <div class="section-title">
         <div>
           <p class="eyebrow">Dry-run manager plan</p>
           <h4>${escapeHtml(mode)}</h4>
         </div>
-        <span class="status-pill small"><span class="dot warn"></span>no workers launched</span>
+        <span class="status-pill small preview-status"><span class="dot warn"></span>no workers launched</span>
       </div>
       <p class="muted clamp-2">${escapeHtml(goal)}</p>
       <div class="preview-grid">
@@ -661,9 +662,38 @@ const renderPlanPreview = ({ goal, mode, provider, budget }) => {
         <li>Approve or edit the plan before any provider call.</li>
         <li>Launch workers only after receipts and limits are visible.</li>
       </ol>
+      <div class="preview-actions">
+        <button type="button" class="secondary approve-preview-button">Approve plan preview</button>
+        <span class="muted">Preview only: no provider call, no worker launch, no external write.</span>
+      </div>
+      <div class="approval-receipt" hidden></div>
     </article>
   `;
 };
+
+byId("plan-preview").addEventListener("click", (event) => {
+  const button = event.target.closest(".approve-preview-button");
+  if (!button) return;
+
+  const card = button.closest(".preview-card");
+  const receiptId = card?.getAttribute("data-preview-receipt-id") ?? "preview-receipt";
+  card?.classList.add("approved-preview");
+  const status = card?.querySelector(".preview-status");
+  if (status) {
+    status.innerHTML = '<span class="dot ok"></span>approved preview';
+  }
+  const receipt = card?.querySelector(".approval-receipt");
+  if (receipt) {
+    receipt.hidden = false;
+    receipt.innerHTML = `
+      <span>Local preview receipt</span>
+      <strong>${escapeHtml(receiptId)}</strong>
+      <p class="muted">Recorded only in this browser preview. Workers remain stopped until an explicit real launch is added.</p>
+    `;
+  }
+  button.setAttribute("disabled", "true");
+  button.textContent = "Preview approved";
+});
 
 byId("manager-plan-form").addEventListener("submit", (event) => {
   event.preventDefault();

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -725,6 +725,37 @@ nav a:hover {
   margin: 0;
   padding-left: 20px;
 }
+.preview-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+.preview-actions .secondary:disabled {
+  color: var(--accent);
+  opacity: 0.8;
+}
+.approval-receipt {
+  background: rgba(119, 240, 178, 0.08);
+  border: 1px solid rgba(119, 240, 178, 0.28);
+  border-radius: 16px;
+  display: grid;
+  gap: 7px;
+  padding: 12px;
+}
+.approval-receipt[hidden] {
+  display: none;
+}
+.approval-receipt span {
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.preview-card.approved-preview {
+  border-color: rgba(119, 240, 178, 0.48);
+}
 label {
   color: var(--muted);
   display: grid;

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -235,6 +235,10 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /renderPlanPreview/u);
   assert.match(data, /Dry-run manager plan/u);
   assert.match(data, /no workers launched/u);
+  assert.match(data, /Approve plan preview/u);
+  assert.match(data, /approved preview/u);
+  assert.match(data, /Local preview receipt/u);
+  assert.match(data, /no provider call, no worker launch, no external write/u);
   assert.match(data, /data-team-id/u);
   assert.match(data, /aria-current/u);
   assert.match(data, /Next required action/u);
@@ -263,5 +267,8 @@ test("control plane preview has bounded text containers for operator UI", async 
   assert.match(css, /\.timeline/u);
   assert.match(css, /\.plan-preview/u);
   assert.match(css, /\.preview-grid/u);
+  assert.match(css, /\.preview-actions/u);
+  assert.match(css, /\.approval-receipt/u);
+  assert.match(css, /\.approved-preview/u);
   assert.match(css, /@media \(max-width: 640px\)/u);
 });


### PR DESCRIPTION
## What changed

- Added `Approve plan preview` to the Control Plane dry-run manager plan.
- Approval updates the UI to `approved preview`.
- Shows a local preview receipt and disables the approval button.
- Keeps the boundary explicit: no provider call, no worker launch, no external write.

## Why

This adds the next safe control-plane step after dry-run planning: approving intent locally before any real orchestration side effect exists.

## Validation

- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- Playwright screenshot capture with dry-run submit, approve preview, click exercise and overflow detection

## Boundary

Local browser preview only. No persistence, no provider call, no worker launch and no Coordination/Projects write.

Closes #262.
