### PR TITLE
Add Control Plane worker delegation plan

### DIFF
--- a/.context/sessions/SESSION-2026-08-19-05-control-plane-worker-delegation-plan.md
+++ b/.context/sessions/SESSION-2026-08-19-05-control-plane-worker-delegation-plan.md
@@ -1,0 +1,32 @@
+# SESSION-2026-08-19-05 — Control Plane worker delegation plan
+
+Date: 2026-08-19
+Repository: `nomed/yukh-mcp`
+Branch: `agent/control-plane-worker-delegation-plan`
+
+## Objective
+
+Add the `prepare_worker_delegation_plan` gate after the manager ready receipt without launching workers.
+
+## Outcome
+
+- Added `GET /api/manager-plan/worker-delegation-plans`.
+- Added `POST /api/manager-plan/worker-delegation-plans`.
+- Worker delegation plan creation requires an existing manager ready receipt and otherwise fails with `409 manager_ready_receipt_required`.
+- Repeated preparation for the same manager ready receipt returns the existing plan.
+- Worker plans derive roles and budgets from the existing launch intent.
+- Worker inputs are stored as digests only; goal text is not persisted in the plan.
+- Worker records include provider, deferred model selection, token budget, command policy and planned status.
+- The Control Plane preview UI can prepare and display the worker delegation plan.
+
+## Component boundaries
+
+- MCP / Control Plane owns local lifecycle gates, budgeted worker delegation plans and orchestration receipts.
+- Coordination owns agent message transcript and message receipts.
+- Projects owns governed work items, policy/admission, roadmap and task metadata.
+
+This increment writes only MCP-local lifecycle state.
+
+## Boundaries
+
+No worker process, provider execution, Coordination write, Projects write, task mutation or roadmap mutation was added.

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -32,6 +32,7 @@ const API_MANAGER_RUNS_PATH = "/api/manager-plan/manager-runs";
 const API_MANAGER_RUNTIME_CONNECTIONS_PATH = "/api/manager-plan/runtime-connections";
 const API_MANAGER_PROCESSES_PATH = "/api/manager-plan/manager-processes";
 const API_MANAGER_READY_RECEIPTS_PATH = "/api/manager-plan/manager-ready-receipts";
