### PR TITLE
Add Control Plane worker plan approval

### DIFF
--- a/.context/sessions/SESSION-2026-08-19-06-control-plane-approve-worker-delegation-plan.md
+++ b/.context/sessions/SESSION-2026-08-19-06-control-plane-approve-worker-delegation-plan.md
@@ -1,0 +1,30 @@
+# SESSION-2026-08-19-06 — Control Plane approve worker delegation plan
+
+Date: 2026-08-19
+Repository: `nomed/yukh-mcp`
+Branch: `agent/control-plane-approve-worker-plan`
+
+## Objective
+
+Add the `approve_worker_delegation_plan` gate after worker delegation plan preparation without launching workers.
+
+## Outcome
+
+- Added `GET /api/manager-plan/worker-delegation-approvals`.
+- Added `POST /api/manager-plan/worker-delegation-approvals`.
+- Worker delegation approval requires an existing worker delegation plan and otherwise fails with `409 worker_delegation_plan_required`.
+- Repeated approval for the same worker delegation plan returns the existing approval receipt.
+- Approval records worker count, approved worker token budget, local-only scope, and the next required action `launch_approved_workers`.
+- The Control Plane preview UI can approve and display the worker delegation approval.
+
+## Component boundaries
+
+- MCP / Control Plane owns local lifecycle approvals and budgeted orchestration receipts.
+- Coordination owns agent message transcript and message receipts.
+- Projects owns governed work items, policy/admission, roadmap and task metadata.
+
+This increment writes only MCP-local lifecycle state.
+
+## Boundaries
+
+No worker process, provider execution, Coordination write, Projects write, task mutation or roadmap mutation was added.

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -33,6 +33,7 @@ const API_MANAGER_RUNTIME_CONNECTIONS_PATH = "/api/manager-plan/runtime-connecti
 const API_MANAGER_PROCESSES_PATH = "/api/manager-plan/manager-processes";
 const API_MANAGER_READY_RECEIPTS_PATH = "/api/manager-plan/manager-ready-receipts";
 const API_WORKER_DELEGATION_PLANS_PATH = "/api/manager-plan/worker-delegation-plans";
