### PR TITLE
Add Control Plane launch intent

### DIFF
--- a/.context/sessions/SESSION-2026-08-18-13-control-plane-launch-intent.md
+++ b/.context/sessions/SESSION-2026-08-18-13-control-plane-launch-intent.md
@@ -1,0 +1,34 @@
+# SESSION-2026-08-18-13 — Control Plane launch intent
+
+Date: 2026-08-18
+Repository: `nomed/yukh-mcp`
+Branch: `agent/control-plane-launch-intent`
+
+## Objective
+
+Add the first explicit launch transition after manager plan readiness, without
+starting workers or calling providers.
+
+## Outcome
+
+- Added `GET /api/manager-plan/launch-intents`.
+- Added `POST /api/manager-plan/launch-intents`.
+- Launch intent creation is blocked with `409 launch_readiness_blocked` until
+  the latest manager plan preview is launch-ready.
+- A launch intent stores only local receipt metadata, the approved preview
+  reference, worker budget snapshot and creation time.
+- The Control Plane preview UI exposes `Record launch intent` only after
+  readiness is `ready`.
+
+## Validation
+
+- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
+- `npm run format:check`
+- `npm run typecheck`
+- `npm run build`
+- `git diff --check`
+
+## Boundaries
+
+No provider call, worker process launch, Coordination write, Projects write or
+external mutation was added.

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -27,6 +27,7 @@ const API_TOPOLOGY_STATUS_PATH = "/api/topology/status";
 const API_TEAM_STATUS_PATH = "/api/teams/status";
 const API_PLAN_PREVIEWS_PATH = "/api/manager-plan/previews";
 const API_LAUNCH_READINESS_PATH = "/api/manager-plan/launch-readiness";
+const API_LAUNCH_INTENTS_PATH = "/api/manager-plan/launch-intents";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
@@ -120,6 +121,54 @@ export function createControlPlaneServer(
         "content-type": "application/json; charset=utf-8",
       });
       response.end(JSON.stringify(options.planPreviewStore.launchReadiness()));
+      return;
+    }
+
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_LAUNCH_INTENTS_PATH
+    ) {
+      if (!options.planPreviewStore) {
+        response.writeHead(503, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "store_unconfigured" }));
+        return;
+      }
+      if (request.method === "GET") {
+        response.writeHead(200, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify(options.planPreviewStore.launchIntents()));
+        return;
+      }
+      if (request.method === "POST") {
+        try {
+          const record = options.planPreviewStore.createLaunchIntent();
+          response.writeHead(201, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(JSON.stringify({ schema: 1, status: "ok", launch_intent: record }));
+        } catch {
+          response.writeHead(409, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({ schema: 1, status: "error", code: "launch_readiness_blocked" }),
+          );
+        }
+        return;
+      }
+      response.writeHead(405, {
+        allow: "GET, POST",
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
       return;
     }
 

--- a/apps/control-plane-preview/src/plan-preview-store.ts
+++ b/apps/control-plane-preview/src/plan-preview-store.ts
@@ -46,6 +46,29 @@ export type ControlPlaneLaunchReadinessStatus = {
   }[];
 };
 
+export type ControlPlaneLaunchIntentRecord = {
+  readonly schema: 1;
+  readonly launch_intent_id: string;
+  readonly preview_id: string;
+  readonly preview_receipt_id: string;
+  readonly readiness_outcome: "ready";
+  readonly token_budget: number;
+  readonly manager_reserve: number;
+  readonly worker_reserve: number;
+  readonly safety_reserve: number;
+  readonly proposed_workers: readonly {
+    readonly role: string;
+    readonly token_budget: number;
+  }[];
+  readonly created_at: string;
+};
+
+export type ControlPlaneLaunchIntentStatus = {
+  readonly schema: "yukh-control-plane-launch-intents-v1";
+  readonly source: "local-control-plane-store";
+  readonly intents: readonly ControlPlaneLaunchIntentRecord[];
+};
+
 export type ControlPlanePlanPreviewInput = {
   readonly goal: string;
   readonly mode: string;
@@ -57,6 +80,7 @@ export type ControlPlanePlanPreviewInput = {
 type Document = {
   readonly schema: 1;
   readonly previews: readonly ControlPlanePlanPreviewRecord[];
+  readonly launch_intents?: readonly ControlPlaneLaunchIntentRecord[];
 };
 
 const validMode = new Set(["plan-first", "delegate, explicit workers"]);
@@ -180,6 +204,46 @@ export class ControlPlanePlanPreviewStore {
     };
   }
 
+  launchIntents(): ControlPlaneLaunchIntentStatus {
+    return {
+      schema: "yukh-control-plane-launch-intents-v1",
+      source: "local-control-plane-store",
+      intents: this.#read().launch_intents ?? [],
+    };
+  }
+
+  createLaunchIntent(): ControlPlaneLaunchIntentRecord {
+    const readiness = this.launchReadiness();
+    if (readiness.outcome !== "ready" || !readiness.preview?.receipt_id) {
+      throw new TypeError("launch readiness blocked");
+    }
+    const preview = readiness.preview;
+    const previewReceiptId = preview.receipt_id;
+    if (!previewReceiptId) {
+      throw new TypeError("launch readiness blocked");
+    }
+    const record: ControlPlaneLaunchIntentRecord = {
+      schema: 1,
+      launch_intent_id: `launch-intent-${randomUUID()}`,
+      preview_id: preview.preview_id,
+      preview_receipt_id: previewReceiptId,
+      readiness_outcome: "ready",
+      token_budget: preview.token_budget,
+      manager_reserve: preview.manager_reserve,
+      worker_reserve: preview.worker_reserve,
+      safety_reserve: preview.safety_reserve,
+      proposed_workers: preview.proposed_workers,
+      created_at: new Date().toISOString(),
+    };
+    const document = this.#read();
+    this.#write({
+      schema: 1,
+      previews: document.previews,
+      launch_intents: [record, ...(document.launch_intents ?? [])].slice(0, 20),
+    });
+    return record;
+  }
+
   create(input: ControlPlanePlanPreviewInput): ControlPlanePlanPreviewRecord {
     validateInput(input);
     const managerReserve = Math.floor(input.token_budget * 0.25);
@@ -204,7 +268,11 @@ export class ControlPlanePlanPreviewStore {
       ...(state === "approved-preview" ? { approved_at: now } : {}),
     };
     const document = this.#read();
-    this.#write({ schema: 1, previews: [record, ...document.previews].slice(0, 20) });
+    this.#write({
+      schema: 1,
+      previews: [record, ...document.previews].slice(0, 20),
+      launch_intents: document.launch_intents ?? [],
+    });
     return record;
   }
 
