### PR TITLE
Add Control Plane manager runtime connection

### DIFF
--- a/.context/sessions/SESSION-2026-08-19-02-control-plane-connect-manager-runtime.md
+++ b/.context/sessions/SESSION-2026-08-19-02-control-plane-connect-manager-runtime.md
@@ -1,0 +1,37 @@
+# SESSION-2026-08-19-02 — Control Plane manager runtime connection
+
+Date: 2026-08-19
+Repository: `nomed/yukh-mcp`
+Branch: `agent/control-plane-connect-manager-runtime`
+
+## Objective
+
+Add the `connect_manager_runtime` transition after a planned manager run while
+keeping provider process start disabled.
+
+## Outcome
+
+- Added `GET /api/manager-plan/runtime-connections`.
+- Added `POST /api/manager-plan/runtime-connections`.
+- Runtime connection requires an existing manager run and otherwise fails with
+  `409 manager_run_required`.
+- Repeated connection for the same manager run returns the existing local
+  connection record instead of creating duplicates.
+- The connection records provider, manager budget, local receipt,
+  `command_policy: not_started`, and `start_manager_process` as the next
+  required action.
+- The Control Plane preview UI can connect and display the manager runtime
+  binding.
+
+## Validation
+
+- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
+- `npm run format:check`
+- `npm run typecheck`
+- `npm run build`
+- `git diff --check`
+
+## Boundaries
+
+No Codex/Copilot process start, worker creation, Coordination write, Projects
+write or external mutation was added.

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -29,6 +29,7 @@ const API_PLAN_PREVIEWS_PATH = "/api/manager-plan/previews";
 const API_LAUNCH_READINESS_PATH = "/api/manager-plan/launch-readiness";
 const API_LAUNCH_INTENTS_PATH = "/api/manager-plan/launch-intents";
 const API_MANAGER_RUNS_PATH = "/api/manager-plan/manager-runs";
