### PR TITLE
Add Control Plane manager run receipt

### DIFF
--- a/.context/sessions/SESSION-2026-08-19-01-control-plane-manager-run.md
+++ b/.context/sessions/SESSION-2026-08-19-01-control-plane-manager-run.md
@@ -1,0 +1,36 @@
+# SESSION-2026-08-19-01 — Control Plane manager run receipt
+
+Date: 2026-08-19
+Repository: `nomed/yukh-mcp`
+Branch: `agent/control-plane-manager-run`
+
+## Objective
+
+Add the first manager-run transition after launch intent while keeping provider
+execution and worker creation disabled.
+
+## Outcome
+
+- Added `GET /api/manager-plan/manager-runs`.
+- Added `POST /api/manager-plan/manager-runs`.
+- Manager-run creation requires an existing launch intent and otherwise fails
+  with `409 launch_intent_required`.
+- Repeated manager-run creation for the same launch intent returns the existing
+  local run record instead of creating duplicates.
+- The run is recorded as `planned`, with a receipt, provider, team budget,
+  manager budget, worker count and `connect_manager_runtime` as the next
+  required action.
+- The Control Plane preview UI can record and display the planned manager run.
+
+## Validation
+
+- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
+- `npm run format:check`
+- `npm run typecheck`
+- `npm run build`
+- `git diff --check`
+
+## Boundaries
+
+No Codex/Copilot provider call, worker process launch, Coordination write,
+Projects write or external mutation was added.

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -28,6 +28,7 @@ const API_TEAM_STATUS_PATH = "/api/teams/status";
 const API_PLAN_PREVIEWS_PATH = "/api/manager-plan/previews";
 const API_LAUNCH_READINESS_PATH = "/api/manager-plan/launch-readiness";
 const API_LAUNCH_INTENTS_PATH = "/api/manager-plan/launch-intents";
+const API_MANAGER_RUNS_PATH = "/api/manager-plan/manager-runs";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
@@ -159,6 +160,54 @@ export function createControlPlaneServer(
           });
           response.end(
             JSON.stringify({ schema: 1, status: "error", code: "launch_readiness_blocked" }),
+          );
+        }
+        return;
+      }
+      response.writeHead(405, {
+        allow: "GET, POST",
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+      return;
+    }
+
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_MANAGER_RUNS_PATH
+    ) {
+      if (!options.planPreviewStore) {
+        response.writeHead(503, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "store_unconfigured" }));
+        return;
+      }
+      if (request.method === "GET") {
+        response.writeHead(200, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify(options.planPreviewStore.managerRuns()));
+        return;
+      }
+      if (request.method === "POST") {
+        try {
+          const record = options.planPreviewStore.createManagerRun();
+          response.writeHead(201, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(JSON.stringify({ schema: 1, status: "ok", manager_run: record }));
+        } catch {
+          response.writeHead(409, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({ schema: 1, status: "error", code: "launch_intent_required" }),
           );
         }
         return;

--- a/apps/control-plane-preview/src/plan-preview-store.ts
+++ b/apps/control-plane-preview/src/plan-preview-store.ts
@@ -69,6 +69,27 @@ export type ControlPlaneLaunchIntentStatus = {
   readonly intents: readonly ControlPlaneLaunchIntentRecord[];
 };
 
+export type ControlPlaneManagerRunRecord = {
+  readonly schema: 1;
+  readonly manager_run_id: string;
+  readonly receipt_id: string;
+  readonly state: "planned";
+  readonly launch_intent_id: string;
+  readonly preview_id: string;
+  readonly provider: string;
+  readonly manager_token_budget: number;
+  readonly team_token_budget: number;
+  readonly worker_count: number;
+  readonly created_at: string;
+  readonly next_required_action: "connect_manager_runtime";
+};
+
+export type ControlPlaneManagerRunStatus = {
+  readonly schema: "yukh-control-plane-manager-runs-v1";
+  readonly source: "local-control-plane-store";
+  readonly runs: readonly ControlPlaneManagerRunRecord[];
+};
+
 export type ControlPlanePlanPreviewInput = {
   readonly goal: string;
   readonly mode: string;
@@ -81,6 +102,7 @@ type Document = {
   readonly schema: 1;
   readonly previews: readonly ControlPlanePlanPreviewRecord[];
   readonly launch_intents?: readonly ControlPlaneLaunchIntentRecord[];
+  readonly manager_runs?: readonly ControlPlaneManagerRunRecord[];
 };
 
 const validMode = new Set(["plan-first", "delegate, explicit workers"]);
@@ -212,6 +234,51 @@ export class ControlPlanePlanPreviewStore {
     };
   }
 
+  managerRuns(): ControlPlaneManagerRunStatus {
+    return {
+      schema: "yukh-control-plane-manager-runs-v1",
+      source: "local-control-plane-store",
+      runs: this.#read().manager_runs ?? [],
+    };
+  }
+
+  createManagerRun(): ControlPlaneManagerRunRecord {
+    const document = this.#read();
+    const launchIntent = document.launch_intents?.[0];
+    if (!launchIntent) {
+      throw new TypeError("missing launch intent");
+    }
+    const existing = document.manager_runs?.find(
+      (run) => run.launch_intent_id === launchIntent.launch_intent_id,
+    );
+    if (existing) return existing;
+    const preview = document.previews.find((item) => item.preview_id === launchIntent.preview_id);
+    if (!preview) {
+      throw new TypeError("missing launch preview");
+    }
+    const record: ControlPlaneManagerRunRecord = {
+      schema: 1,
+      manager_run_id: `manager-run-${randomUUID()}`,
+      receipt_id: `manager-run-receipt-${randomUUID()}`,
+      state: "planned",
+      launch_intent_id: launchIntent.launch_intent_id,
+      preview_id: launchIntent.preview_id,
+      provider: preview.provider,
+      manager_token_budget: launchIntent.manager_reserve,
+      team_token_budget: launchIntent.token_budget,
+      worker_count: launchIntent.proposed_workers.length,
+      created_at: new Date().toISOString(),
+      next_required_action: "connect_manager_runtime",
+    };
+    this.#write({
+      schema: 1,
+      previews: document.previews,
+      launch_intents: document.launch_intents ?? [],
+      manager_runs: [record, ...(document.manager_runs ?? [])].slice(0, 20),
+    });
+    return record;
+  }
+
   createLaunchIntent(): ControlPlaneLaunchIntentRecord {
     const readiness = this.launchReadiness();
     if (readiness.outcome !== "ready" || !readiness.preview?.receipt_id) {
@@ -240,6 +307,7 @@ export class ControlPlanePlanPreviewStore {
       schema: 1,
       previews: document.previews,
       launch_intents: [record, ...(document.launch_intents ?? [])].slice(0, 20),
+      manager_runs: document.manager_runs ?? [],
     });
     return record;
   }