+const API_WORKER_DELEGATION_APPROVALS_PATH = "/api/manager-plan/worker-delegation-approvals";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
@@ -404,6 +405,60 @@ export function createControlPlaneServer(
           });
           response.end(
             JSON.stringify({ schema: 1, status: "error", code: "manager_ready_receipt_required" }),
+          );
+        }
+        return;
+      }
+      response.writeHead(405, {
+        allow: "GET, POST",
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+      return;
+    }
+
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_WORKER_DELEGATION_APPROVALS_PATH
+    ) {
+      if (!options.planPreviewStore) {
+        response.writeHead(503, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "store_unconfigured" }));
+        return;
+      }
+      if (request.method === "GET") {
+        response.writeHead(200, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify(options.planPreviewStore.workerDelegationApprovals()));
+        return;
+      }
+      if (request.method === "POST") {
+        try {
+          const record = options.planPreviewStore.approveWorkerDelegationPlan();
+          response.writeHead(201, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({ schema: 1, status: "ok", worker_delegation_approval: record }),
+          );
+        } catch {
+          response.writeHead(409, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({
+              schema: 1,
+              status: "error",
+              code: "worker_delegation_plan_required",
+            }),
           );
         }
         return;

--- a/apps/control-plane-preview/src/plan-preview-store.ts
+++ b/apps/control-plane-preview/src/plan-preview-store.ts
@@ -183,6 +183,29 @@ export type ControlPlaneWorkerDelegationPlanStatus = {
   readonly plans: readonly ControlPlaneWorkerDelegationPlanRecord[];
 };
 
+export type ControlPlaneWorkerDelegationApprovalRecord = {
+  readonly schema: 1;
+  readonly worker_delegation_approval_id: string;
+  readonly worker_delegation_plan_id: string;
+  readonly manager_ready_receipt_id: string;
+  readonly manager_process_id: string;
+  readonly manager_run_id: string;
+  readonly approved_worker_count: number;
+  readonly approved_worker_token_budget: number;
+  readonly approval_scope: "local_control_plane_only";
+  readonly worker_launch: "not_performed";
+  readonly coordination_write: "not_performed";
+  readonly projects_write: "not_performed";
+  readonly created_at: string;
+  readonly next_required_action: "launch_approved_workers";
+};
+
+export type ControlPlaneWorkerDelegationApprovalStatus = {
+  readonly schema: "yukh-control-plane-worker-delegation-approvals-v1";
+  readonly source: "local-control-plane-store";
+  readonly approvals: readonly ControlPlaneWorkerDelegationApprovalRecord[];
+};
+
 export type ControlPlanePlanPreviewInput = {
   readonly goal: string;
   readonly mode: string;
@@ -200,6 +223,7 @@ type Document = {
   readonly manager_processes?: readonly ControlPlaneManagerProcessRecord[];
   readonly manager_ready_receipts?: readonly ControlPlaneManagerReadyReceiptRecord[];
   readonly worker_delegation_plans?: readonly ControlPlaneWorkerDelegationPlanRecord[];
+  readonly worker_delegation_approvals?: readonly ControlPlaneWorkerDelegationApprovalRecord[];
 };
 
 const validMode = new Set(["plan-first", "delegate, explicit workers"]);
@@ -377,6 +401,57 @@ export class ControlPlanePlanPreviewStore {
     };
   }
 
+  workerDelegationApprovals(): ControlPlaneWorkerDelegationApprovalStatus {
+    return {
+      schema: "yukh-control-plane-worker-delegation-approvals-v1",
+      source: "local-control-plane-store",
+      approvals: this.#read().worker_delegation_approvals ?? [],
+    };
+  }
+
+  approveWorkerDelegationPlan(): ControlPlaneWorkerDelegationApprovalRecord {
+    const document = this.#read();
+    const plan = document.worker_delegation_plans?.[0];
+    if (!plan) {
+      throw new TypeError("missing worker delegation plan");
+    }
+    const existing = document.worker_delegation_approvals?.find(
+      (approval) => approval.worker_delegation_plan_id === plan.worker_delegation_plan_id,
+    );
+    if (existing) return existing;
+    const record: ControlPlaneWorkerDelegationApprovalRecord = {
+      schema: 1,
+      worker_delegation_approval_id: `worker-delegation-approval-${randomUUID()}`,
+      worker_delegation_plan_id: plan.worker_delegation_plan_id,
+      manager_ready_receipt_id: plan.manager_ready_receipt_id,
+      manager_process_id: plan.manager_process_id,
+      manager_run_id: plan.manager_run_id,
+      approved_worker_count: plan.workers.length,
+      approved_worker_token_budget: plan.total_worker_token_budget,
+      approval_scope: "local_control_plane_only",
+      worker_launch: "not_performed",
+      coordination_write: "not_performed",
+      projects_write: "not_performed",
+      created_at: new Date().toISOString(),
+      next_required_action: "launch_approved_workers",
+    };
+    this.#write({
+      schema: 1,
+      previews: document.previews,
+      launch_intents: document.launch_intents ?? [],
+      manager_runs: document.manager_runs ?? [],
+      manager_runtime_connections: document.manager_runtime_connections ?? [],
+      manager_processes: document.manager_processes ?? [],
+      manager_ready_receipts: document.manager_ready_receipts ?? [],
+      worker_delegation_plans: document.worker_delegation_plans ?? [],
+      worker_delegation_approvals: [record, ...(document.worker_delegation_approvals ?? [])].slice(
+        0,
+        20,
+      ),
+    });
+    return record;
+  }
+
   prepareWorkerDelegationPlan(): ControlPlaneWorkerDelegationPlanRecord {
     const document = this.#read();
     const readyReceipt = document.manager_ready_receipts?.[0];
@@ -433,6 +508,7 @@ export class ControlPlanePlanPreviewStore {
       manager_processes: document.manager_processes ?? [],
       manager_ready_receipts: document.manager_ready_receipts ?? [],
       worker_delegation_plans: [record, ...(document.worker_delegation_plans ?? [])].slice(0, 20),
+      worker_delegation_approvals: document.worker_delegation_approvals ?? [],
     });
     return record;
   }
@@ -469,6 +545,7 @@ export class ControlPlanePlanPreviewStore {
       manager_processes: document.manager_processes ?? [],
       manager_ready_receipts: [record, ...(document.manager_ready_receipts ?? [])].slice(0, 20),
       worker_delegation_plans: document.worker_delegation_plans ?? [],
+      worker_delegation_approvals: document.worker_delegation_approvals ?? [],
     });
     return record;
   }