+const API_WORKER_DELEGATION_PLANS_PATH = "/api/manager-plan/worker-delegation-plans";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
@@ -355,6 +356,54 @@ export function createControlPlaneServer(
           });
           response.end(
             JSON.stringify({ schema: 1, status: "error", code: "manager_process_required" }),
+          );
+        }
+        return;
+      }
+      response.writeHead(405, {
+        allow: "GET, POST",
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+      return;
+    }
+
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_WORKER_DELEGATION_PLANS_PATH
+    ) {
+      if (!options.planPreviewStore) {
+        response.writeHead(503, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "store_unconfigured" }));
+        return;
+      }
+      if (request.method === "GET") {
+        response.writeHead(200, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify(options.planPreviewStore.workerDelegationPlans()));
+        return;
+      }
+      if (request.method === "POST") {
+        try {
+          const record = options.planPreviewStore.prepareWorkerDelegationPlan();
+          response.writeHead(201, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(JSON.stringify({ schema: 1, status: "ok", worker_delegation_plan: record }));
+        } catch {
+          response.writeHead(409, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({ schema: 1, status: "error", code: "manager_ready_receipt_required" }),
           );
         }
         return;

--- a/apps/control-plane-preview/src/plan-preview-store.ts
+++ b/apps/control-plane-preview/src/plan-preview-store.ts
@@ -151,6 +151,38 @@ export type ControlPlaneManagerReadyReceiptStatus = {
   readonly receipts: readonly ControlPlaneManagerReadyReceiptRecord[];
 };
 
+export type ControlPlaneWorkerDelegationPlanRecord = {
+  readonly schema: 1;
+  readonly worker_delegation_plan_id: string;
+  readonly manager_ready_receipt_id: string;
+  readonly manager_process_id: string;
+  readonly manager_run_id: string;
+  readonly launch_intent_id: string;
+  readonly provider: string;
+  readonly total_worker_token_budget: number;
+  readonly worker_launch: "not_performed";
+  readonly coordination_write: "not_performed";
+  readonly projects_write: "not_performed";
+  readonly workers: readonly {
+    readonly role: string;
+    readonly provider: string;
+    readonly model: string;
+    readonly model_source: "deferred_to_provider_inventory";
+    readonly token_budget: number;
+    readonly input_digest: `sha-256:${string}`;
+    readonly command_policy: "not_started";
+    readonly status: "planned";
+  }[];
+  readonly created_at: string;
+  readonly next_required_action: "approve_worker_delegation_plan";
+};
+
+export type ControlPlaneWorkerDelegationPlanStatus = {
+  readonly schema: "yukh-control-plane-worker-delegation-plans-v1";
+  readonly source: "local-control-plane-store";
+  readonly plans: readonly ControlPlaneWorkerDelegationPlanRecord[];
+};
+
 export type ControlPlanePlanPreviewInput = {
   readonly goal: string;
   readonly mode: string;
@@ -167,6 +199,7 @@ type Document = {
   readonly manager_runtime_connections?: readonly ControlPlaneManagerRuntimeConnectionRecord[];
   readonly manager_processes?: readonly ControlPlaneManagerProcessRecord[];
   readonly manager_ready_receipts?: readonly ControlPlaneManagerReadyReceiptRecord[];
+  readonly worker_delegation_plans?: readonly ControlPlaneWorkerDelegationPlanRecord[];
 };
 
 const validMode = new Set(["plan-first", "delegate, explicit workers"]);
@@ -192,6 +225,12 @@ function workersForGoal(
   const unique = [...new Set(roles)];
   const perWorker = unique.length > 0 ? Math.floor(workerReserve / unique.length) : 0;
   return unique.map((role) => ({ role, token_budget: perWorker }));
+}
+
+function modelForProvider(provider: string): string {
+  if (provider === "Copilot SDK workers") return "copilot-sdk-default";
+  if (provider === "Codex SDK, planned") return "codex-sdk-default";
+  return "codex-cli-default";
 }
 
 function validateInput(input: ControlPlanePlanPreviewInput): void {
@@ -330,6 +369,74 @@ export class ControlPlanePlanPreviewStore {
     };
   }
 
+  workerDelegationPlans(): ControlPlaneWorkerDelegationPlanStatus {
+    return {
+      schema: "yukh-control-plane-worker-delegation-plans-v1",
+      source: "local-control-plane-store",
+      plans: this.#read().worker_delegation_plans ?? [],
+    };
+  }
+
+  prepareWorkerDelegationPlan(): ControlPlaneWorkerDelegationPlanRecord {
+    const document = this.#read();
+    const readyReceipt = document.manager_ready_receipts?.[0];
+    if (!readyReceipt) {
+      throw new TypeError("missing manager ready receipt");
+    }
+    const existing = document.worker_delegation_plans?.find(
+      (plan) => plan.manager_ready_receipt_id === readyReceipt.manager_ready_receipt_id,
+    );
+    if (existing) return existing;
+    const managerRun = document.manager_runs?.find(
+      (run) => run.manager_run_id === readyReceipt.manager_run_id,
+    );
+    const launchIntent = document.launch_intents?.find(
+      (intent) => intent.launch_intent_id === managerRun?.launch_intent_id,
+    );
+    if (!managerRun || !launchIntent) {
+      throw new TypeError("missing launch intent");
+    }
+    const workers = launchIntent.proposed_workers.map((worker) => ({
+      role: worker.role,
+      provider: readyReceipt.provider,
+      model: modelForProvider(readyReceipt.provider),
+      model_source: "deferred_to_provider_inventory" as const,
+      token_budget: worker.token_budget,
+      input_digest: digest(
+        `${launchIntent.preview_receipt_id}:${readyReceipt.manager_ready_receipt_id}:${worker.role}`,
+      ),
+      command_policy: "not_started" as const,
+      status: "planned" as const,
+    }));
+    const record: ControlPlaneWorkerDelegationPlanRecord = {
+      schema: 1,
+      worker_delegation_plan_id: `worker-delegation-plan-${randomUUID()}`,
+      manager_ready_receipt_id: readyReceipt.manager_ready_receipt_id,
+      manager_process_id: readyReceipt.manager_process_id,
+      manager_run_id: readyReceipt.manager_run_id,
+      launch_intent_id: launchIntent.launch_intent_id,
+      provider: readyReceipt.provider,
+      total_worker_token_budget: workers.reduce((total, worker) => total + worker.token_budget, 0),
+      worker_launch: "not_performed",
+      coordination_write: "not_performed",
+      projects_write: "not_performed",
+      workers,
+      created_at: new Date().toISOString(),
+      next_required_action: "approve_worker_delegation_plan",
+    };
+    this.#write({
+      schema: 1,
+      previews: document.previews,
+      launch_intents: document.launch_intents ?? [],
+      manager_runs: document.manager_runs ?? [],
+      manager_runtime_connections: document.manager_runtime_connections ?? [],
+      manager_processes: document.manager_processes ?? [],
+      manager_ready_receipts: document.manager_ready_receipts ?? [],
+      worker_delegation_plans: [record, ...(document.worker_delegation_plans ?? [])].slice(0, 20),
+    });
+    return record;
+  }
+
   recordManagerReadyReceipt(): ControlPlaneManagerReadyReceiptRecord {
     const document = this.#read();
     const process = document.manager_processes?.[0];
@@ -361,6 +468,7 @@ export class ControlPlanePlanPreviewStore {
       manager_runtime_connections: document.manager_runtime_connections ?? [],
       manager_processes: document.manager_processes ?? [],
       manager_ready_receipts: [record, ...(document.manager_ready_receipts ?? [])].slice(0, 20),
+      worker_delegation_plans: document.worker_delegation_plans ?? [],
     });
     return record;
   }
