### PR TITLE
Add Control Plane manager process start

### DIFF
--- a/.context/sessions/SESSION-2026-08-19-03-control-plane-start-manager-process.md
+++ b/.context/sessions/SESSION-2026-08-19-03-control-plane-start-manager-process.md
@@ -1,0 +1,38 @@
+# SESSION-2026-08-19-03 — Control Plane start manager process
+
+Date: 2026-08-19
+Repository: `nomed/yukh-mcp`
+Branch: `agent/control-plane-start-manager-process`
+
+## Objective
+
+Add the `start_manager_process` transition after a manager runtime connection,
+with hard token cap recorded before any worker delegation.
+
+## Outcome
+
+- Added `GET /api/manager-plan/manager-processes`.
+- Added `POST /api/manager-plan/manager-processes`.
+- Manager process creation requires an existing runtime connection and
+  otherwise fails with `409 runtime_connection_required`.
+- Repeated start for the same runtime connection returns the existing local
+  process record instead of creating duplicates.
+- The process records `state: starting`, provider, hard token cap, local
+  receipt, `provider_process: pending_provider_runner`,
+  `worker_delegation: disabled_until_manager_receipt`, and
+  `record_manager_ready_receipt` as the next required action.
+- The Control Plane preview UI can start and display the manager process state.
+
+## Validation
+
+- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
+- `npm run format:check`
+- `npm run typecheck`
+- `npm run build`
+- `git diff --check`
+
+## Boundaries
+
+No provider subprocess, worker creation, Coordination write, Projects write or
+external mutation was added. The provider process remains explicitly pending
+until a provider runner is connected.

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -30,6 +30,7 @@ const API_LAUNCH_READINESS_PATH = "/api/manager-plan/launch-readiness";
 const API_LAUNCH_INTENTS_PATH = "/api/manager-plan/launch-intents";
 const API_MANAGER_RUNS_PATH = "/api/manager-plan/manager-runs";
 const API_MANAGER_RUNTIME_CONNECTIONS_PATH = "/api/manager-plan/runtime-connections";