+const API_MANAGER_RUNTIME_CONNECTIONS_PATH = "/api/manager-plan/runtime-connections";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
@@ -208,6 +209,54 @@ export function createControlPlaneServer(
           });
           response.end(
             JSON.stringify({ schema: 1, status: "error", code: "launch_intent_required" }),
+          );
+        }
+        return;
+      }
+      response.writeHead(405, {
+        allow: "GET, POST",
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+      return;
+    }
+
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_MANAGER_RUNTIME_CONNECTIONS_PATH
+    ) {
+      if (!options.planPreviewStore) {
+        response.writeHead(503, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "store_unconfigured" }));
+        return;
+      }
+      if (request.method === "GET") {
+        response.writeHead(200, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify(options.planPreviewStore.managerRuntimeConnections()));
+        return;
+      }
+      if (request.method === "POST") {
+        try {
+          const record = options.planPreviewStore.connectManagerRuntime();
+          response.writeHead(201, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(JSON.stringify({ schema: 1, status: "ok", runtime_connection: record }));
+        } catch {
+          response.writeHead(409, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({ schema: 1, status: "error", code: "manager_run_required" }),
           );
         }
         return;

--- a/apps/control-plane-preview/src/plan-preview-store.ts
+++ b/apps/control-plane-preview/src/plan-preview-store.ts
@@ -90,6 +90,26 @@ export type ControlPlaneManagerRunStatus = {
   readonly runs: readonly ControlPlaneManagerRunRecord[];
 };
 
+export type ControlPlaneManagerRuntimeConnectionRecord = {
+  readonly schema: 1;
+  readonly runtime_connection_id: string;
+  readonly receipt_id: string;
+  readonly state: "connected";
+  readonly manager_run_id: string;
+  readonly launch_intent_id: string;
+  readonly provider: string;
+  readonly manager_token_budget: number;
+  readonly command_policy: "not_started";
+  readonly created_at: string;
+  readonly next_required_action: "start_manager_process";
+};
+
+export type ControlPlaneManagerRuntimeConnectionStatus = {
+  readonly schema: "yukh-control-plane-manager-runtime-connections-v1";
+  readonly source: "local-control-plane-store";
+  readonly connections: readonly ControlPlaneManagerRuntimeConnectionRecord[];
+};
+
 export type ControlPlanePlanPreviewInput = {
   readonly goal: string;
   readonly mode: string;
@@ -103,6 +123,7 @@ type Document = {
   readonly previews: readonly ControlPlanePlanPreviewRecord[];
   readonly launch_intents?: readonly ControlPlaneLaunchIntentRecord[];
   readonly manager_runs?: readonly ControlPlaneManagerRunRecord[];
+  readonly manager_runtime_connections?: readonly ControlPlaneManagerRuntimeConnectionRecord[];
 };
 
 const validMode = new Set(["plan-first", "delegate, explicit workers"]);
@@ -242,6 +263,50 @@ export class ControlPlanePlanPreviewStore {
     };
   }
 
+  managerRuntimeConnections(): ControlPlaneManagerRuntimeConnectionStatus {
+    return {
+      schema: "yukh-control-plane-manager-runtime-connections-v1",
+      source: "local-control-plane-store",
+      connections: this.#read().manager_runtime_connections ?? [],
+    };
+  }
+
+  connectManagerRuntime(): ControlPlaneManagerRuntimeConnectionRecord {
+    const document = this.#read();
+    const managerRun = document.manager_runs?.[0];
+    if (!managerRun) {
+      throw new TypeError("missing manager run");
+    }
+    const existing = document.manager_runtime_connections?.find(
+      (connection) => connection.manager_run_id === managerRun.manager_run_id,
+    );
+    if (existing) return existing;
+    const record: ControlPlaneManagerRuntimeConnectionRecord = {
+      schema: 1,
+      runtime_connection_id: `manager-runtime-${randomUUID()}`,
+      receipt_id: `manager-runtime-receipt-${randomUUID()}`,
+      state: "connected",
+      manager_run_id: managerRun.manager_run_id,
+      launch_intent_id: managerRun.launch_intent_id,
+      provider: managerRun.provider,
+      manager_token_budget: managerRun.manager_token_budget,
+      command_policy: "not_started",
+      created_at: new Date().toISOString(),
+      next_required_action: "start_manager_process",
+    };
+    this.#write({
+      schema: 1,
+      previews: document.previews,
+      launch_intents: document.launch_intents ?? [],
+      manager_runs: document.manager_runs ?? [],
+      manager_runtime_connections: [record, ...(document.manager_runtime_connections ?? [])].slice(
+        0,
+        20,
+      ),
+    });
+    return record;
+  }
+
   createManagerRun(): ControlPlaneManagerRunRecord {
     const document = this.#read();
     const launchIntent = document.launch_intents?.[0];
@@ -275,6 +340,7 @@ export class ControlPlanePlanPreviewStore {
       previews: document.previews,
       launch_intents: document.launch_intents ?? [],
       manager_runs: [record, ...(document.manager_runs ?? [])].slice(0, 20),
+      manager_runtime_connections: document.manager_runtime_connections ?? [],
     });
     return record;
   }
@@ -308,6 +374,7 @@ export class ControlPlanePlanPreviewStore {
       previews: document.previews,
       launch_intents: [record, ...(document.launch_intents ?? [])].slice(0, 20),
       manager_runs: document.manager_runs ?? [],
+      manager_runtime_connections: document.manager_runtime_connections ?? [],
     });
     return record;
   }
@@ -341,6 +408,7 @@ export class ControlPlanePlanPreviewStore {
       previews: [record, ...document.previews].slice(0, 20),
       launch_intents: document.launch_intents ?? [],
       manager_runs: document.manager_runs ?? [],
+      manager_runtime_connections: document.manager_runtime_connections ?? [],
     });
     return record;
   }
@@ -360,9 +428,18 @@ export class ControlPlanePlanPreviewStore {
         manager_runs: Array.isArray(parsed.manager_runs)
           ? parsed.manager_runs.filter((item) => item?.schema === 1)
           : [],
+        manager_runtime_connections: Array.isArray(parsed.manager_runtime_connections)
+          ? parsed.manager_runtime_connections.filter((item) => item?.schema === 1)
+          : [],
       };
     } catch {
-      return { schema: 1, previews: [], launch_intents: [], manager_runs: [] };
+      return {
+        schema: 1,
+        previews: [],
+        launch_intents: [],
+        manager_runs: [],
+        manager_runtime_connections: [],
+      };
     }
   }
 

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -689,6 +689,21 @@ const createManagerRun = async () => {
   }
 };
 
