### PR TITLE
Add Control Plane launch readiness

### DIFF
--- a/.context/sessions/SESSION-2026-08-18-12-control-plane-launch-readiness.md
+++ b/.context/sessions/SESSION-2026-08-18-12-control-plane-launch-readiness.md
@@ -1,0 +1,30 @@
+# SESSION-2026-08-18-12 — Control Plane launch readiness
+
+- Status: completed
+- Governing issue: https://github.com/nomed/yukh-mcp/issues/266
+- Branch: `agent/control-plane-launch-readiness`
+
+## Objective
+
+Add a read-only launch readiness check for persisted manager plan previews.
+
+## Outcome
+
+- Added `GET /api/manager-plan/launch-readiness`.
+- Added readiness evaluation in `ControlPlanePlanPreviewStore`.
+- Reports `ready` only when the latest preview is approved, has a local receipt, has a valid budget split and has budgeted workers.
+- Reports `blocked` with concrete reason codes otherwise.
+- UI renders a Launch readiness panel for persisted previews and after approval.
+
+## Validation
+
+- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
+- `npm run format:check`
+- `npm run typecheck`
+- `npm run build`
+- `git diff --check`
+- Playwright screenshot capture with submit, approve, reload readiness and overflow detection.
+
+## Boundary
+
+Read-only readiness only. No provider call, no worker launch, no Coordination write and no Projects write.

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -26,6 +26,7 @@ const CONTENT_TYPES = new Map([
 const API_TOPOLOGY_STATUS_PATH = "/api/topology/status";
 const API_TEAM_STATUS_PATH = "/api/teams/status";
 const API_PLAN_PREVIEWS_PATH = "/api/manager-plan/previews";
+const API_LAUNCH_READINESS_PATH = "/api/manager-plan/launch-readiness";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
@@ -93,6 +94,35 @@ export function createControlPlaneServer(
   } = {},
 ): Server {
   return createServer(async (request, response) => {
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_LAUNCH_READINESS_PATH
+    ) {
+      if (!options.planPreviewStore) {
+        response.writeHead(503, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "store_unconfigured" }));
+        return;
+      }
+      if (request.method !== "GET") {
+        response.writeHead(405, {
+          allow: "GET",
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+        return;
+      }
+      response.writeHead(200, {
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify(options.planPreviewStore.launchReadiness()));
+      return;
+    }
+
     if (
       request.url &&
       new URL(request.url, "http://127.0.0.1").pathname === API_PLAN_PREVIEWS_PATH

--- a/apps/control-plane-preview/src/plan-preview-store.ts
+++ b/apps/control-plane-preview/src/plan-preview-store.ts
@@ -30,6 +30,22 @@ export type ControlPlanePlanPreviewStoreStatus = {
   readonly previews: readonly ControlPlanePlanPreviewRecord[];
 };
 
+export type ControlPlaneLaunchReadinessStatus = {
+  readonly schema: "yukh-control-plane-launch-readiness-v1";
+  readonly source: "local-control-plane-store";
+  readonly outcome: "ready" | "blocked";
+  readonly preview?: ControlPlanePlanPreviewRecord;
+  readonly reasons: readonly {
+    readonly code:
+      | "missing_plan_preview"
+      | "plan_not_approved"
+      | "missing_preview_receipt"
+      | "invalid_budget"
+      | "missing_workers";
+    readonly message: string;
+  }[];
+};
+
 export type ControlPlanePlanPreviewInput = {
   readonly goal: string;
   readonly mode: string;
@@ -99,6 +115,68 @@ export class ControlPlanePlanPreviewStore {
       schema: "yukh-control-plane-plan-previews-v1",
       source: "local-control-plane-store",
       previews: this.#read().previews,
+    };
+  }
+
+  launchReadiness(): ControlPlaneLaunchReadinessStatus {
+    const preview = this.#read().previews[0];
+    if (!preview) {
+      return {
+        schema: "yukh-control-plane-launch-readiness-v1",
+        source: "local-control-plane-store",
+        outcome: "blocked",
+        reasons: [
+          {
+            code: "missing_plan_preview",
+            message: "Create and approve a manager plan preview before launch readiness can pass.",
+          },
+        ],
+      };
+    }
+    const reasons: ControlPlaneLaunchReadinessStatus["reasons"] = [
+      ...(preview.state !== "approved-preview"
+        ? [
+            {
+              code: "plan_not_approved" as const,
+              message: "The latest manager plan preview has not been approved.",
+            },
+          ]
+        : []),
+      ...(!preview.receipt_id
+        ? [
+            {
+              code: "missing_preview_receipt" as const,
+              message: "The latest manager plan preview has no local approval receipt.",
+            },
+          ]
+        : []),
+      ...(preview.token_budget < 1_000 ||
+      preview.manager_reserve < 1 ||
+      preview.worker_reserve < 1 ||
+      preview.safety_reserve < 0
+        ? [
+            {
+              code: "invalid_budget" as const,
+              message: "The token budget split is invalid.",
+            },
+          ]
+        : []),
+      ...(preview.proposed_workers.length < 1 ||
+      preview.proposed_workers.some((worker) => worker.token_budget < 1)
+        ? [
+            {
+              code: "missing_workers" as const,
+              message: "The manager plan preview has no budgeted workers.",
+            },
+          ]
+        : []),
+    ];
+    return {
+      schema: "yukh-control-plane-launch-readiness-v1",
+      source: "local-control-plane-store",
+      outcome: reasons.length === 0 ? "ready" : "blocked",
+      preview,
+      reasons,
     };
   }
 

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -649,7 +649,34 @@ const loadPersistedPlanPreview = async () => {
   }
 };
 
-const renderPersistedPlanPreview = (preview) => {
+const loadLaunchReadiness = async () => {
+  try {
+    const response = await fetch("./api/manager-plan/launch-readiness", { cache: "no-store" });
+    if (!response.ok) return null;
+    return await response.json();
+  } catch {
+    return null;
+  }
+};
+
+const readinessPanel = (readiness) => {
+  if (!readiness) return "";
+  return `
+    <div class="readiness-panel ${readiness.outcome}">
+      <div>
+        <span>Launch readiness</span>
+        <strong>${escapeHtml(readiness.outcome)}</strong>
+      </div>
+      ${
+        readiness.reasons.length === 0
+          ? '<p class="muted">Ready for the next explicit launch step. This panel still launches nothing.</p>'
+          : `<ul>${readiness.reasons.map((reason) => `<li>${escapeHtml(reason.message)}</li>`).join("")}</ul>`
+      }
+    </div>
+  `;
+};
+
+const renderPersistedPlanPreview = (preview, readiness = null) => {
   byId("plan-preview").innerHTML = `
     <article class="preview-card ${preview.state === "approved-preview" ? "approved-preview" : ""}">
       <div class="section-title">
@@ -686,6 +713,7 @@ const renderPersistedPlanPreview = (preview) => {
             </div>`
           : ""
       }
+      ${readinessPanel(readiness)}
     </article>
   `;
 };
@@ -775,6 +803,10 @@ byId("plan-preview").addEventListener("click", async (event) => {
   }
   button.setAttribute("disabled", "true");
   button.textContent = "Preview approved";
+  const readiness = await loadLaunchReadiness();
+  if (readiness) {
+    card?.insertAdjacentHTML("beforeend", readinessPanel(readiness));
+  }
 });
 
 byId("manager-plan-form").addEventListener("submit", (event) => {
@@ -789,5 +821,5 @@ byId("manager-plan-form").addEventListener("submit", (event) => {
 
 const persistedPlan = await loadPersistedPlanPreview();
 if (persistedPlan) {
-  renderPersistedPlanPreview(persistedPlan);
+  renderPersistedPlanPreview(persistedPlan, await loadLaunchReadiness());
 }

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -753,6 +753,41 @@ nav a:hover {
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+.readiness-panel {
+  border-radius: 16px;
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+}
+.readiness-panel.ready {
+  background: rgba(119, 240, 178, 0.08);
+  border: 1px solid rgba(119, 240, 178, 0.28);
+}
+.readiness-panel.blocked {
+  background: rgba(255, 209, 102, 0.08);
+  border: 1px solid rgba(255, 209, 102, 0.28);
+}
+.readiness-panel > div {
+  display: grid;
+  gap: 5px;
+}
+.readiness-panel span {
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.readiness-panel.blocked span {
+  color: var(--warn);
+}
+.readiness-panel ul {
+  color: var(--muted);
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 20px;
+}
 .preview-card.approved-preview {
   border-color: rgba(119, 240, 178, 0.48);
 }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -233,6 +233,13 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(initial.headers.get("cache-control"), "no-store");
     assert.deepEqual((await initial.json()).previews, []);
 
+    const initialReadiness = await fetch(`${base}/api/manager-plan/launch-readiness`);
+    assert.equal(initialReadiness.status, 200);
+    const initialReadinessBody = await initialReadiness.json();
+    assert.equal(initialReadinessBody.schema, "yukh-control-plane-launch-readiness-v1");
+    assert.equal(initialReadinessBody.outcome, "blocked");
+    assert.equal(initialReadinessBody.reasons[0].code, "missing_plan_preview");
+
     const goal = "Persist this sensitive manager plan preview locally";
     const proposed = await fetch(`${base}/api/manager-plan/previews`, {
       method: "POST",
@@ -251,6 +258,11 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(proposedBody.preview.proposed_workers.length, 2);
     assert.match(proposedBody.preview.goal_digest, /^sha-256:[a-f0-9]{64}$/u);
 
+    const proposedReadiness = await fetch(`${base}/api/manager-plan/launch-readiness`);
+    const proposedReadinessBody = await proposedReadiness.json();
+    assert.equal(proposedReadinessBody.outcome, "blocked");
+    assert.equal(proposedReadinessBody.reasons[0].code, "plan_not_approved");
+
     const approved = await fetch(`${base}/api/manager-plan/previews`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -267,6 +279,12 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(approvedBody.preview.state, "approved-preview");
     assert.match(approvedBody.preview.receipt_id, /^preview-receipt-/u);
 
+    const approvedReadiness = await fetch(`${base}/api/manager-plan/launch-readiness`);
+    const approvedReadinessBody = await approvedReadiness.json();
+    assert.equal(approvedReadinessBody.outcome, "ready");
+    assert.deepEqual(approvedReadinessBody.reasons, []);
+    assert.doesNotMatch(JSON.stringify(approvedReadinessBody), /sensitive manager plan preview/iu);
+
     const persisted = await fetch(`${base}/api/manager-plan/previews`);
     const persistedBody = await persisted.json();
     assert.equal(persistedBody.previews.length, 2);
@@ -276,6 +294,12 @@ test("control plane preview persists local manager plan previews without leaking
     const denied = await fetch(`${base}/api/manager-plan/previews`, { method: "DELETE" });
     assert.equal(denied.status, 405);
     assert.equal(denied.headers.get("allow"), "GET, POST");
+
+    const readinessDenied = await fetch(`${base}/api/manager-plan/launch-readiness`, {
+      method: "POST",
+    });
+    assert.equal(readinessDenied.status, 405);
+    assert.equal(readinessDenied.headers.get("allow"), "GET");
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
@@ -313,6 +337,8 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /renderTeamDetail/u);
   assert.match(data, /renderPlanPreview/u);
   assert.match(data, /api\/manager-plan\/previews/u);
+  assert.match(data, /api\/manager-plan\/launch-readiness/u);
+  assert.match(data, /Launch readiness/u);
   assert.match(data, /Persisted manager plan/u);
   assert.match(data, /Dry-run manager plan/u);
   assert.match(data, /no workers launched/u);
@@ -351,5 +377,6 @@ test("control plane preview has bounded text containers for operator UI", async 
   assert.match(css, /\.preview-actions/u);
   assert.match(css, /\.approval-receipt/u);
   assert.match(css, /\.approved-preview/u);
+  assert.match(css, /\.readiness-panel/u);
   assert.match(css, /@media \(max-width: 640px\)/u);
 });


### PR DESCRIPTION
## What changed

- Added `GET /api/manager-plan/launch-readiness`.
- Added readiness evaluation to `ControlPlanePlanPreviewStore`.
- Reports `ready` only when the latest preview is approved, has a local receipt, has a valid budget split and has budgeted workers.
- Reports `blocked` with reason codes otherwise.
- UI renders Launch readiness for persisted previews and after approval.

## Why

Before adding any real launch action, the Control Plane needs a read-only preflight that explains whether launching would be allowed and why.

## Validation

- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- Playwright screenshot capture with submit, approve, reload readiness and overflow detection

## Boundary

Read-only readiness only. No provider call, no worker launch, no Coordination write and no Projects write.

Closes #266.