+const API_MANAGER_PROCESSES_PATH = "/api/manager-plan/manager-processes";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
@@ -257,6 +258,54 @@ export function createControlPlaneServer(
           });
           response.end(
             JSON.stringify({ schema: 1, status: "error", code: "manager_run_required" }),
+          );
+        }
+        return;
+      }
+      response.writeHead(405, {
+        allow: "GET, POST",
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+      return;
+    }
+
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_MANAGER_PROCESSES_PATH
+    ) {
+      if (!options.planPreviewStore) {
+        response.writeHead(503, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "store_unconfigured" }));
+        return;
+      }
+      if (request.method === "GET") {
+        response.writeHead(200, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify(options.planPreviewStore.managerProcesses()));
+        return;
+      }
+      if (request.method === "POST") {
+        try {
+          const record = options.planPreviewStore.startManagerProcess();
+          response.writeHead(201, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(JSON.stringify({ schema: 1, status: "ok", manager_process: record }));
+        } catch {
+          response.writeHead(409, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({ schema: 1, status: "error", code: "runtime_connection_required" }),
           );
         }
         return;

--- a/apps/control-plane-preview/src/plan-preview-store.ts
+++ b/apps/control-plane-preview/src/plan-preview-store.ts
@@ -110,6 +110,27 @@ export type ControlPlaneManagerRuntimeConnectionStatus = {
   readonly connections: readonly ControlPlaneManagerRuntimeConnectionRecord[];
 };
 
+export type ControlPlaneManagerProcessRecord = {
+  readonly schema: 1;
+  readonly manager_process_id: string;
+  readonly receipt_id: string;
+  readonly state: "starting";
+  readonly runtime_connection_id: string;
+  readonly manager_run_id: string;
+  readonly provider: string;
+  readonly hard_token_cap: number;
+  readonly provider_process: "pending_provider_runner";
+  readonly worker_delegation: "disabled_until_manager_receipt";
+  readonly created_at: string;
+  readonly next_required_action: "record_manager_ready_receipt";
+};
+
+export type ControlPlaneManagerProcessStatus = {
+  readonly schema: "yukh-control-plane-manager-processes-v1";
+  readonly source: "local-control-plane-store";
+  readonly processes: readonly ControlPlaneManagerProcessRecord[];
+};
+
 export type ControlPlanePlanPreviewInput = {
   readonly goal: string;
   readonly mode: string;
@@ -124,6 +145,7 @@ type Document = {
   readonly launch_intents?: readonly ControlPlaneLaunchIntentRecord[];
   readonly manager_runs?: readonly ControlPlaneManagerRunRecord[];
   readonly manager_runtime_connections?: readonly ControlPlaneManagerRuntimeConnectionRecord[];
+  readonly manager_processes?: readonly ControlPlaneManagerProcessRecord[];
 };
 
 const validMode = new Set(["plan-first", "delegate, explicit workers"]);
@@ -271,6 +293,49 @@ export class ControlPlanePlanPreviewStore {
     };
   }
 
+  managerProcesses(): ControlPlaneManagerProcessStatus {
+    return {
+      schema: "yukh-control-plane-manager-processes-v1",
+      source: "local-control-plane-store",
+      processes: this.#read().manager_processes ?? [],
+    };
+  }
+
+  startManagerProcess(): ControlPlaneManagerProcessRecord {
+    const document = this.#read();
+    const connection = document.manager_runtime_connections?.[0];
+    if (!connection) {
+      throw new TypeError("missing manager runtime connection");
+    }
+    const existing = document.manager_processes?.find(
+      (process) => process.runtime_connection_id === connection.runtime_connection_id,
+    );
+    if (existing) return existing;
+    const record: ControlPlaneManagerProcessRecord = {
+      schema: 1,
+      manager_process_id: `manager-process-${randomUUID()}`,
+      receipt_id: `manager-process-receipt-${randomUUID()}`,
+      state: "starting",
+      runtime_connection_id: connection.runtime_connection_id,
+      manager_run_id: connection.manager_run_id,
+      provider: connection.provider,
+      hard_token_cap: connection.manager_token_budget,
+      provider_process: "pending_provider_runner",
+      worker_delegation: "disabled_until_manager_receipt",
+      created_at: new Date().toISOString(),
+      next_required_action: "record_manager_ready_receipt",
+    };
+    this.#write({
+      schema: 1,
+      previews: document.previews,
+      launch_intents: document.launch_intents ?? [],
+      manager_runs: document.manager_runs ?? [],
+      manager_runtime_connections: document.manager_runtime_connections ?? [],
+      manager_processes: [record, ...(document.manager_processes ?? [])].slice(0, 20),
+    });
+    return record;
+  }
+
   connectManagerRuntime(): ControlPlaneManagerRuntimeConnectionRecord {
     const document = this.#read();
     const managerRun = document.manager_runs?.[0];
@@ -303,6 +368,7 @@ export class ControlPlanePlanPreviewStore {
         0,
         20,
       ),
+      manager_processes: document.manager_processes ?? [],
     });
     return record;
   }
@@ -341,6 +407,7 @@ export class ControlPlanePlanPreviewStore {
       launch_intents: document.launch_intents ?? [],
       manager_runs: [record, ...(document.manager_runs ?? [])].slice(0, 20),
       manager_runtime_connections: document.manager_runtime_connections ?? [],
+      manager_processes: document.manager_processes ?? [],
     });
     return record;
   }
@@ -375,6 +442,7 @@ export class ControlPlanePlanPreviewStore {
       launch_intents: [record, ...(document.launch_intents ?? [])].slice(0, 20),
       manager_runs: document.manager_runs ?? [],
       manager_runtime_connections: document.manager_runtime_connections ?? [],
+      manager_processes: document.manager_processes ?? [],
     });
     return record;
   }
@@ -409,6 +477,7 @@ export class ControlPlanePlanPreviewStore {
       launch_intents: document.launch_intents ?? [],
       manager_runs: document.manager_runs ?? [],
       manager_runtime_connections: document.manager_runtime_connections ?? [],
+      manager_processes: document.manager_processes ?? [],
     });
     return record;
   }
