### PR TITLE
Add Control Plane manager ready receipt

### DIFF
--- a/.context/sessions/SESSION-2026-08-19-04-control-plane-manager-ready-receipt.md
+++ b/.context/sessions/SESSION-2026-08-19-04-control-plane-manager-ready-receipt.md
@@ -1,0 +1,30 @@
+# SESSION-2026-08-19-04 — Control Plane manager ready receipt
+
+Date: 2026-08-19
+Repository: `nomed/yukh-mcp`
+Branch: `agent/control-plane-manager-ready-receipt`
+
+## Objective
+
+Add the `record_manager_ready_receipt` gate after manager process start while keeping component ownership explicit.
+
+## Outcome
+
+- Added `GET /api/manager-plan/manager-ready-receipts`.
+- Added `POST /api/manager-plan/manager-ready-receipts`.
+- Ready receipt creation requires an existing manager process and otherwise fails with `409 manager_process_required`.
+- Repeated readiness for the same manager process returns the existing receipt instead of creating duplicates.
+- Receipt records provider, hard token cap, readiness, explicit `coordination_write: not_performed`, explicit `projects_write: not_performed`, and `prepare_worker_delegation_plan`.
+- The Control Plane preview UI can record and display the ready receipt.
+
+## Component boundaries
+
+- MCP / Control Plane owns local lifecycle gates and budgeted manager/worker orchestration receipts.
+- Coordination owns agent message transcript and message receipts.
+- Projects owns governed work items, policy/admission, roadmap and task metadata.
+
+This increment writes only MCP-local lifecycle state.
+
+## Boundaries
+
+No worker creation, Coordination write, Projects write, task mutation, roadmap mutation or provider execution was added.

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -31,6 +31,7 @@ const API_LAUNCH_INTENTS_PATH = "/api/manager-plan/launch-intents";
 const API_MANAGER_RUNS_PATH = "/api/manager-plan/manager-runs";
 const API_MANAGER_RUNTIME_CONNECTIONS_PATH = "/api/manager-plan/runtime-connections";
 const API_MANAGER_PROCESSES_PATH = "/api/manager-plan/manager-processes";