@@ -397,6 +505,7 @@ export class ControlPlanePlanPreviewStore {
       manager_runtime_connections: document.manager_runtime_connections ?? [],
       manager_processes: [record, ...(document.manager_processes ?? [])].slice(0, 20),
       manager_ready_receipts: document.manager_ready_receipts ?? [],
+      worker_delegation_plans: document.worker_delegation_plans ?? [],
     });
     return record;
   }
@@ -435,6 +544,7 @@ export class ControlPlanePlanPreviewStore {
       ),
       manager_processes: document.manager_processes ?? [],
       manager_ready_receipts: document.manager_ready_receipts ?? [],
+      worker_delegation_plans: document.worker_delegation_plans ?? [],
     });
     return record;
   }
@@ -475,6 +585,7 @@ export class ControlPlanePlanPreviewStore {
       manager_runtime_connections: document.manager_runtime_connections ?? [],
       manager_processes: document.manager_processes ?? [],
       manager_ready_receipts: document.manager_ready_receipts ?? [],
+      worker_delegation_plans: document.worker_delegation_plans ?? [],
     });
     return record;
   }
@@ -511,6 +622,7 @@ export class ControlPlanePlanPreviewStore {
       manager_runtime_connections: document.manager_runtime_connections ?? [],
       manager_processes: document.manager_processes ?? [],
       manager_ready_receipts: document.manager_ready_receipts ?? [],
+      worker_delegation_plans: document.worker_delegation_plans ?? [],
     });
     return record;
   }
@@ -547,6 +659,7 @@ export class ControlPlanePlanPreviewStore {
       manager_runtime_connections: document.manager_runtime_connections ?? [],
       manager_processes: document.manager_processes ?? [],
       manager_ready_receipts: document.manager_ready_receipts ?? [],
+      worker_delegation_plans: document.worker_delegation_plans ?? [],
     });
     return record;
   }