@@ -431,6 +500,9 @@ export class ControlPlanePlanPreviewStore {
         manager_runtime_connections: Array.isArray(parsed.manager_runtime_connections)
           ? parsed.manager_runtime_connections.filter((item) => item?.schema === 1)
           : [],
+        manager_processes: Array.isArray(parsed.manager_processes)
+          ? parsed.manager_processes.filter((item) => item?.schema === 1)
+          : [],
       };
     } catch {
       return {
@@ -439,6 +511,7 @@ export class ControlPlanePlanPreviewStore {
         launch_intents: [],
         manager_runs: [],
         manager_runtime_connections: [],
+        manager_processes: [],
       };
     }
   }

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -704,6 +704,21 @@ const connectManagerRuntime = async () => {
   }
 };
 
+const startManagerProcess = async () => {
+  try {
+    const response = await fetch("./api/manager-plan/manager-processes", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return body?.manager_process ?? null;
+  } catch {
+    return null;
+  }
+};
+
 const renderLaunchIntent = (intent) => {
   if (!intent) return "";
   return `
@@ -737,6 +752,19 @@ const renderRuntimeConnection = (connection) => {
       <strong>${escapeHtml(connection.runtime_connection_id)}</strong>
       <p class="muted">${escapeHtml(connection.provider)} · ${connection.manager_token_budget.toLocaleString()} manager tokens · commands ${escapeHtml(connection.command_policy)}.</p>
       <p class="muted">Next required action: ${escapeHtml(connection.next_required_action)}. No provider process has been started.</p>
+      <button type="button" class="secondary manager-process-button">Start manager process</button>
+    </div>
+  `;
+};
+
+const renderManagerProcess = (process) => {
+  if (!process) return "";
+  return `
+    <div class="manager-process">
+      <span>Manager process starting</span>
+      <strong>${escapeHtml(process.manager_process_id)}</strong>
+      <p class="muted">${escapeHtml(process.provider)} · hard cap ${process.hard_token_cap.toLocaleString()} tokens · provider ${escapeHtml(process.provider_process)}.</p>
+      <p class="muted">Worker delegation ${escapeHtml(process.worker_delegation)}. Next required action: ${escapeHtml(process.next_required_action)}.</p>
     </div>
   `;
 };
@@ -938,6 +966,22 @@ byId("plan-preview").addEventListener("click", async (event) => {
   button
     .closest(".manager-run")
     ?.insertAdjacentHTML("afterend", renderRuntimeConnection(connection));
+});
+
+byId("plan-preview").addEventListener("click", async (event) => {
+  const button = event.target.closest(".manager-process-button");
+  if (!button) return;
+  button.setAttribute("disabled", "true");
+  const process = await startManagerProcess();
+  if (!process) {
+    button.removeAttribute("disabled");
+    button.textContent = "Runtime connection required";
+    return;
+  }
+  button.textContent = "Manager process starting";
+  button
+    .closest(".runtime-connection")
+    ?.insertAdjacentHTML("afterend", renderManagerProcess(process));
 });
 
 byId("manager-plan-form").addEventListener("submit", (event) => {

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -833,6 +833,21 @@ nav a:hover {
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+.manager-process {
+  background: rgba(255, 209, 102, 0.08);
+  border: 1px solid rgba(255, 209, 102, 0.28);
+  border-radius: 16px;
+  display: grid;
+  gap: 7px;
+  padding: 12px;
+}
+.manager-process span {
+  color: var(--warn);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 .preview-card.approved-preview {
   border-color: rgba(119, 240, 178, 0.48);
 }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -258,6 +258,12 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(blockedConnection.status, 409);
     assert.equal((await blockedConnection.json()).code, "manager_run_required");
 
+    const blockedProcess = await fetch(`${base}/api/manager-plan/manager-processes`, {
+      method: "POST",
+    });
+    assert.equal(blockedProcess.status, 409);
+    assert.equal((await blockedProcess.json()).code, "runtime_connection_required");
+
     const goal = "Persist this sensitive manager plan preview locally";
     const proposed = await fetch(`${base}/api/manager-plan/previews`, {
       method: "POST",
@@ -391,6 +397,44 @@ test("control plane preview persists local manager plan previews without leaking
       connectionBody.runtime_connection.runtime_connection_id,
     );
 
+    const process = await fetch(`${base}/api/manager-plan/manager-processes`, {
+      method: "POST",
+    });
+    assert.equal(process.status, 201);
+    const processBody = await process.json();
+    assert.equal(processBody.manager_process.state, "starting");
+    assert.equal(
+      processBody.manager_process.runtime_connection_id,
+      connectionBody.runtime_connection.runtime_connection_id,
+    );
+    assert.equal(processBody.manager_process.manager_run_id, runBody.manager_run.manager_run_id);
+    assert.equal(processBody.manager_process.provider, "Copilot SDK workers");
+    assert.equal(processBody.manager_process.hard_token_cap, 30_000);
+    assert.equal(processBody.manager_process.provider_process, "pending_provider_runner");
+    assert.equal(processBody.manager_process.worker_delegation, "disabled_until_manager_receipt");
+    assert.equal(processBody.manager_process.next_required_action, "record_manager_ready_receipt");
+    assert.match(processBody.manager_process.receipt_id, /^manager-process-receipt-/u);
+    assert.doesNotMatch(JSON.stringify(processBody), /sensitive manager plan preview/iu);
+
+    const repeatedProcess = await fetch(`${base}/api/manager-plan/manager-processes`, {
+      method: "POST",
+    });
+    assert.equal(repeatedProcess.status, 201);
+    assert.equal(
+      (await repeatedProcess.json()).manager_process.manager_process_id,
+      processBody.manager_process.manager_process_id,
+    );
+
+    const processes = await fetch(`${base}/api/manager-plan/manager-processes`);
+    assert.equal(processes.status, 200);
+    const processesBody = await processes.json();
+    assert.equal(processesBody.schema, "yukh-control-plane-manager-processes-v1");
+    assert.equal(processesBody.processes.length, 1);
+    assert.equal(
+      processesBody.processes[0].manager_process_id,
+      processBody.manager_process.manager_process_id,
+    );
+
     const persisted = await fetch(`${base}/api/manager-plan/previews`);
     const persistedBody = await persisted.json();
     assert.equal(persistedBody.previews.length, 2);
@@ -424,6 +468,12 @@ test("control plane preview persists local manager plan previews without leaking
     });
     assert.equal(connectionDenied.status, 405);
     assert.equal(connectionDenied.headers.get("allow"), "GET, POST");
+
+    const processDenied = await fetch(`${base}/api/manager-plan/manager-processes`, {
+      method: "DELETE",
+    });
+    assert.equal(processDenied.status, 405);
+    assert.equal(processDenied.headers.get("allow"), "GET, POST");
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
@@ -465,10 +515,14 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /api\/manager-plan\/launch-intents/u);
   assert.match(data, /api\/manager-plan\/manager-runs/u);
   assert.match(data, /api\/manager-plan\/runtime-connections/u);
+  assert.match(data, /api\/manager-plan\/manager-processes/u);
   assert.match(data, /Launch readiness/u);
   assert.match(data, /Launch intent recorded/u);
   assert.match(data, /Manager run planned/u);
   assert.match(data, /Manager runtime connected/u);
+  assert.match(data, /Manager process starting/u);
+  assert.match(data, /provider_process/u);
+  assert.match(data, /worker_delegation/u);
   assert.match(data, /command_policy/u);
   assert.match(data, /next_required_action/u);
   assert.match(data, /Persisted manager plan/u);
@@ -513,5 +567,6 @@ test("control plane preview has bounded text containers for operator UI", async 
   assert.match(css, /\.launch-intent/u);
   assert.match(css, /\.manager-run/u);
   assert.match(css, /\.runtime-connection/u);
+  assert.match(css, /\.manager-process/u);
   assert.match(css, /@media \(max-width: 640px\)/u);
 });


### PR DESCRIPTION
## Summary

Adds the local `start_manager_process` transition after a Control Plane manager runtime connection.

## What changed

- Adds `GET /api/manager-plan/manager-processes`.
- Adds `POST /api/manager-plan/manager-processes`.
- Requires an existing runtime connection before starting the manager process.
- Records a local process receipt with `state: starting`, provider, hard token cap, pending provider runner marker, and worker delegation disabled until manager receipt.
- Makes repeated start for the same runtime connection idempotent by returning the existing process record.
- Adds UI to start and display the manager process state.
- Documents the increment in `.context/sessions/`.

## Boundaries

This does not spawn Codex/Copilot, create workers, write Coordination events, write Projects state, or perform external mutations. The provider process is explicitly marked `pending_provider_runner`.

## Validation

- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