@@ -272,6 +340,7 @@ export class ControlPlanePlanPreviewStore {
       schema: 1,
       previews: [record, ...document.previews].slice(0, 20),
       launch_intents: document.launch_intents ?? [],
+      manager_runs: document.manager_runs ?? [],
     });
     return record;
   }
@@ -288,9 +357,12 @@ export class ControlPlanePlanPreviewStore {
         launch_intents: Array.isArray(parsed.launch_intents)
           ? parsed.launch_intents.filter((item) => item?.schema === 1)
           : [],
+        manager_runs: Array.isArray(parsed.manager_runs)
+          ? parsed.manager_runs.filter((item) => item?.schema === 1)
+          : [],
       };
     } catch {
-      return { schema: 1, previews: [], launch_intents: [] };
+      return { schema: 1, previews: [], launch_intents: [], manager_runs: [] };
     }
   }
 

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -674,6 +674,21 @@ const createLaunchIntent = async () => {
   }
 };
 
+const createManagerRun = async () => {
+  try {
+    const response = await fetch("./api/manager-plan/manager-runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return body?.manager_run ?? null;
+  } catch {
+    return null;
+  }
+};
+
 const renderLaunchIntent = (intent) => {
   if (!intent) return "";
   return `
@@ -681,6 +696,19 @@ const renderLaunchIntent = (intent) => {
       <span>Launch intent recorded</span>
       <strong>${escapeHtml(intent.launch_intent_id)}</strong>
       <p class="muted">Local receipt only. No provider call and no worker process has been started.</p>
+      <button type="button" class="secondary manager-run-button">Record manager run</button>
+    </div>
+  `;
+};
+
+const renderManagerRun = (run) => {
+  if (!run) return "";
+  return `
+    <div class="manager-run">
+      <span>Manager run planned</span>
+      <strong>${escapeHtml(run.manager_run_id)}</strong>
+      <p class="muted">${escapeHtml(run.provider)} · ${run.manager_token_budget.toLocaleString()} manager tokens · ${run.worker_count.toLocaleString()} proposed workers.</p>
+      <p class="muted">Next required action: ${escapeHtml(run.next_required_action)}. No provider process has been started.</p>
     </div>
   `;
 };
@@ -852,6 +880,20 @@ byId("plan-preview").addEventListener("click", async (event) => {
   }
   button.textContent = "Launch intent recorded";
   button.closest(".readiness-panel")?.insertAdjacentHTML("afterend", renderLaunchIntent(intent));
+});
+
+byId("plan-preview").addEventListener("click", async (event) => {
+  const button = event.target.closest(".manager-run-button");
+  if (!button) return;
+  button.setAttribute("disabled", "true");
+  const run = await createManagerRun();
+  if (!run) {
+    button.removeAttribute("disabled");
+    button.textContent = "Launch intent required";
+    return;
+  }
+  button.textContent = "Manager run planned";
+  button.closest(".launch-intent")?.insertAdjacentHTML("afterend", renderManagerRun(run));
 });
 
 byId("manager-plan-form").addEventListener("submit", (event) => {

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -803,6 +803,21 @@ nav a:hover {
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+.manager-run {
+  background: rgba(255, 255, 255, 0.045);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 16px;
+  display: grid;
+  gap: 7px;
+  padding: 12px;
+}
+.manager-run span {
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 .preview-card.approved-preview {
   border-color: rgba(119, 240, 178, 0.48);
 }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -246,6 +246,12 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(blockedIntent.status, 409);
     assert.equal((await blockedIntent.json()).code, "launch_readiness_blocked");
 
+    const blockedRun = await fetch(`${base}/api/manager-plan/manager-runs`, {
+      method: "POST",
+    });
+    assert.equal(blockedRun.status, 409);
+    assert.equal((await blockedRun.json()).code, "launch_intent_required");
+
     const goal = "Persist this sensitive manager plan preview locally";
     const proposed = await fetch(`${base}/api/manager-plan/previews`, {
       method: "POST",
@@ -311,6 +317,34 @@ test("control plane preview persists local manager plan previews without leaking
       intentBody.launch_intent.launch_intent_id,
     );
 
+    const run = await fetch(`${base}/api/manager-plan/manager-runs`, { method: "POST" });
+    assert.equal(run.status, 201);
+    const runBody = await run.json();
+    assert.equal(runBody.manager_run.state, "planned");
+    assert.equal(runBody.manager_run.launch_intent_id, intentBody.launch_intent.launch_intent_id);
+    assert.equal(runBody.manager_run.preview_id, approvedBody.preview.preview_id);
+    assert.equal(runBody.manager_run.provider, "Copilot SDK workers");
+    assert.equal(runBody.manager_run.manager_token_budget, 30_000);
+    assert.equal(runBody.manager_run.team_token_budget, 120_000);
+    assert.equal(runBody.manager_run.worker_count, 2);
+    assert.equal(runBody.manager_run.next_required_action, "connect_manager_runtime");
+    assert.match(runBody.manager_run.receipt_id, /^manager-run-receipt-/u);
+    assert.doesNotMatch(JSON.stringify(runBody), /sensitive manager plan preview/iu);
+
+    const repeatedRun = await fetch(`${base}/api/manager-plan/manager-runs`, { method: "POST" });
+    assert.equal(repeatedRun.status, 201);
+    assert.equal(
+      (await repeatedRun.json()).manager_run.manager_run_id,
+      runBody.manager_run.manager_run_id,
+    );
+
+    const runs = await fetch(`${base}/api/manager-plan/manager-runs`);
+    assert.equal(runs.status, 200);
+    const runsBody = await runs.json();
+    assert.equal(runsBody.schema, "yukh-control-plane-manager-runs-v1");
+    assert.equal(runsBody.runs.length, 1);
+    assert.equal(runsBody.runs[0].manager_run_id, runBody.manager_run.manager_run_id);
+
     const persisted = await fetch(`${base}/api/manager-plan/previews`);
     const persistedBody = await persisted.json();
     assert.equal(persistedBody.previews.length, 2);
@@ -332,6 +366,12 @@ test("control plane preview persists local manager plan previews without leaking
     });
     assert.equal(intentDenied.status, 405);
     assert.equal(intentDenied.headers.get("allow"), "GET, POST");
+
+    const runDenied = await fetch(`${base}/api/manager-plan/manager-runs`, {
+      method: "DELETE",
+    });
+    assert.equal(runDenied.status, 405);
+    assert.equal(runDenied.headers.get("allow"), "GET, POST");
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
@@ -371,8 +411,11 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /api\/manager-plan\/previews/u);
   assert.match(data, /api\/manager-plan\/launch-readiness/u);
   assert.match(data, /api\/manager-plan\/launch-intents/u);
+  assert.match(data, /api\/manager-plan\/manager-runs/u);
   assert.match(data, /Launch readiness/u);
   assert.match(data, /Launch intent recorded/u);
+  assert.match(data, /Manager run planned/u);
+  assert.match(data, /next_required_action/u);
   assert.match(data, /Persisted manager plan/u);
   assert.match(data, /Dry-run manager plan/u);
   assert.match(data, /no workers launched/u);
@@ -413,5 +456,6 @@ test("control plane preview has bounded text containers for operator UI", async 
   assert.match(css, /\.approved-preview/u);
   assert.match(css, /\.readiness-panel/u);
   assert.match(css, /\.launch-intent/u);
+  assert.match(css, /\.manager-run/u);
   assert.match(css, /@media \(max-width: 640px\)/u);
 });


### PR DESCRIPTION
## Summary

Adds a local Control Plane manager-run receipt after launch intent, without starting provider runtimes or workers.

## What changed

- Adds `GET /api/manager-plan/manager-runs`.
- Adds `POST /api/manager-plan/manager-runs`.
- Requires an existing launch intent before manager-run creation.
- Records the manager run as `planned` with a local receipt, provider, team budget, manager budget, worker count, and next required action.
- Makes repeated creation for the same launch intent idempotent by returning the existing run record.
- Adds UI to record and display the planned manager run.
- Documents the increment in `.context/sessions/`.

## Boundaries

This does not call Codex/Copilot, start a provider process, create workers, write Coordination events, write Projects state, or perform external mutations.

## Validation

- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