+const API_MANAGER_READY_RECEIPTS_PATH = "/api/manager-plan/manager-ready-receipts";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
@@ -306,6 +307,54 @@ export function createControlPlaneServer(
           });
           response.end(
             JSON.stringify({ schema: 1, status: "error", code: "runtime_connection_required" }),
+          );
+        }
+        return;
+      }
+      response.writeHead(405, {
+        allow: "GET, POST",
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+      return;
+    }
+
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_MANAGER_READY_RECEIPTS_PATH
+    ) {
+      if (!options.planPreviewStore) {
+        response.writeHead(503, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "store_unconfigured" }));
+        return;
+      }
+      if (request.method === "GET") {
+        response.writeHead(200, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify(options.planPreviewStore.managerReadyReceipts()));
+        return;
+      }
+      if (request.method === "POST") {
+        try {
+          const record = options.planPreviewStore.recordManagerReadyReceipt();
+          response.writeHead(201, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(JSON.stringify({ schema: 1, status: "ok", manager_ready_receipt: record }));
+        } catch {
+          response.writeHead(409, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({ schema: 1, status: "error", code: "manager_process_required" }),
           );
         }
         return;

--- a/apps/control-plane-preview/src/plan-preview-store.ts
+++ b/apps/control-plane-preview/src/plan-preview-store.ts
@@ -131,6 +131,26 @@ export type ControlPlaneManagerProcessStatus = {
   readonly processes: readonly ControlPlaneManagerProcessRecord[];
 };
 
+export type ControlPlaneManagerReadyReceiptRecord = {
+  readonly schema: 1;
+  readonly manager_ready_receipt_id: string;
+  readonly manager_process_id: string;
+  readonly manager_run_id: string;
+  readonly provider: string;
+  readonly hard_token_cap: number;
+  readonly readiness: "ready_for_worker_delegation";
+  readonly coordination_write: "not_performed";
+  readonly projects_write: "not_performed";
+  readonly created_at: string;
+  readonly next_required_action: "prepare_worker_delegation_plan";
+};
+
+export type ControlPlaneManagerReadyReceiptStatus = {
+  readonly schema: "yukh-control-plane-manager-ready-receipts-v1";
+  readonly source: "local-control-plane-store";
+  readonly receipts: readonly ControlPlaneManagerReadyReceiptRecord[];
+};
+
 export type ControlPlanePlanPreviewInput = {
   readonly goal: string;
   readonly mode: string;
@@ -146,6 +166,7 @@ type Document = {
   readonly manager_runs?: readonly ControlPlaneManagerRunRecord[];
   readonly manager_runtime_connections?: readonly ControlPlaneManagerRuntimeConnectionRecord[];
   readonly manager_processes?: readonly ControlPlaneManagerProcessRecord[];
+  readonly manager_ready_receipts?: readonly ControlPlaneManagerReadyReceiptRecord[];
 };
 
 const validMode = new Set(["plan-first", "delegate, explicit workers"]);
@@ -301,6 +322,49 @@ export class ControlPlanePlanPreviewStore {
     };
   }
 
+  managerReadyReceipts(): ControlPlaneManagerReadyReceiptStatus {
+    return {
+      schema: "yukh-control-plane-manager-ready-receipts-v1",
+      source: "local-control-plane-store",
+      receipts: this.#read().manager_ready_receipts ?? [],
+    };
+  }
+
+  recordManagerReadyReceipt(): ControlPlaneManagerReadyReceiptRecord {
+    const document = this.#read();
+    const process = document.manager_processes?.[0];
+    if (!process) {
+      throw new TypeError("missing manager process");
+    }
+    const existing = document.manager_ready_receipts?.find(
+      (receipt) => receipt.manager_process_id === process.manager_process_id,
+    );
+    if (existing) return existing;
+    const record: ControlPlaneManagerReadyReceiptRecord = {
+      schema: 1,
+      manager_ready_receipt_id: `manager-ready-receipt-${randomUUID()}`,
+      manager_process_id: process.manager_process_id,
+      manager_run_id: process.manager_run_id,
+      provider: process.provider,
+      hard_token_cap: process.hard_token_cap,
+      readiness: "ready_for_worker_delegation",
+      coordination_write: "not_performed",
+      projects_write: "not_performed",
+      created_at: new Date().toISOString(),
+      next_required_action: "prepare_worker_delegation_plan",
+    };
+    this.#write({
+      schema: 1,
+      previews: document.previews,
+      launch_intents: document.launch_intents ?? [],
+      manager_runs: document.manager_runs ?? [],
+      manager_runtime_connections: document.manager_runtime_connections ?? [],
+      manager_processes: document.manager_processes ?? [],
+      manager_ready_receipts: [record, ...(document.manager_ready_receipts ?? [])].slice(0, 20),
+    });
+    return record;
+  }
+
   startManagerProcess(): ControlPlaneManagerProcessRecord {
     const document = this.#read();
     const connection = document.manager_runtime_connections?.[0];
@@ -332,6 +396,7 @@ export class ControlPlanePlanPreviewStore {
       manager_runs: document.manager_runs ?? [],
       manager_runtime_connections: document.manager_runtime_connections ?? [],
       manager_processes: [record, ...(document.manager_processes ?? [])].slice(0, 20),
+      manager_ready_receipts: document.manager_ready_receipts ?? [],
     });
     return record;
   }
@@ -369,6 +434,7 @@ export class ControlPlanePlanPreviewStore {
         20,
       ),
       manager_processes: document.manager_processes ?? [],
+      manager_ready_receipts: document.manager_ready_receipts ?? [],
     });
     return record;
   }
@@ -408,6 +474,7 @@ export class ControlPlanePlanPreviewStore {
       manager_runs: [record, ...(document.manager_runs ?? [])].slice(0, 20),
       manager_runtime_connections: document.manager_runtime_connections ?? [],
       manager_processes: document.manager_processes ?? [],
+      manager_ready_receipts: document.manager_ready_receipts ?? [],
     });
     return record;
   }
@@ -443,6 +510,7 @@ export class ControlPlanePlanPreviewStore {
       manager_runs: document.manager_runs ?? [],
       manager_runtime_connections: document.manager_runtime_connections ?? [],
       manager_processes: document.manager_processes ?? [],
+      manager_ready_receipts: document.manager_ready_receipts ?? [],
     });
     return record;
   }
@@ -478,6 +546,7 @@ export class ControlPlanePlanPreviewStore {
       manager_runs: document.manager_runs ?? [],
       manager_runtime_connections: document.manager_runtime_connections ?? [],
       manager_processes: document.manager_processes ?? [],
+      manager_ready_receipts: document.manager_ready_receipts ?? [],
     });
     return record;
   }
