### PR TITLE
Persist Control Plane plan previews

### DIFF
--- a/.context/sessions/SESSION-2026-08-18-11-control-plane-plan-preview-store.md
+++ b/.context/sessions/SESSION-2026-08-18-11-control-plane-plan-preview-store.md
@@ -1,0 +1,32 @@
+# SESSION-2026-08-18-11 — Control Plane plan preview store
+
+- Status: completed
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/264
+- Branch: `agent/control-plane-plan-preview-store`
+
+## Objective
+
+Persist Control Plane manager plan previews in the local runtime so approved preview state survives refresh.
+
+## Outcome
+
+- Added `ControlPlanePlanPreviewStore`.
+- Stores records under workspace `.yukh/control-plane/plan-previews.json`.
+- Added `GET /api/manager-plan/previews`.
+- Added `POST /api/manager-plan/previews`.
+- Redacts goal text to `sha-256` digest in stored/API records.
+- UI now loads the latest persisted preview on refresh.
+- UI saves proposed and approved-preview records through the local API when available.
+
+## Validation
+
+- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
+- `npm run format:check`
+- `npm run typecheck`
+- `npm run build`
+- `git diff --check`
+- Playwright screenshot capture with submit, approve, reload persistence and overflow detection.
+
+## Boundary
+
+Local Control Plane runtime only. No provider call, no worker launch, no Coordination write and no Projects write.

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -1,8 +1,12 @@
-import { createServer, type Server } from "node:http";
+import { createServer, type IncomingMessage, type Server } from "node:http";
 import { readFile } from "node:fs/promises";
 import { dirname, join, normalize } from "node:path";
 import { fileURLToPath } from "node:url";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
+import {
+  ControlPlanePlanPreviewStore,
+  type ControlPlanePlanPreviewInput,
+} from "./plan-preview-store.js";
 import { createTeamStatus } from "./team-status.js";
 import { createTopologyStatus } from "./topology-status.js";
 