@@ -575,6 +688,9 @@ export class ControlPlanePlanPreviewStore {
         manager_ready_receipts: Array.isArray(parsed.manager_ready_receipts)
           ? parsed.manager_ready_receipts.filter((item) => item?.schema === 1)
           : [],
+        worker_delegation_plans: Array.isArray(parsed.worker_delegation_plans)
+          ? parsed.worker_delegation_plans.filter((item) => item?.schema === 1)
+          : [],
       };
     } catch {
       return {
@@ -585,6 +701,7 @@ export class ControlPlanePlanPreviewStore {
         manager_runtime_connections: [],
         manager_processes: [],
         manager_ready_receipts: [],
+        worker_delegation_plans: [],
       };
     }
   }

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -734,6 +734,21 @@ const recordManagerReadyReceipt = async () => {
   }
 };
 
+const prepareWorkerDelegationPlan = async () => {
+  try {
+    const response = await fetch("./api/manager-plan/worker-delegation-plans", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return body?.worker_delegation_plan ?? null;
+  } catch {
+    return null;
+  }
+};
+
 const renderLaunchIntent = (intent) => {
   if (!intent) return "";
   return `
@@ -794,6 +809,35 @@ const renderManagerReadyReceipt = (receipt) => {
       <p class="muted">${escapeHtml(receipt.readiness)} · hard cap ${receipt.hard_token_cap.toLocaleString()} tokens.</p>
       <p class="muted">Coordination write: ${escapeHtml(receipt.coordination_write)} · Projects write: ${escapeHtml(receipt.projects_write)}.</p>
       <p class="muted">Next required action: ${escapeHtml(receipt.next_required_action)}.</p>
+      <button type="button" class="secondary worker-plan-button">Prepare worker delegation plan</button>
+    </div>
+  `;
+};
+
+const renderWorkerDelegationPlan = (plan) => {
+  if (!plan) return "";
+  return `
+    <div class="worker-delegation-plan">
+      <span>Worker delegation plan</span>
+      <strong>${escapeHtml(plan.worker_delegation_plan_id)}</strong>
+      <p class="muted">${plan.workers.length.toLocaleString()} workers · ${plan.total_worker_token_budget.toLocaleString()} worker tokens · launch ${escapeHtml(plan.worker_launch)}.</p>
+      <div class="worker-plan-grid">
+        ${plan.workers
+          .map(
+            (worker) => `
+              <article>
+                <span>${escapeHtml(worker.role)}</span>
+                <strong>${escapeHtml(worker.model)}</strong>
+                <p class="muted">Model source: ${escapeHtml(worker.model_source)}</p>
+                <p class="muted">${worker.token_budget.toLocaleString()} tokens · ${escapeHtml(worker.command_policy)} · ${escapeHtml(worker.status)}</p>
+                <p class="muted clamp-2">Input ${escapeHtml(worker.input_digest)}</p>
+              </article>
+            `,
+          )
+          .join("")}
+      </div>
+      <p class="muted">Coordination write: ${escapeHtml(plan.coordination_write)} · Projects write: ${escapeHtml(plan.projects_write)}.</p>
+      <p class="muted">Next required action: ${escapeHtml(plan.next_required_action)}.</p>
     </div>
   `;
 };
@@ -1027,6 +1071,22 @@ byId("plan-preview").addEventListener("click", async (event) => {
   button
     .closest(".manager-process")
     ?.insertAdjacentHTML("afterend", renderManagerReadyReceipt(receipt));
+});
+
+byId("plan-preview").addEventListener("click", async (event) => {
+  const button = event.target.closest(".worker-plan-button");
+  if (!button) return;
+  button.setAttribute("disabled", "true");
+  const plan = await prepareWorkerDelegationPlan();
+  if (!plan) {
+    button.removeAttribute("disabled");
+    button.textContent = "Manager ready receipt required";
+    return;
+  }
+  button.textContent = "Worker delegation plan prepared";
+  button
+    .closest(".manager-ready-receipt")
+    ?.insertAdjacentHTML("afterend", renderWorkerDelegationPlan(plan));
 });
 
 byId("manager-plan-form").addEventListener("submit", (event) => {

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -863,6 +863,37 @@ nav a:hover {
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+.worker-delegation-plan {
+  background: rgba(125, 140, 255, 0.08);
+  border: 1px solid rgba(125, 140, 255, 0.28);
+  border-radius: 16px;
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+.worker-delegation-plan span,
+.worker-plan-grid span {
+  color: var(--accent-2);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.worker-plan-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  min-width: 0;
+}
+.worker-plan-grid article {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+  padding: 10px;
+}
 .preview-card.approved-preview {
   border-color: rgba(119, 240, 178, 0.48);
 }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -270,6 +270,12 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(blockedReady.status, 409);
     assert.equal((await blockedReady.json()).code, "manager_process_required");
 
+    const blockedWorkerPlan = await fetch(`${base}/api/manager-plan/worker-delegation-plans`, {
+      method: "POST",
+    });
+    assert.equal(blockedWorkerPlan.status, 409);
+    assert.equal((await blockedWorkerPlan.json()).code, "manager_ready_receipt_required");
+
     const goal = "Persist this sensitive manager plan preview locally";
     const proposed = await fetch(`${base}/api/manager-plan/previews`, {
       method: "POST",
@@ -484,6 +490,76 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(readyReceiptsBody.schema, "yukh-control-plane-manager-ready-receipts-v1");
     assert.equal(readyReceiptsBody.receipts.length, 1);
 
+    const workerPlan = await fetch(`${base}/api/manager-plan/worker-delegation-plans`, {
+      method: "POST",
+    });
+    assert.equal(workerPlan.status, 201);
+    const workerPlanBody = await workerPlan.json();
+    assert.equal(
+      workerPlanBody.worker_delegation_plan.manager_ready_receipt_id,
+      readyBody.manager_ready_receipt.manager_ready_receipt_id,
+    );
+    assert.equal(
+      workerPlanBody.worker_delegation_plan.manager_process_id,
+      processBody.manager_process.manager_process_id,
+    );
+    assert.equal(
+      workerPlanBody.worker_delegation_plan.manager_run_id,
+      runBody.manager_run.manager_run_id,
+    );
+    assert.equal(
+      workerPlanBody.worker_delegation_plan.launch_intent_id,
+      intentBody.launch_intent.launch_intent_id,
+    );
+    assert.equal(workerPlanBody.worker_delegation_plan.provider, "Copilot SDK workers");
+    assert.equal(
+      workerPlanBody.worker_delegation_plan.total_worker_token_budget,
+      intentBody.launch_intent.worker_reserve,
+    );
+    assert.equal(workerPlanBody.worker_delegation_plan.worker_launch, "not_performed");
+    assert.equal(workerPlanBody.worker_delegation_plan.coordination_write, "not_performed");
+    assert.equal(workerPlanBody.worker_delegation_plan.projects_write, "not_performed");
+    assert.equal(
+      workerPlanBody.worker_delegation_plan.next_required_action,
+      "approve_worker_delegation_plan",
+    );
+    assert.match(
+      workerPlanBody.worker_delegation_plan.worker_delegation_plan_id,
+      /^worker-delegation-plan-/u,
+    );
+    assert.equal(
+      workerPlanBody.worker_delegation_plan.workers.length,
+      intentBody.launch_intent.proposed_workers.length,
+    );
+    assert.equal(workerPlanBody.worker_delegation_plan.workers[0].provider, "Copilot SDK workers");
+    assert.equal(workerPlanBody.worker_delegation_plan.workers[0].model, "copilot-sdk-default");
+    assert.equal(
+      workerPlanBody.worker_delegation_plan.workers[0].model_source,
+      "deferred_to_provider_inventory",
+    );
+    assert.equal(workerPlanBody.worker_delegation_plan.workers[0].command_policy, "not_started");
+    assert.equal(workerPlanBody.worker_delegation_plan.workers[0].status, "planned");
+    assert.match(
+      workerPlanBody.worker_delegation_plan.workers[0].input_digest,
+      /^sha-256:[a-f0-9]{64}$/u,
+    );
+    assert.doesNotMatch(JSON.stringify(workerPlanBody), /sensitive manager plan preview/iu);
+
+    const repeatedWorkerPlan = await fetch(`${base}/api/manager-plan/worker-delegation-plans`, {
+      method: "POST",
+    });
+    assert.equal(repeatedWorkerPlan.status, 201);
+    assert.equal(
+      (await repeatedWorkerPlan.json()).worker_delegation_plan.worker_delegation_plan_id,
+      workerPlanBody.worker_delegation_plan.worker_delegation_plan_id,
+    );
+
+    const workerPlans = await fetch(`${base}/api/manager-plan/worker-delegation-plans`);
+    assert.equal(workerPlans.status, 200);
+    const workerPlansBody = await workerPlans.json();
+    assert.equal(workerPlansBody.schema, "yukh-control-plane-worker-delegation-plans-v1");
+    assert.equal(workerPlansBody.plans.length, 1);
+
     const persisted = await fetch(`${base}/api/manager-plan/previews`);
     const persistedBody = await persisted.json();
     assert.equal(persistedBody.previews.length, 2);
@@ -529,6 +605,12 @@ test("control plane preview persists local manager plan previews without leaking
     });
     assert.equal(readyDenied.status, 405);
     assert.equal(readyDenied.headers.get("allow"), "GET, POST");
+
+    const workerPlanDenied = await fetch(`${base}/api/manager-plan/worker-delegation-plans`, {
+      method: "DELETE",
+    });
+    assert.equal(workerPlanDenied.status, 405);
+    assert.equal(workerPlanDenied.headers.get("allow"), "GET, POST");
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
@@ -572,14 +654,18 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /api\/manager-plan\/runtime-connections/u);
   assert.match(data, /api\/manager-plan\/manager-processes/u);
   assert.match(data, /api\/manager-plan\/manager-ready-receipts/u);
+  assert.match(data, /api\/manager-plan\/worker-delegation-plans/u);
   assert.match(data, /Launch readiness/u);
   assert.match(data, /Launch intent recorded/u);
   assert.match(data, /Manager run planned/u);
   assert.match(data, /Manager runtime connected/u);
   assert.match(data, /Manager process starting/u);
   assert.match(data, /Manager ready receipt/u);
+  assert.match(data, /Worker delegation plan/u);
   assert.match(data, /provider_process/u);
   assert.match(data, /worker_delegation/u);
+  assert.match(data, /worker_launch/u);
+  assert.match(data, /model_source/u);
   assert.match(data, /coordination_write/u);
   assert.match(data, /projects_write/u);
   assert.match(data, /command_policy/u);
@@ -628,5 +714,7 @@ test("control plane preview has bounded text containers for operator UI", async 
   assert.match(css, /\.runtime-connection/u);
   assert.match(css, /\.manager-process/u);
   assert.match(css, /\.manager-ready-receipt/u);
+  assert.match(css, /\.worker-delegation-plan/u);
+  assert.match(css, /\.worker-plan-grid/u);
   assert.match(css, /@media \(max-width: 640px\)/u);
 });


### PR DESCRIPTION
## What changed

- Adds `GET /api/manager-plan/worker-delegation-plans`.
- Adds `POST /api/manager-plan/worker-delegation-plans`.
- Creates an idempotent worker delegation plan after the manager ready receipt gate.
- Derives worker roles and budgets from the existing launch intent instead of duplicating task state.
- Stores worker input digests only, not goal text.
- Shows the worker delegation plan in the Control Plane preview UI.
- Documents the lifecycle boundary in a session note.

## Component boundaries

This is intentionally MCP / Control Plane local state only.

- MCP / Control Plane: lifecycle gates, worker delegation plans, local budget/orchestration receipts.
- Coordination: agent message transcript and message receipts. No Coordination write is performed here.
- Projects: work items, admission/policy, roadmap and task metadata. No Projects write is performed here.

The plan explicitly records `worker_launch: not_performed`, `coordination_write: not_performed`, and `projects_write: not_performed`.

## Validation

- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