@@ -503,6 +572,9 @@ export class ControlPlanePlanPreviewStore {
         manager_processes: Array.isArray(parsed.manager_processes)
           ? parsed.manager_processes.filter((item) => item?.schema === 1)
           : [],
+        manager_ready_receipts: Array.isArray(parsed.manager_ready_receipts)
+          ? parsed.manager_ready_receipts.filter((item) => item?.schema === 1)
+          : [],
       };
     } catch {
       return {
@@ -512,6 +584,7 @@ export class ControlPlanePlanPreviewStore {
         manager_runs: [],
         manager_runtime_connections: [],
         manager_processes: [],
+        manager_ready_receipts: [],
       };
     }
   }

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -719,6 +719,21 @@ const startManagerProcess = async () => {
   }
 };
 
+const recordManagerReadyReceipt = async () => {
+  try {
+    const response = await fetch("./api/manager-plan/manager-ready-receipts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return body?.manager_ready_receipt ?? null;
+  } catch {
+    return null;
+  }
+};
+
 const renderLaunchIntent = (intent) => {
   if (!intent) return "";
   return `
@@ -765,6 +780,20 @@ const renderManagerProcess = (process) => {
       <strong>${escapeHtml(process.manager_process_id)}</strong>
       <p class="muted">${escapeHtml(process.provider)} · hard cap ${process.hard_token_cap.toLocaleString()} tokens · provider ${escapeHtml(process.provider_process)}.</p>
       <p class="muted">Worker delegation ${escapeHtml(process.worker_delegation)}. Next required action: ${escapeHtml(process.next_required_action)}.</p>
+      <button type="button" class="secondary manager-ready-button">Record manager ready receipt</button>
+    </div>
+  `;
+};
+
+const renderManagerReadyReceipt = (receipt) => {
+  if (!receipt) return "";
+  return `
+    <div class="manager-ready-receipt">
+      <span>Manager ready receipt</span>
+      <strong>${escapeHtml(receipt.manager_ready_receipt_id)}</strong>
+      <p class="muted">${escapeHtml(receipt.readiness)} · hard cap ${receipt.hard_token_cap.toLocaleString()} tokens.</p>
+      <p class="muted">Coordination write: ${escapeHtml(receipt.coordination_write)} · Projects write: ${escapeHtml(receipt.projects_write)}.</p>
+      <p class="muted">Next required action: ${escapeHtml(receipt.next_required_action)}.</p>
     </div>
   `;
 };
@@ -982,6 +1011,22 @@ byId("plan-preview").addEventListener("click", async (event) => {
   button
     .closest(".runtime-connection")
     ?.insertAdjacentHTML("afterend", renderManagerProcess(process));
+});
+
+byId("plan-preview").addEventListener("click", async (event) => {
+  const button = event.target.closest(".manager-ready-button");
+  if (!button) return;
+  button.setAttribute("disabled", "true");
+  const receipt = await recordManagerReadyReceipt();
+  if (!receipt) {
+    button.removeAttribute("disabled");
+    button.textContent = "Manager process required";
+    return;
+  }
+  button.textContent = "Manager ready receipt recorded";
+  button
+    .closest(".manager-process")
+    ?.insertAdjacentHTML("afterend", renderManagerReadyReceipt(receipt));
 });
 
 byId("manager-plan-form").addEventListener("submit", (event) => {

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -848,6 +848,21 @@ nav a:hover {
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+.manager-ready-receipt {
+  background: rgba(119, 240, 178, 0.08);
+  border: 1px solid rgba(119, 240, 178, 0.28);
+  border-radius: 16px;
+  display: grid;
+  gap: 7px;
+  padding: 12px;
+}
+.manager-ready-receipt span {
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 .preview-card.approved-preview {
   border-color: rgba(119, 240, 178, 0.48);
 }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -264,6 +264,12 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(blockedProcess.status, 409);
     assert.equal((await blockedProcess.json()).code, "runtime_connection_required");
 
+    const blockedReady = await fetch(`${base}/api/manager-plan/manager-ready-receipts`, {
+      method: "POST",
+    });
+    assert.equal(blockedReady.status, 409);
+    assert.equal((await blockedReady.json()).code, "manager_process_required");
+
     const goal = "Persist this sensitive manager plan preview locally";
     const proposed = await fetch(`${base}/api/manager-plan/previews`, {
       method: "POST",
@@ -435,6 +441,49 @@ test("control plane preview persists local manager plan previews without leaking
       processBody.manager_process.manager_process_id,
     );
 
+    const ready = await fetch(`${base}/api/manager-plan/manager-ready-receipts`, {
+      method: "POST",
+    });
+    assert.equal(ready.status, 201);
+    const readyBody = await ready.json();
+    assert.equal(
+      readyBody.manager_ready_receipt.manager_process_id,
+      processBody.manager_process.manager_process_id,
+    );
+    assert.equal(
+      readyBody.manager_ready_receipt.manager_run_id,
+      runBody.manager_run.manager_run_id,
+    );
+    assert.equal(readyBody.manager_ready_receipt.provider, "Copilot SDK workers");
+    assert.equal(readyBody.manager_ready_receipt.hard_token_cap, 30_000);
+    assert.equal(readyBody.manager_ready_receipt.readiness, "ready_for_worker_delegation");
+    assert.equal(readyBody.manager_ready_receipt.coordination_write, "not_performed");
+    assert.equal(readyBody.manager_ready_receipt.projects_write, "not_performed");
+    assert.equal(
+      readyBody.manager_ready_receipt.next_required_action,
+      "prepare_worker_delegation_plan",
+    );
+    assert.match(
+      readyBody.manager_ready_receipt.manager_ready_receipt_id,
+      /^manager-ready-receipt-/u,
+    );
+    assert.doesNotMatch(JSON.stringify(readyBody), /sensitive manager plan preview/iu);
+
+    const repeatedReady = await fetch(`${base}/api/manager-plan/manager-ready-receipts`, {
+      method: "POST",
+    });
+    assert.equal(repeatedReady.status, 201);
+    assert.equal(
+      (await repeatedReady.json()).manager_ready_receipt.manager_ready_receipt_id,
+      readyBody.manager_ready_receipt.manager_ready_receipt_id,
+    );
+
+    const readyReceipts = await fetch(`${base}/api/manager-plan/manager-ready-receipts`);
+    assert.equal(readyReceipts.status, 200);
+    const readyReceiptsBody = await readyReceipts.json();
+    assert.equal(readyReceiptsBody.schema, "yukh-control-plane-manager-ready-receipts-v1");
+    assert.equal(readyReceiptsBody.receipts.length, 1);
+
     const persisted = await fetch(`${base}/api/manager-plan/previews`);
     const persistedBody = await persisted.json();
     assert.equal(persistedBody.previews.length, 2);
@@ -474,6 +523,12 @@ test("control plane preview persists local manager plan previews without leaking
     });
     assert.equal(processDenied.status, 405);
     assert.equal(processDenied.headers.get("allow"), "GET, POST");
+
+    const readyDenied = await fetch(`${base}/api/manager-plan/manager-ready-receipts`, {
+      method: "DELETE",
+    });
+    assert.equal(readyDenied.status, 405);
+    assert.equal(readyDenied.headers.get("allow"), "GET, POST");
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
@@ -516,13 +571,17 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /api\/manager-plan\/manager-runs/u);
   assert.match(data, /api\/manager-plan\/runtime-connections/u);
   assert.match(data, /api\/manager-plan\/manager-processes/u);
+  assert.match(data, /api\/manager-plan\/manager-ready-receipts/u);
   assert.match(data, /Launch readiness/u);
   assert.match(data, /Launch intent recorded/u);
   assert.match(data, /Manager run planned/u);
   assert.match(data, /Manager runtime connected/u);
   assert.match(data, /Manager process starting/u);
+  assert.match(data, /Manager ready receipt/u);
   assert.match(data, /provider_process/u);
   assert.match(data, /worker_delegation/u);
+  assert.match(data, /coordination_write/u);
+  assert.match(data, /projects_write/u);
   assert.match(data, /command_policy/u);
   assert.match(data, /next_required_action/u);
   assert.match(data, /Persisted manager plan/u);
@@ -568,5 +627,6 @@ test("control plane preview has bounded text containers for operator UI", async 
   assert.match(css, /\.manager-run/u);
   assert.match(css, /\.runtime-connection/u);
   assert.match(css, /\.manager-process/u);
+  assert.match(css, /\.manager-ready-receipt/u);
   assert.match(css, /@media \(max-width: 640px\)/u);
 });


### PR DESCRIPTION
## What changed

- Adds `GET /api/manager-plan/manager-ready-receipts`.
- Adds `POST /api/manager-plan/manager-ready-receipts`.
- Records an idempotent manager ready receipt after `start_manager_process`.
- Shows the ready receipt in the Control Plane preview UI.
- Documents the lifecycle boundary in a session note.

## Component boundaries

This is intentionally MCP / Control Plane local state only.

- MCP / Control Plane: lifecycle gates, manager process readiness, local budget/orchestration receipts.
- Coordination: agent message transcript and message receipts. No Coordination write is performed here.
- Projects: work items, admission/policy, roadmap and task metadata. No Projects write is performed here.

The receipt explicitly records `coordination_write: not_performed` and `projects_write: not_performed` to prevent semantic overlap.

## Validation

- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