+const connectManagerRuntime = async () => {
+  try {
+    const response = await fetch("./api/manager-plan/runtime-connections", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return body?.runtime_connection ?? null;
+  } catch {
+    return null;
+  }
+};
+
 const renderLaunchIntent = (intent) => {
   if (!intent) return "";
   return `
@@ -709,6 +724,19 @@ const renderManagerRun = (run) => {
       <strong>${escapeHtml(run.manager_run_id)}</strong>
       <p class="muted">${escapeHtml(run.provider)} · ${run.manager_token_budget.toLocaleString()} manager tokens · ${run.worker_count.toLocaleString()} proposed workers.</p>
       <p class="muted">Next required action: ${escapeHtml(run.next_required_action)}. No provider process has been started.</p>
+      <button type="button" class="secondary runtime-connection-button">Connect manager runtime</button>
+    </div>
+  `;
+};
+
+const renderRuntimeConnection = (connection) => {
+  if (!connection) return "";
+  return `
+    <div class="runtime-connection">
+      <span>Manager runtime connected</span>
+      <strong>${escapeHtml(connection.runtime_connection_id)}</strong>
+      <p class="muted">${escapeHtml(connection.provider)} · ${connection.manager_token_budget.toLocaleString()} manager tokens · commands ${escapeHtml(connection.command_policy)}.</p>
+      <p class="muted">Next required action: ${escapeHtml(connection.next_required_action)}. No provider process has been started.</p>
     </div>
   `;
 };
@@ -894,6 +922,22 @@ byId("plan-preview").addEventListener("click", async (event) => {
   }
   button.textContent = "Manager run planned";
   button.closest(".launch-intent")?.insertAdjacentHTML("afterend", renderManagerRun(run));
+});
+
+byId("plan-preview").addEventListener("click", async (event) => {
+  const button = event.target.closest(".runtime-connection-button");
+  if (!button) return;
+  button.setAttribute("disabled", "true");
+  const connection = await connectManagerRuntime();
+  if (!connection) {
+    button.removeAttribute("disabled");
+    button.textContent = "Manager run required";
+    return;
+  }
+  button.textContent = "Runtime connected";
+  button
+    .closest(".manager-run")
+    ?.insertAdjacentHTML("afterend", renderRuntimeConnection(connection));
 });
 
 byId("manager-plan-form").addEventListener("submit", (event) => {

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -818,6 +818,21 @@ nav a:hover {
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+.runtime-connection {
+  background: rgba(119, 240, 178, 0.07);
+  border: 1px solid rgba(119, 240, 178, 0.24);
+  border-radius: 16px;
+  display: grid;
+  gap: 7px;
+  padding: 12px;
+}
+.runtime-connection span {
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 .preview-card.approved-preview {
   border-color: rgba(119, 240, 178, 0.48);
 }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -252,6 +252,12 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(blockedRun.status, 409);
     assert.equal((await blockedRun.json()).code, "launch_intent_required");
 
+    const blockedConnection = await fetch(`${base}/api/manager-plan/runtime-connections`, {
+      method: "POST",
+    });
+    assert.equal(blockedConnection.status, 409);
+    assert.equal((await blockedConnection.json()).code, "manager_run_required");
+
     const goal = "Persist this sensitive manager plan preview locally";
     const proposed = await fetch(`${base}/api/manager-plan/previews`, {
       method: "POST",
@@ -345,6 +351,46 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(runsBody.runs.length, 1);
     assert.equal(runsBody.runs[0].manager_run_id, runBody.manager_run.manager_run_id);
 
+    const connection = await fetch(`${base}/api/manager-plan/runtime-connections`, {
+      method: "POST",
+    });
+    assert.equal(connection.status, 201);
+    const connectionBody = await connection.json();
+    assert.equal(connectionBody.runtime_connection.state, "connected");
+    assert.equal(
+      connectionBody.runtime_connection.manager_run_id,
+      runBody.manager_run.manager_run_id,
+    );
+    assert.equal(
+      connectionBody.runtime_connection.launch_intent_id,
+      intentBody.launch_intent.launch_intent_id,
+    );
+    assert.equal(connectionBody.runtime_connection.provider, "Copilot SDK workers");
+    assert.equal(connectionBody.runtime_connection.manager_token_budget, 30_000);
+    assert.equal(connectionBody.runtime_connection.command_policy, "not_started");
+    assert.equal(connectionBody.runtime_connection.next_required_action, "start_manager_process");
+    assert.match(connectionBody.runtime_connection.receipt_id, /^manager-runtime-receipt-/u);
+    assert.doesNotMatch(JSON.stringify(connectionBody), /sensitive manager plan preview/iu);
+
+    const repeatedConnection = await fetch(`${base}/api/manager-plan/runtime-connections`, {
+      method: "POST",
+    });
+    assert.equal(repeatedConnection.status, 201);
+    assert.equal(
+      (await repeatedConnection.json()).runtime_connection.runtime_connection_id,
+      connectionBody.runtime_connection.runtime_connection_id,
+    );
+
+    const connections = await fetch(`${base}/api/manager-plan/runtime-connections`);
+    assert.equal(connections.status, 200);
+    const connectionsBody = await connections.json();
+    assert.equal(connectionsBody.schema, "yukh-control-plane-manager-runtime-connections-v1");
+    assert.equal(connectionsBody.connections.length, 1);
+    assert.equal(
+      connectionsBody.connections[0].runtime_connection_id,
+      connectionBody.runtime_connection.runtime_connection_id,
+    );
+
     const persisted = await fetch(`${base}/api/manager-plan/previews`);
     const persistedBody = await persisted.json();
     assert.equal(persistedBody.previews.length, 2);
@@ -372,6 +418,12 @@ test("control plane preview persists local manager plan previews without leaking
     });
     assert.equal(runDenied.status, 405);
     assert.equal(runDenied.headers.get("allow"), "GET, POST");
+
+    const connectionDenied = await fetch(`${base}/api/manager-plan/runtime-connections`, {
+      method: "DELETE",
+    });
+    assert.equal(connectionDenied.status, 405);
+    assert.equal(connectionDenied.headers.get("allow"), "GET, POST");
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
@@ -412,9 +464,12 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /api\/manager-plan\/launch-readiness/u);
   assert.match(data, /api\/manager-plan\/launch-intents/u);
   assert.match(data, /api\/manager-plan\/manager-runs/u);
+  assert.match(data, /api\/manager-plan\/runtime-connections/u);
   assert.match(data, /Launch readiness/u);
   assert.match(data, /Launch intent recorded/u);
   assert.match(data, /Manager run planned/u);
+  assert.match(data, /Manager runtime connected/u);
+  assert.match(data, /command_policy/u);
   assert.match(data, /next_required_action/u);
   assert.match(data, /Persisted manager plan/u);
   assert.match(data, /Dry-run manager plan/u);
@@ -457,5 +512,6 @@ test("control plane preview has bounded text containers for operator UI", async 
   assert.match(css, /\.readiness-panel/u);
   assert.match(css, /\.launch-intent/u);
   assert.match(css, /\.manager-run/u);
+  assert.match(css, /\.runtime-connection/u);
   assert.match(css, /@media \(max-width: 640px\)/u);
 });


### PR DESCRIPTION
## Summary

Adds a local `connect_manager_runtime` transition for Control Plane manager runs.

## What changed

- Adds `GET /api/manager-plan/runtime-connections`.
- Adds `POST /api/manager-plan/runtime-connections`.
- Requires an existing manager run before connecting the runtime.
- Records a local runtime connection receipt with provider, manager token budget, `command_policy: not_started`, and next required action `start_manager_process`.
- Makes repeated connection for the same manager run idempotent by returning the existing record.
- Adds UI to connect and display the manager runtime binding.
- Documents the increment in `.context/sessions/`.

## Boundaries

This does not start Codex/Copilot, create workers, write Coordination events, write Projects state, or perform external mutations.

## Validation

- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