@@ -506,6 +583,7 @@ export class ControlPlanePlanPreviewStore {
       manager_processes: [record, ...(document.manager_processes ?? [])].slice(0, 20),
       manager_ready_receipts: document.manager_ready_receipts ?? [],
       worker_delegation_plans: document.worker_delegation_plans ?? [],
+      worker_delegation_approvals: document.worker_delegation_approvals ?? [],
     });
     return record;
   }
@@ -545,6 +623,7 @@ export class ControlPlanePlanPreviewStore {
       manager_processes: document.manager_processes ?? [],
       manager_ready_receipts: document.manager_ready_receipts ?? [],
       worker_delegation_plans: document.worker_delegation_plans ?? [],
+      worker_delegation_approvals: document.worker_delegation_approvals ?? [],
     });
     return record;
   }
@@ -586,6 +665,7 @@ export class ControlPlanePlanPreviewStore {
       manager_processes: document.manager_processes ?? [],
       manager_ready_receipts: document.manager_ready_receipts ?? [],
       worker_delegation_plans: document.worker_delegation_plans ?? [],
+      worker_delegation_approvals: document.worker_delegation_approvals ?? [],
     });
     return record;
   }
@@ -623,6 +703,7 @@ export class ControlPlanePlanPreviewStore {
       manager_processes: document.manager_processes ?? [],
       manager_ready_receipts: document.manager_ready_receipts ?? [],
       worker_delegation_plans: document.worker_delegation_plans ?? [],
+      worker_delegation_approvals: document.worker_delegation_approvals ?? [],
     });
     return record;
   }
@@ -660,6 +741,7 @@ export class ControlPlanePlanPreviewStore {
       manager_processes: document.manager_processes ?? [],
       manager_ready_receipts: document.manager_ready_receipts ?? [],
       worker_delegation_plans: document.worker_delegation_plans ?? [],
+      worker_delegation_approvals: document.worker_delegation_approvals ?? [],
     });
     return record;
   }
@@ -691,6 +773,9 @@ export class ControlPlanePlanPreviewStore {
         worker_delegation_plans: Array.isArray(parsed.worker_delegation_plans)
           ? parsed.worker_delegation_plans.filter((item) => item?.schema === 1)
           : [],
+        worker_delegation_approvals: Array.isArray(parsed.worker_delegation_approvals)
+          ? parsed.worker_delegation_approvals.filter((item) => item?.schema === 1)
+          : [],
       };
     } catch {
       return {
@@ -702,6 +787,7 @@ export class ControlPlanePlanPreviewStore {
         manager_processes: [],
         manager_ready_receipts: [],
         worker_delegation_plans: [],
+        worker_delegation_approvals: [],
       };
     }
   }

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -749,6 +749,21 @@ const prepareWorkerDelegationPlan = async () => {
   }
 };
 