@@ -214,9 +282,15 @@ export class ControlPlanePlanPreviewStore {
       if (parsed.schema !== 1 || !Array.isArray(parsed.previews)) {
         return { schema: 1, previews: [] };
       }
-      return { schema: 1, previews: parsed.previews.filter((item) => item?.schema === 1) };
+      return {
+        schema: 1,
+        previews: parsed.previews.filter((item) => item?.schema === 1),
+        launch_intents: Array.isArray(parsed.launch_intents)
+          ? parsed.launch_intents.filter((item) => item?.schema === 1)
+          : [],
+      };
     } catch {
-      return { schema: 1, previews: [] };
+      return { schema: 1, previews: [], launch_intents: [] };
     }
   }
 

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -659,6 +659,32 @@ const loadLaunchReadiness = async () => {
   }
 };
 
+const createLaunchIntent = async () => {
+  try {
+    const response = await fetch("./api/manager-plan/launch-intents", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return body?.launch_intent ?? null;
+  } catch {
+    return null;
+  }
+};
+
+const renderLaunchIntent = (intent) => {
+  if (!intent) return "";
+  return `
+    <div class="launch-intent">
+      <span>Launch intent recorded</span>
+      <strong>${escapeHtml(intent.launch_intent_id)}</strong>
+      <p class="muted">Local receipt only. No provider call and no worker process has been started.</p>
+    </div>
+  `;
+};
+
 const readinessPanel = (readiness) => {
   if (!readiness) return "";
   return `
@@ -671,6 +697,11 @@ const readinessPanel = (readiness) => {
         readiness.reasons.length === 0
           ? '<p class="muted">Ready for the next explicit launch step. This panel still launches nothing.</p>'
           : `<ul>${readiness.reasons.map((reason) => `<li>${escapeHtml(reason.message)}</li>`).join("")}</ul>`
+      }
+      ${
+        readiness.outcome === "ready"
+          ? '<button type="button" class="secondary launch-intent-button">Record launch intent</button>'
+          : ""
       }
     </div>
   `;
@@ -807,6 +838,20 @@ byId("plan-preview").addEventListener("click", async (event) => {
   if (readiness) {
     card?.insertAdjacentHTML("beforeend", readinessPanel(readiness));
   }
+});
+
+byId("plan-preview").addEventListener("click", async (event) => {
+  const button = event.target.closest(".launch-intent-button");
+  if (!button) return;
+  button.setAttribute("disabled", "true");
+  const intent = await createLaunchIntent();
+  if (!intent) {
+    button.removeAttribute("disabled");
+    button.textContent = "Launch readiness blocked";
+    return;
+  }
+  button.textContent = "Launch intent recorded";
+  button.closest(".readiness-panel")?.insertAdjacentHTML("afterend", renderLaunchIntent(intent));
 });
 
 byId("manager-plan-form").addEventListener("submit", (event) => {

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -788,6 +788,21 @@ nav a:hover {
   margin: 0;
   padding-left: 20px;
 }
+.launch-intent {
+  background: rgba(124, 144, 255, 0.09);
+  border: 1px solid rgba(124, 144, 255, 0.3);
+  border-radius: 16px;
+  display: grid;
+  gap: 7px;
+  padding: 12px;
+}
+.launch-intent span {
+  color: #aeb9ff;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 .preview-card.approved-preview {
   border-color: rgba(119, 240, 178, 0.48);
 }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -240,6 +240,12 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(initialReadinessBody.outcome, "blocked");
     assert.equal(initialReadinessBody.reasons[0].code, "missing_plan_preview");
 
+    const blockedIntent = await fetch(`${base}/api/manager-plan/launch-intents`, {
+      method: "POST",
+    });
+    assert.equal(blockedIntent.status, 409);
+    assert.equal((await blockedIntent.json()).code, "launch_readiness_blocked");
+
     const goal = "Persist this sensitive manager plan preview locally";
     const proposed = await fetch(`${base}/api/manager-plan/previews`, {
       method: "POST",
@@ -285,6 +291,26 @@ test("control plane preview persists local manager plan previews without leaking
     assert.deepEqual(approvedReadinessBody.reasons, []);
     assert.doesNotMatch(JSON.stringify(approvedReadinessBody), /sensitive manager plan preview/iu);
 
+    const intent = await fetch(`${base}/api/manager-plan/launch-intents`, { method: "POST" });
+    assert.equal(intent.status, 201);
+    const intentBody = await intent.json();
+    assert.equal(intentBody.launch_intent.readiness_outcome, "ready");
+    assert.equal(intentBody.launch_intent.preview_id, approvedBody.preview.preview_id);
+    assert.equal(intentBody.launch_intent.preview_receipt_id, approvedBody.preview.receipt_id);
+    assert.equal(intentBody.launch_intent.token_budget, 120_000);
+    assert.match(intentBody.launch_intent.launch_intent_id, /^launch-intent-/u);
+    assert.doesNotMatch(JSON.stringify(intentBody), /sensitive manager plan preview/iu);
+
+    const intents = await fetch(`${base}/api/manager-plan/launch-intents`);
+    assert.equal(intents.status, 200);
+    const intentsBody = await intents.json();
+    assert.equal(intentsBody.schema, "yukh-control-plane-launch-intents-v1");
+    assert.equal(intentsBody.intents.length, 1);
+    assert.equal(
+      intentsBody.intents[0].launch_intent_id,
+      intentBody.launch_intent.launch_intent_id,
+    );
+
     const persisted = await fetch(`${base}/api/manager-plan/previews`);
     const persistedBody = await persisted.json();
     assert.equal(persistedBody.previews.length, 2);
@@ -300,6 +326,12 @@ test("control plane preview persists local manager plan previews without leaking
     });
     assert.equal(readinessDenied.status, 405);
     assert.equal(readinessDenied.headers.get("allow"), "GET");
+
+    const intentDenied = await fetch(`${base}/api/manager-plan/launch-intents`, {
+      method: "DELETE",
+    });
+    assert.equal(intentDenied.status, 405);
+    assert.equal(intentDenied.headers.get("allow"), "GET, POST");
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
@@ -338,7 +370,9 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /renderPlanPreview/u);
   assert.match(data, /api\/manager-plan\/previews/u);
   assert.match(data, /api\/manager-plan\/launch-readiness/u);
+  assert.match(data, /api\/manager-plan\/launch-intents/u);
   assert.match(data, /Launch readiness/u);
+  assert.match(data, /Launch intent recorded/u);
   assert.match(data, /Persisted manager plan/u);
   assert.match(data, /Dry-run manager plan/u);
   assert.match(data, /no workers launched/u);
@@ -378,5 +412,6 @@ test("control plane preview has bounded text containers for operator UI", async 
   assert.match(css, /\.approval-receipt/u);
   assert.match(css, /\.approved-preview/u);
   assert.match(css, /\.readiness-panel/u);
+  assert.match(css, /\.launch-intent/u);
   assert.match(css, /@media \(max-width: 640px\)/u);
 });


### PR DESCRIPTION
## Summary

Adds a safe Control Plane launch-intent step after manager plan readiness.

## What changed

- Adds `GET /api/manager-plan/launch-intents`.
- Adds `POST /api/manager-plan/launch-intents`.
- Blocks launch-intent creation with `409 launch_readiness_blocked` until the latest manager plan preview is approved and launch-ready.
- Stores only local receipt metadata, approved preview reference, worker budget snapshot, and creation time.
- Adds UI affordance `Record launch intent` only when readiness is ready.
- Documents the increment in `.context/sessions/`.

## Boundaries

This does not launch workers, call Codex/Copilot providers, write Coordination events, write Projects state, or perform external mutations.

## Validation

- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