@@ -21,6 +25,7 @@ const CONTENT_TYPES = new Map([
 
 const API_TOPOLOGY_STATUS_PATH = "/api/topology/status";
 const API_TEAM_STATUS_PATH = "/api/teams/status";
+const API_PLAN_PREVIEWS_PATH = "/api/manager-plan/previews";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
@@ -68,11 +73,75 @@ function requestedFile(url = "/"): string | null {
   return null;
 }
 
+async function readJsonBody(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.byteLength;
+    if (size > 32_768) throw new TypeError("request body too large");
+    chunks.push(buffer);
+  }
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
 export function createControlPlaneServer(
   staticRoot = defaultStaticRoot(),
-  options: { readonly teamStore?: Pick<TeamStore, "teams"> } = {},
+  options: {
+    readonly teamStore?: Pick<TeamStore, "teams">;
+    readonly planPreviewStore?: ControlPlanePlanPreviewStore;
+  } = {},
 ): Server {
   return createServer(async (request, response) => {
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_PLAN_PREVIEWS_PATH
+    ) {
+      if (!options.planPreviewStore) {
+        response.writeHead(503, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "store_unconfigured" }));
+        return;
+      }
+      if (request.method === "GET") {
+        response.writeHead(200, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify(options.planPreviewStore.status()));
+        return;
+      }
+      if (request.method === "POST") {
+        try {
+          const body = await readJsonBody(request);
+          const record = options.planPreviewStore.create(body as ControlPlanePlanPreviewInput);
+          response.writeHead(201, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(JSON.stringify({ schema: 1, status: "ok", preview: record }));
+        } catch {
+          response.writeHead(400, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({ schema: 1, status: "error", code: "invalid_plan_preview" }),
+          );
+        }
+        return;
+      }
+      response.writeHead(405, {
+        allow: "GET, POST",
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+      return;
+    }
+
     if (request.url && new URL(request.url, "http://127.0.0.1").pathname === API_TEAM_STATUS_PATH) {
       if (request.method !== "GET") {
         response.writeHead(405, {
@@ -137,6 +206,7 @@ export async function startControlPlane(options: ControlPlaneOptions): Promise<S
     options.workspace ?? process.env.YUKH_CONVERSATION_WORKSPACE ?? process.env.YUKH_TEAM_WORKSPACE;
   const server = createControlPlaneServer(options.staticRoot, {
     ...(workspace ? { teamStore: new TeamStore(workspace) } : {}),
+    ...(workspace ? { planPreviewStore: new ControlPlanePlanPreviewStore(workspace) } : {}),
   });
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
@@ -155,7 +225,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   const port = typeof address === "object" && address !== null ? address.port : options.port;
   process.stdout.write(
     `Yukh Control Plane preview: http://${options.host}:${port}\n` +
-      "Static mock UI only: no runtime mutations are exposed.\n",
+      "Bounded preview controls only: no provider calls or worker launches are exposed.\n",
   );
 }
 

--- a/apps/control-plane-preview/src/plan-preview-store.ts
+++ b/apps/control-plane-preview/src/plan-preview-store.ts
@@ -1,0 +1,150 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+
+export type ControlPlanePlanPreviewState = "proposed" | "approved-preview";
+
+export type ControlPlanePlanPreviewRecord = {
+  readonly schema: 1;
+  readonly preview_id: string;
+  readonly receipt_id?: string;
+  readonly state: ControlPlanePlanPreviewState;
+  readonly goal_digest: `sha-256:${string}`;
+  readonly mode: string;
+  readonly provider: string;
+  readonly token_budget: number;
+  readonly manager_reserve: number;
+  readonly worker_reserve: number;
+  readonly safety_reserve: number;
+  readonly proposed_workers: readonly {
+    readonly role: string;
+    readonly token_budget: number;
+  }[];
+  readonly created_at: string;
+  readonly approved_at?: string;
+};
+
+export type ControlPlanePlanPreviewStoreStatus = {
+  readonly schema: "yukh-control-plane-plan-previews-v1";
+  readonly source: "local-control-plane-store";
+  readonly previews: readonly ControlPlanePlanPreviewRecord[];
+};
+
+export type ControlPlanePlanPreviewInput = {
+  readonly goal: string;
+  readonly mode: string;
+  readonly provider: string;
+  readonly token_budget: number;
+  readonly state?: ControlPlanePlanPreviewState;
+};
+
+type Document = {
+  readonly schema: 1;
+  readonly previews: readonly ControlPlanePlanPreviewRecord[];
+};
+
+const validMode = new Set(["plan-first", "delegate, explicit workers"]);
+const validProvider = new Set(["Copilot SDK workers", "Codex manager CLI", "Codex SDK, planned"]);
+
+function digest(value: string): `sha-256:${string}` {
+  return `sha-256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function workersForGoal(
+  goal: string,
+  workerReserve: number,
+): ControlPlanePlanPreviewRecord["proposed_workers"] {
+  const normalized = goal.toLowerCase();
+  const roles = [
+    normalized.includes("ui") || normalized.includes("control plane")
+      ? "frontend-control-plane-worker"
+      : "implementation-worker",
+    normalized.includes("test") || normalized.includes("verify")
+      ? "qa-verification-worker"
+      : "runtime-verification-worker",
+  ];
+  const unique = [...new Set(roles)];
+  const perWorker = unique.length > 0 ? Math.floor(workerReserve / unique.length) : 0;
+  return unique.map((role) => ({ role, token_budget: perWorker }));
+}
+
+function validateInput(input: ControlPlanePlanPreviewInput): void {
+  if (
+    input.goal.trim() !== input.goal ||
+    input.goal.length < 1 ||
+    input.goal.length > 4_096 ||
+    !validMode.has(input.mode) ||
+    !validProvider.has(input.provider) ||
+    !Number.isSafeInteger(input.token_budget) ||
+    input.token_budget < 1_000 ||
+    input.token_budget > 10_000_000 ||
+    (input.state !== undefined && !["proposed", "approved-preview"].includes(input.state))
+  ) {
+    throw new TypeError("invalid plan preview input");
+  }
+}
+
+export class ControlPlanePlanPreviewStore {
+  readonly #path: string;
+
+  constructor(workspace: string) {
+    if (!isAbsolute(workspace)) throw new TypeError("invalid control plane workspace");
+    const root = join(workspace, ".yukh", "control-plane");
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+    this.#path = join(root, "plan-previews.json");
+  }
+
+  status(): ControlPlanePlanPreviewStoreStatus {
+    return {
+      schema: "yukh-control-plane-plan-previews-v1",
+      source: "local-control-plane-store",
+      previews: this.#read().previews,
+    };
+  }
+
+  create(input: ControlPlanePlanPreviewInput): ControlPlanePlanPreviewRecord {
+    validateInput(input);
+    const managerReserve = Math.floor(input.token_budget * 0.25);
+    const workerReserve = Math.floor(input.token_budget * 0.55);
+    const safetyReserve = Math.max(0, input.token_budget - managerReserve - workerReserve);
+    const now = new Date().toISOString();
+    const state = input.state ?? "proposed";
+    const record: ControlPlanePlanPreviewRecord = {
+      schema: 1,
+      preview_id: `preview-${randomUUID()}`,
+      ...(state === "approved-preview" ? { receipt_id: `preview-receipt-${randomUUID()}` } : {}),
+      state,
+      goal_digest: digest(input.goal),
+      mode: input.mode,
+      provider: input.provider,
+      token_budget: input.token_budget,
+      manager_reserve: managerReserve,
+      worker_reserve: workerReserve,
+      safety_reserve: safetyReserve,
+      proposed_workers: workersForGoal(input.goal, workerReserve),
+      created_at: now,
+      ...(state === "approved-preview" ? { approved_at: now } : {}),
+    };
+    const document = this.#read();
+    this.#write({ schema: 1, previews: [record, ...document.previews].slice(0, 20) });
+    return record;
+  }
+
+  #read(): Document {
+    try {
+      const parsed = JSON.parse(readFileSync(this.#path, "utf8")) as Partial<Document>;
+      if (parsed.schema !== 1 || !Array.isArray(parsed.previews)) {
+        return { schema: 1, previews: [] };
+      }
+      return { schema: 1, previews: parsed.previews.filter((item) => item?.schema === 1) };
+    } catch {
+      return { schema: 1, previews: [] };
+    }
+  }
+
+  #write(document: Document): void {
+    const tmp = `${this.#path}.${process.pid}.${Date.now()}.tmp`;
+    writeFileSync(tmp, `${JSON.stringify(document, null, 2)}\n`, { mode: 0o600 });
+    renameSync(tmp, this.#path);
+  }
+}

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -621,14 +621,90 @@ const suggestWorkers = (goal) => {
   return [...new Set(roles)];
 };
 
-const renderPlanPreview = ({ goal, mode, provider, budget }) => {
+let latestPlanInput = null;
+
+const persistPlanPreview = async ({ goal, mode, provider, budget, state = "proposed" }) => {
+  try {
+    const response = await fetch("./api/manager-plan/previews", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ goal, mode, provider, token_budget: budget, state }),
+    });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return body?.preview ?? null;
+  } catch {
+    return null;
+  }
+};
+
+const loadPersistedPlanPreview = async () => {
+  try {
+    const response = await fetch("./api/manager-plan/previews", { cache: "no-store" });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return body?.previews?.[0] ?? null;
+  } catch {
+    return null;
+  }
+};
+
+const renderPersistedPlanPreview = (preview) => {
+  byId("plan-preview").innerHTML = `
+    <article class="preview-card ${preview.state === "approved-preview" ? "approved-preview" : ""}">
+      <div class="section-title">
+        <div>
+          <p class="eyebrow">Persisted manager plan</p>
+          <h4>${escapeHtml(preview.mode)}</h4>
+        </div>
+        <span class="status-pill small preview-status"><span class="dot ${preview.state === "approved-preview" ? "ok" : "warn"}"></span>${escapeHtml(preview.state)}</span>
+      </div>
+      <p class="muted">Goal ${escapeHtml(preview.goal_digest)}</p>
+      <div class="preview-grid">
+        <article>
+          <span>Manager</span>
+          <strong>${escapeHtml(preview.provider)}</strong>
+          <p class="muted">${preview.manager_reserve.toLocaleString()} tokens reserved for plan, synthesis and receipts.</p>
+        </article>
+        <article>
+          <span>Workers proposed</span>
+          <strong>${preview.proposed_workers.length}</strong>
+          <p class="muted">${preview.proposed_workers.map((worker) => `${worker.role}: ${worker.token_budget.toLocaleString()}`).join(" · ")}</p>
+        </article>
+        <article>
+          <span>Safety reserve</span>
+          <strong>${preview.safety_reserve.toLocaleString()}</strong>
+          <p class="muted">Held back until operator approval.</p>
+        </article>
+      </div>
+      ${
+        preview.receipt_id
+          ? `<div class="approval-receipt">
+              <span>Persisted local receipt</span>
+              <strong>${escapeHtml(preview.receipt_id)}</strong>
+              <p class="muted">Stored in the local Control Plane runtime. Workers remain stopped.</p>
+            </div>`
+          : ""
+      }
+    </article>
+  `;
+};
+
+const renderPlanPreview = async ({ goal, mode, provider, budget }) => {
+  latestPlanInput = { goal, mode, provider, budget };
+  const persisted = await persistPlanPreview(latestPlanInput);
   const safeBudget = Number.isFinite(budget) && budget > 0 ? Math.floor(budget) : 0;
-  const managerReserve = Math.floor(safeBudget * 0.25);
-  const workerReserve = Math.floor(safeBudget * 0.55);
-  const safetyReserve = Math.max(0, safeBudget - managerReserve - workerReserve);
-  const workers = suggestWorkers(goal);
-  const perWorker = workers.length > 0 ? Math.floor(workerReserve / workers.length) : 0;
-  const receiptId = `preview-receipt-${Date.now().toString(36)}`;
+  const managerReserve = persisted?.manager_reserve ?? Math.floor(safeBudget * 0.25);
+  const workerReserve = persisted?.worker_reserve ?? Math.floor(safeBudget * 0.55);
+  const safetyReserve =
+    persisted?.safety_reserve ?? Math.max(0, safeBudget - managerReserve - workerReserve);
+  const workers =
+    persisted?.proposed_workers ??
+    suggestWorkers(goal).map((worker) => ({
+      role: worker,
+      token_budget: Math.floor(workerReserve / suggestWorkers(goal).length),
+    }));
+  const receiptId = persisted?.receipt_id ?? `preview-receipt-${Date.now().toString(36)}`;
 
   byId("plan-preview").innerHTML = `
     <article class="preview-card" data-preview-receipt-id="${receiptId}">
@@ -649,7 +725,7 @@ const renderPlanPreview = ({ goal, mode, provider, budget }) => {
         <article>
           <span>Workers proposed</span>
           <strong>${workers.length}</strong>
-          <p class="muted">${workers.map((worker) => `${worker}: ${perWorker.toLocaleString()}`).join(" · ")}</p>
+          <p class="muted">${workers.map((worker) => `${worker.role}: ${worker.token_budget.toLocaleString()}`).join(" · ")}</p>
         </article>
         <article>
           <span>Safety reserve</span>
@@ -671,9 +747,15 @@ const renderPlanPreview = ({ goal, mode, provider, budget }) => {
   `;
 };
 
-byId("plan-preview").addEventListener("click", (event) => {
+byId("plan-preview").addEventListener("click", async (event) => {
   const button = event.target.closest(".approve-preview-button");
   if (!button) return;
+  if (latestPlanInput) {
+    const approved = await persistPlanPreview({ ...latestPlanInput, state: "approved-preview" });
+    if (approved?.receipt_id) {
+      button.closest(".preview-card")?.setAttribute("data-preview-receipt-id", approved.receipt_id);
+    }
+  }
 
   const card = button.closest(".preview-card");
   const receiptId = card?.getAttribute("data-preview-receipt-id") ?? "preview-receipt";
@@ -697,10 +779,15 @@ byId("plan-preview").addEventListener("click", (event) => {
 
 byId("manager-plan-form").addEventListener("submit", (event) => {
   event.preventDefault();
-  renderPlanPreview({
+  void renderPlanPreview({
     goal: byId("plan-goal").value.trim() || "Untitled Yukh manager plan",
     mode: byId("plan-mode").value,
     provider: byId("plan-provider").value,
     budget: Number.parseInt(byId("plan-budget").value.replaceAll(/[^\d]/g, ""), 10),
   });
 });
+
+const persistedPlan = await loadPersistedPlanPreview();
+if (persistedPlan) {
+  renderPersistedPlanPreview(persistedPlan);
+}

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -7,6 +7,7 @@ import {
   createControlPlaneServer,
   parseArguments,
 } from "../../apps/control-plane-preview/src/main.js";
+import { ControlPlanePlanPreviewStore } from "../../apps/control-plane-preview/src/plan-preview-store.js";
 import { TeamStore } from "../../packages/team-control/src/store.js";
 
 test("control plane preview parses bounded local server options", () => {
@@ -204,6 +205,84 @@ test("control plane preview exposes redacted live team status", async () => {
   }
 });
 
+test("control plane preview persists local manager plan previews without leaking goal text", async () => {
+  const root = await mkdtemp(join(tmpdir(), "yukh-control-plane-preview-plan-api-"));
+  await writeFile(join(root, "index.html"), "<h1>Control</h1>");
+  await writeFile(join(root, "styles.css"), "body{}");
+  await writeFile(join(root, "mock-data.js"), "export {};");
+
+  const workspace = await mkdtemp(join(tmpdir(), "yukh-control-plane-plan-workspace-"));
+  const planPreviewStore = new ControlPlanePlanPreviewStore(workspace);
+  const server = createControlPlaneServer(root, { planPreviewStore });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  try {
+    const address = server.address();
+    if (typeof address !== "object" || address === null) {
+      throw new TypeError("expected TCP server address");
+    }
+    const base = `http://127.0.0.1:${address.port}`;
+
+    const initial = await fetch(`${base}/api/manager-plan/previews`);
+    assert.equal(initial.status, 200);
+    assert.equal(initial.headers.get("cache-control"), "no-store");
+    assert.deepEqual((await initial.json()).previews, []);
+
+    const goal = "Persist this sensitive manager plan preview locally";
+    const proposed = await fetch(`${base}/api/manager-plan/previews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        goal,
+        mode: "plan-first",
+        provider: "Copilot SDK workers",
+        token_budget: 120_000,
+      }),
+    });
+    assert.equal(proposed.status, 201);
+    const proposedBody = await proposed.json();
+    assert.equal(proposedBody.preview.state, "proposed");
+    assert.equal(proposedBody.preview.manager_reserve, 30_000);
+    assert.equal(proposedBody.preview.proposed_workers.length, 2);
+    assert.match(proposedBody.preview.goal_digest, /^sha-256:[a-f0-9]{64}$/u);
+
+    const approved = await fetch(`${base}/api/manager-plan/previews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        goal,
+        mode: "plan-first",
+        provider: "Copilot SDK workers",
+        token_budget: 120_000,
+        state: "approved-preview",
+      }),
+    });
+    assert.equal(approved.status, 201);
+    const approvedBody = await approved.json();
+    assert.equal(approvedBody.preview.state, "approved-preview");
+    assert.match(approvedBody.preview.receipt_id, /^preview-receipt-/u);
+
+    const persisted = await fetch(`${base}/api/manager-plan/previews`);
+    const persistedBody = await persisted.json();
+    assert.equal(persistedBody.previews.length, 2);
+    assert.equal(persistedBody.previews[0].state, "approved-preview");
+    assert.doesNotMatch(JSON.stringify(persistedBody), /sensitive manager plan preview/iu);
+
+    const denied = await fetch(`${base}/api/manager-plan/previews`, { method: "DELETE" });
+    assert.equal(denied.status, 405);
+    assert.equal(denied.headers.get("allow"), "GET, POST");
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
 test("control plane preview explains runtime topology without Mermaid", async () => {
   const html = await readFile("apps/control-plane-preview/static/index.html", "utf8");
   const data = await readFile("apps/control-plane-preview/static/mock-data.js", "utf8");
@@ -233,6 +312,8 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /team-detail-panel/u);
   assert.match(data, /renderTeamDetail/u);
   assert.match(data, /renderPlanPreview/u);
+  assert.match(data, /api\/manager-plan\/previews/u);
+  assert.match(data, /Persisted manager plan/u);
   assert.match(data, /Dry-run manager plan/u);
   assert.match(data, /no workers launched/u);
   assert.match(data, /Approve plan preview/u);


### PR DESCRIPTION
## What changed

- Added a local `ControlPlanePlanPreviewStore`.
- Persists plan preview records under workspace `.yukh/control-plane/plan-previews.json`.
- Added `GET /api/manager-plan/previews`.
- Added `POST /api/manager-plan/previews`.
- UI now saves proposed and approved-preview records through the local API when available.
- UI loads the latest persisted preview after refresh.
- Stored/API records keep goal text redacted as a SHA-256 digest.

## Why

The Control Plane had safe dry-run and approve-preview steps, but the state disappeared on refresh. This makes the approved preview durable in the local runtime without introducing real orchestration side effects.

## Validation

- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- Playwright screenshot capture with submit, approve, reload persistence and overflow detection

## Boundary

Local Control Plane runtime only. No provider call, no worker launch, no Coordination write and no Projects write.

Closes #264.