+const approveWorkerDelegationPlan = async () => {
+  try {
+    const response = await fetch("./api/manager-plan/worker-delegation-approvals", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return body?.worker_delegation_approval ?? null;
+  } catch {
+    return null;
+  }
+};
+
 const renderLaunchIntent = (intent) => {
   if (!intent) return "";
   return `
@@ -838,6 +853,20 @@ const renderWorkerDelegationPlan = (plan) => {
       </div>
       <p class="muted">Coordination write: ${escapeHtml(plan.coordination_write)} · Projects write: ${escapeHtml(plan.projects_write)}.</p>
       <p class="muted">Next required action: ${escapeHtml(plan.next_required_action)}.</p>
+      <button type="button" class="secondary worker-approval-button">Approve worker delegation plan</button>
+    </div>
+  `;
+};
+
+const renderWorkerDelegationApproval = (approval) => {
+  if (!approval) return "";
+  return `
+    <div class="worker-delegation-approval">
+      <span>Worker delegation approved</span>
+      <strong>${escapeHtml(approval.worker_delegation_approval_id)}</strong>
+      <p class="muted">${approval.approved_worker_count.toLocaleString()} workers · ${approval.approved_worker_token_budget.toLocaleString()} approved worker tokens · scope ${escapeHtml(approval.approval_scope)}.</p>
+      <p class="muted">Worker launch: ${escapeHtml(approval.worker_launch)} · Coordination write: ${escapeHtml(approval.coordination_write)} · Projects write: ${escapeHtml(approval.projects_write)}.</p>
+      <p class="muted">Next required action: ${escapeHtml(approval.next_required_action)}.</p>
     </div>
   `;
 };
@@ -1087,6 +1116,22 @@ byId("plan-preview").addEventListener("click", async (event) => {
   button
     .closest(".manager-ready-receipt")
     ?.insertAdjacentHTML("afterend", renderWorkerDelegationPlan(plan));
+});
+
+byId("plan-preview").addEventListener("click", async (event) => {
+  const button = event.target.closest(".worker-approval-button");
+  if (!button) return;
+  button.setAttribute("disabled", "true");
+  const approval = await approveWorkerDelegationPlan();
+  if (!approval) {
+    button.removeAttribute("disabled");
+    button.textContent = "Worker plan required";
+    return;
+  }
+  button.textContent = "Worker delegation approved";
+  button
+    .closest(".worker-delegation-plan")
+    ?.insertAdjacentHTML("afterend", renderWorkerDelegationApproval(approval));
 });
 
 byId("manager-plan-form").addEventListener("submit", (event) => {

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -894,6 +894,21 @@ nav a:hover {
   min-width: 0;
   padding: 10px;
 }
+.worker-delegation-approval {
+  background: rgba(119, 240, 178, 0.08);
+  border: 1px solid rgba(119, 240, 178, 0.28);
+  border-radius: 16px;
+  display: grid;
+  gap: 7px;
+  padding: 12px;
+}
+.worker-delegation-approval span {
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 .preview-card.approved-preview {
   border-color: rgba(119, 240, 178, 0.48);
 }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -276,6 +276,15 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(blockedWorkerPlan.status, 409);
     assert.equal((await blockedWorkerPlan.json()).code, "manager_ready_receipt_required");
 
+    const blockedWorkerApproval = await fetch(
+      `${base}/api/manager-plan/worker-delegation-approvals`,
+      {
+        method: "POST",
+      },
+    );
+    assert.equal(blockedWorkerApproval.status, 409);
+    assert.equal((await blockedWorkerApproval.json()).code, "worker_delegation_plan_required");
+
     const goal = "Persist this sensitive manager plan preview locally";
     const proposed = await fetch(`${base}/api/manager-plan/previews`, {
       method: "POST",
@@ -560,6 +569,66 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(workerPlansBody.schema, "yukh-control-plane-worker-delegation-plans-v1");
     assert.equal(workerPlansBody.plans.length, 1);
 
+    const workerApproval = await fetch(`${base}/api/manager-plan/worker-delegation-approvals`, {
+      method: "POST",
+    });
+    assert.equal(workerApproval.status, 201);
+    const workerApprovalBody = await workerApproval.json();
+    assert.equal(
+      workerApprovalBody.worker_delegation_approval.worker_delegation_plan_id,
+      workerPlanBody.worker_delegation_plan.worker_delegation_plan_id,
+    );
+    assert.equal(
+      workerApprovalBody.worker_delegation_approval.manager_ready_receipt_id,
+      readyBody.manager_ready_receipt.manager_ready_receipt_id,
+    );
+    assert.equal(
+      workerApprovalBody.worker_delegation_approval.manager_process_id,
+      processBody.manager_process.manager_process_id,
+    );
+    assert.equal(
+      workerApprovalBody.worker_delegation_approval.manager_run_id,
+      runBody.manager_run.manager_run_id,
+    );
+    assert.equal(workerApprovalBody.worker_delegation_approval.approved_worker_count, 2);
+    assert.equal(
+      workerApprovalBody.worker_delegation_approval.approved_worker_token_budget,
+      workerPlanBody.worker_delegation_plan.total_worker_token_budget,
+    );
+    assert.equal(
+      workerApprovalBody.worker_delegation_approval.approval_scope,
+      "local_control_plane_only",
+    );
+    assert.equal(workerApprovalBody.worker_delegation_approval.worker_launch, "not_performed");
+    assert.equal(workerApprovalBody.worker_delegation_approval.coordination_write, "not_performed");
+    assert.equal(workerApprovalBody.worker_delegation_approval.projects_write, "not_performed");
+    assert.equal(
+      workerApprovalBody.worker_delegation_approval.next_required_action,
+      "launch_approved_workers",
+    );
+    assert.match(
+      workerApprovalBody.worker_delegation_approval.worker_delegation_approval_id,
+      /^worker-delegation-approval-/u,
+    );
+    assert.doesNotMatch(JSON.stringify(workerApprovalBody), /sensitive manager plan preview/iu);
+
+    const repeatedWorkerApproval = await fetch(
+      `${base}/api/manager-plan/worker-delegation-approvals`,
+      { method: "POST" },
+    );
+    assert.equal(repeatedWorkerApproval.status, 201);
+    assert.equal(
+      (await repeatedWorkerApproval.json()).worker_delegation_approval
+        .worker_delegation_approval_id,
+      workerApprovalBody.worker_delegation_approval.worker_delegation_approval_id,
+    );
+
+    const workerApprovals = await fetch(`${base}/api/manager-plan/worker-delegation-approvals`);
+    assert.equal(workerApprovals.status, 200);
+    const workerApprovalsBody = await workerApprovals.json();
+    assert.equal(workerApprovalsBody.schema, "yukh-control-plane-worker-delegation-approvals-v1");
+    assert.equal(workerApprovalsBody.approvals.length, 1);
+
     const persisted = await fetch(`${base}/api/manager-plan/previews`);
     const persistedBody = await persisted.json();
     assert.equal(persistedBody.previews.length, 2);
@@ -611,6 +680,13 @@ test("control plane preview persists local manager plan previews without leaking
     });
     assert.equal(workerPlanDenied.status, 405);
     assert.equal(workerPlanDenied.headers.get("allow"), "GET, POST");
+
+    const workerApprovalDenied = await fetch(
+      `${base}/api/manager-plan/worker-delegation-approvals`,
+      { method: "DELETE" },
+    );
+    assert.equal(workerApprovalDenied.status, 405);
+    assert.equal(workerApprovalDenied.headers.get("allow"), "GET, POST");
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
@@ -655,6 +731,7 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /api\/manager-plan\/manager-processes/u);
   assert.match(data, /api\/manager-plan\/manager-ready-receipts/u);
   assert.match(data, /api\/manager-plan\/worker-delegation-plans/u);
+  assert.match(data, /api\/manager-plan\/worker-delegation-approvals/u);
   assert.match(data, /Launch readiness/u);
   assert.match(data, /Launch intent recorded/u);
   assert.match(data, /Manager run planned/u);
@@ -662,9 +739,11 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /Manager process starting/u);
   assert.match(data, /Manager ready receipt/u);
   assert.match(data, /Worker delegation plan/u);
+  assert.match(data, /Worker delegation approved/u);
   assert.match(data, /provider_process/u);
   assert.match(data, /worker_delegation/u);
   assert.match(data, /worker_launch/u);
+  assert.match(data, /approval_scope/u);
   assert.match(data, /model_source/u);
   assert.match(data, /coordination_write/u);
   assert.match(data, /projects_write/u);
@@ -716,5 +795,6 @@ test("control plane preview has bounded text containers for operator UI", async 
   assert.match(css, /\.manager-ready-receipt/u);
   assert.match(css, /\.worker-delegation-plan/u);
   assert.match(css, /\.worker-plan-grid/u);
+  assert.match(css, /\.worker-delegation-approval/u);
   assert.match(css, /@media \(max-width: 640px\)/u);
 });


### PR DESCRIPTION
## What changed

- Adds `GET /api/manager-plan/worker-delegation-approvals`.
- Adds `POST /api/manager-plan/worker-delegation-approvals`.
- Creates an idempotent local approval receipt after `prepare_worker_delegation_plan`.
- Records worker count, approved worker token budget, local-only approval scope and next required action.
- Shows the approval receipt in the Control Plane preview UI.
- Documents the lifecycle boundary in a session note.

## Component boundaries

This remains MCP / Control Plane local lifecycle state only.

- MCP / Control Plane: local approval gates, budgeted orchestration receipts.
- Coordination: agent message transcript and message receipts. No Coordination write is performed here.
- Projects: work items, admission/policy, roadmap and task metadata. No Projects write is performed here.

The approval explicitly records `approval_scope: local_control_plane_only`, `worker_launch: not_performed`, `coordination_write: not_performed`, and `projects_write: not_performed`.

## Validation

- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
