### PR TITLE
Add Control Plane worker launch preflight

### DIFF
--- a/.context/sessions/SESSION-2026-08-19-07-control-plane-worker-launch-preflight.md
+++ b/.context/sessions/SESSION-2026-08-19-07-control-plane-worker-launch-preflight.md
@@ -1,0 +1,31 @@
+# SESSION-2026-08-19-07 — Control Plane worker launch preflight
+
+Date: 2026-08-19
+Repository: `nomed/yukh-mcp`
+Branch: `agent/control-plane-launch-workers-preflight`
+
+## Objective
+
+Add the `launch_approved_workers` preflight gate after worker delegation approval without launching workers.
+
+## Outcome
+
+- Added `GET /api/manager-plan/worker-launch-preflights`.
+- Added `POST /api/manager-plan/worker-launch-preflights`.
+- Worker launch preflight requires an existing worker delegation approval and otherwise fails with `409 worker_delegation_approval_required`.
+- Repeated preflight for the same worker delegation approval returns the existing preflight receipt.
+- Preflight records local policy and budget checks as satisfied.
+- Preflight records provider runtime and provider capability inventory as still requiring a separate probe.
+- The Control Plane preview UI can record and display the preflight.
+
+## Component boundaries
+
+- MCP / Control Plane owns local lifecycle preflight receipts and budget/policy readiness.
+- Coordination owns agent message transcript and message receipts.
+- Projects owns governed work items, policy/admission, roadmap and task metadata.
+
+This increment writes only MCP-local lifecycle state.
+
+## Boundaries
+
+No worker process, provider execution, Coordination write, Projects write, task mutation or roadmap mutation was added.

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -34,6 +34,7 @@ const API_MANAGER_PROCESSES_PATH = "/api/manager-plan/manager-processes";
 const API_MANAGER_READY_RECEIPTS_PATH = "/api/manager-plan/manager-ready-receipts";
 const API_WORKER_DELEGATION_PLANS_PATH = "/api/manager-plan/worker-delegation-plans";
 const API_WORKER_DELEGATION_APPROVALS_PATH = "/api/manager-plan/worker-delegation-approvals";
+const API_WORKER_LAUNCH_PREFLIGHTS_PATH = "/api/manager-plan/worker-launch-preflights";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
@@ -458,6 +459,60 @@ export function createControlPlaneServer(
               schema: 1,
               status: "error",
               code: "worker_delegation_plan_required",
+            }),
+          );
+        }
+        return;
+      }
+      response.writeHead(405, {
+        allow: "GET, POST",
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+      return;
+    }
+
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_WORKER_LAUNCH_PREFLIGHTS_PATH
+    ) {
+      if (!options.planPreviewStore) {
+        response.writeHead(503, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "store_unconfigured" }));
+        return;
+      }
+      if (request.method === "GET") {
+        response.writeHead(200, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify(options.planPreviewStore.workerLaunchPreflights()));
+        return;
+      }
+      if (request.method === "POST") {
+        try {
+          const record = options.planPreviewStore.preflightApprovedWorkerLaunch();
+          response.writeHead(201, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({ schema: 1, status: "ok", worker_launch_preflight: record }),
+          );
+        } catch {
+          response.writeHead(409, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({
+              schema: 1,
+              status: "error",
+              code: "worker_delegation_approval_required",
             }),
           );
         }

--- a/apps/control-plane-preview/src/plan-preview-store.ts
+++ b/apps/control-plane-preview/src/plan-preview-store.ts
@@ -206,6 +206,34 @@ export type ControlPlaneWorkerDelegationApprovalStatus = {
   readonly approvals: readonly ControlPlaneWorkerDelegationApprovalRecord[];
 };
 
+export type ControlPlaneWorkerLaunchPreflightRecord = {
+  readonly schema: 1;
+  readonly worker_launch_preflight_id: string;
+  readonly worker_delegation_approval_id: string;
+  readonly worker_delegation_plan_id: string;
+  readonly manager_ready_receipt_id: string;
+  readonly manager_process_id: string;
+  readonly manager_run_id: string;
+  readonly approved_worker_count: number;
+  readonly approved_worker_token_budget: number;
+  readonly outcome: "blocked_until_provider_runtime_probe";
+  readonly provider_runtime_check: "requires_provider_runtime_probe";
+  readonly policy_check: "local_approval_present";
+  readonly budget_check: "within_approved_worker_budget";
+  readonly capability_check: "requires_provider_capability_inventory";
+  readonly worker_launch: "not_performed";
+  readonly coordination_write: "not_performed";
+  readonly projects_write: "not_performed";
+  readonly created_at: string;
+  readonly next_required_action: "probe_provider_runtime";
+};
+
+export type ControlPlaneWorkerLaunchPreflightStatus = {
+  readonly schema: "yukh-control-plane-worker-launch-preflights-v1";
+  readonly source: "local-control-plane-store";
+  readonly preflights: readonly ControlPlaneWorkerLaunchPreflightRecord[];
+};
+
 export type ControlPlanePlanPreviewInput = {
   readonly goal: string;
   readonly mode: string;
@@ -224,6 +252,7 @@ type Document = {
   readonly manager_ready_receipts?: readonly ControlPlaneManagerReadyReceiptRecord[];
   readonly worker_delegation_plans?: readonly ControlPlaneWorkerDelegationPlanRecord[];
   readonly worker_delegation_approvals?: readonly ControlPlaneWorkerDelegationApprovalRecord[];
+  readonly worker_launch_preflights?: readonly ControlPlaneWorkerLaunchPreflightRecord[];
 };
 
 const validMode = new Set(["plan-first", "delegate, explicit workers"]);
@@ -409,6 +438,61 @@ export class ControlPlanePlanPreviewStore {
     };
   }
 
+  workerLaunchPreflights(): ControlPlaneWorkerLaunchPreflightStatus {
+    return {
+      schema: "yukh-control-plane-worker-launch-preflights-v1",
+      source: "local-control-plane-store",
+      preflights: this.#read().worker_launch_preflights ?? [],
+    };
+  }
+
+  preflightApprovedWorkerLaunch(): ControlPlaneWorkerLaunchPreflightRecord {
+    const document = this.#read();
+    const approval = document.worker_delegation_approvals?.[0];
+    if (!approval) {
+      throw new TypeError("missing worker delegation approval");
+    }
+    const existing = document.worker_launch_preflights?.find(
+      (preflight) =>
+        preflight.worker_delegation_approval_id === approval.worker_delegation_approval_id,
+    );
+    if (existing) return existing;
+    const record: ControlPlaneWorkerLaunchPreflightRecord = {
+      schema: 1,
+      worker_launch_preflight_id: `worker-launch-preflight-${randomUUID()}`,
+      worker_delegation_approval_id: approval.worker_delegation_approval_id,
+      worker_delegation_plan_id: approval.worker_delegation_plan_id,
+      manager_ready_receipt_id: approval.manager_ready_receipt_id,
+      manager_process_id: approval.manager_process_id,
+      manager_run_id: approval.manager_run_id,
+      approved_worker_count: approval.approved_worker_count,
+      approved_worker_token_budget: approval.approved_worker_token_budget,
+      outcome: "blocked_until_provider_runtime_probe",
+      provider_runtime_check: "requires_provider_runtime_probe",
+      policy_check: "local_approval_present",
+      budget_check: "within_approved_worker_budget",
+      capability_check: "requires_provider_capability_inventory",
+      worker_launch: "not_performed",
+      coordination_write: "not_performed",
+      projects_write: "not_performed",
+      created_at: new Date().toISOString(),
+      next_required_action: "probe_provider_runtime",
+    };
+    this.#write({
+      schema: 1,
+      previews: document.previews,
+      launch_intents: document.launch_intents ?? [],
+      manager_runs: document.manager_runs ?? [],
+      manager_runtime_connections: document.manager_runtime_connections ?? [],
+      manager_processes: document.manager_processes ?? [],
+      manager_ready_receipts: document.manager_ready_receipts ?? [],
+      worker_delegation_plans: document.worker_delegation_plans ?? [],
+      worker_delegation_approvals: document.worker_delegation_approvals ?? [],
+      worker_launch_preflights: [record, ...(document.worker_launch_preflights ?? [])].slice(0, 20),
+    });
+    return record;
+  }
+
   approveWorkerDelegationPlan(): ControlPlaneWorkerDelegationApprovalRecord {
     const document = this.#read();
     const plan = document.worker_delegation_plans?.[0];
@@ -448,6 +532,7 @@ export class ControlPlanePlanPreviewStore {
         0,
         20,
       ),
+      worker_launch_preflights: document.worker_launch_preflights ?? [],
     });
     return record;
   }
@@ -509,6 +594,7 @@ export class ControlPlanePlanPreviewStore {
       manager_ready_receipts: document.manager_ready_receipts ?? [],
       worker_delegation_plans: [record, ...(document.worker_delegation_plans ?? [])].slice(0, 20),
       worker_delegation_approvals: document.worker_delegation_approvals ?? [],
+      worker_launch_preflights: document.worker_launch_preflights ?? [],
     });
     return record;
   }
@@ -546,6 +632,7 @@ export class ControlPlanePlanPreviewStore {
       manager_ready_receipts: [record, ...(document.manager_ready_receipts ?? [])].slice(0, 20),
       worker_delegation_plans: document.worker_delegation_plans ?? [],
       worker_delegation_approvals: document.worker_delegation_approvals ?? [],
+      worker_launch_preflights: document.worker_launch_preflights ?? [],
     });
     return record;
   }
@@ -584,6 +671,7 @@ export class ControlPlanePlanPreviewStore {
       manager_ready_receipts: document.manager_ready_receipts ?? [],
       worker_delegation_plans: document.worker_delegation_plans ?? [],
       worker_delegation_approvals: document.worker_delegation_approvals ?? [],
+      worker_launch_preflights: document.worker_launch_preflights ?? [],
     });
     return record;
   }
@@ -624,6 +712,7 @@ export class ControlPlanePlanPreviewStore {
       manager_ready_receipts: document.manager_ready_receipts ?? [],
       worker_delegation_plans: document.worker_delegation_plans ?? [],
       worker_delegation_approvals: document.worker_delegation_approvals ?? [],
+      worker_launch_preflights: document.worker_launch_preflights ?? [],
     });
     return record;
   }
@@ -666,6 +755,7 @@ export class ControlPlanePlanPreviewStore {
       manager_ready_receipts: document.manager_ready_receipts ?? [],
       worker_delegation_plans: document.worker_delegation_plans ?? [],
       worker_delegation_approvals: document.worker_delegation_approvals ?? [],
+      worker_launch_preflights: document.worker_launch_preflights ?? [],
     });
     return record;
   }
@@ -704,6 +794,7 @@ export class ControlPlanePlanPreviewStore {
       manager_ready_receipts: document.manager_ready_receipts ?? [],
       worker_delegation_plans: document.worker_delegation_plans ?? [],
       worker_delegation_approvals: document.worker_delegation_approvals ?? [],
+      worker_launch_preflights: document.worker_launch_preflights ?? [],
     });
     return record;
   }
@@ -742,6 +833,7 @@ export class ControlPlanePlanPreviewStore {
       manager_ready_receipts: document.manager_ready_receipts ?? [],
       worker_delegation_plans: document.worker_delegation_plans ?? [],
       worker_delegation_approvals: document.worker_delegation_approvals ?? [],
+      worker_launch_preflights: document.worker_launch_preflights ?? [],
     });
     return record;
   }
@@ -776,6 +868,9 @@ export class ControlPlanePlanPreviewStore {
         worker_delegation_approvals: Array.isArray(parsed.worker_delegation_approvals)
           ? parsed.worker_delegation_approvals.filter((item) => item?.schema === 1)
           : [],
+        worker_launch_preflights: Array.isArray(parsed.worker_launch_preflights)
+          ? parsed.worker_launch_preflights.filter((item) => item?.schema === 1)
+          : [],
       };
     } catch {
       return {
@@ -788,6 +883,7 @@ export class ControlPlanePlanPreviewStore {
         manager_ready_receipts: [],
         worker_delegation_plans: [],
         worker_delegation_approvals: [],
+        worker_launch_preflights: [],
       };
     }
   }

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -764,6 +764,21 @@ const approveWorkerDelegationPlan = async () => {
   }
 };
 
+const preflightApprovedWorkerLaunch = async () => {
+  try {
+    const response = await fetch("./api/manager-plan/worker-launch-preflights", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return body?.worker_launch_preflight ?? null;
+  } catch {
+    return null;
+  }
+};
+
 const renderLaunchIntent = (intent) => {
   if (!intent) return "";
   return `
@@ -867,6 +882,26 @@ const renderWorkerDelegationApproval = (approval) => {
       <p class="muted">${approval.approved_worker_count.toLocaleString()} workers · ${approval.approved_worker_token_budget.toLocaleString()} approved worker tokens · scope ${escapeHtml(approval.approval_scope)}.</p>
       <p class="muted">Worker launch: ${escapeHtml(approval.worker_launch)} · Coordination write: ${escapeHtml(approval.coordination_write)} · Projects write: ${escapeHtml(approval.projects_write)}.</p>
       <p class="muted">Next required action: ${escapeHtml(approval.next_required_action)}.</p>
+      <button type="button" class="secondary worker-preflight-button">Preflight approved worker launch</button>
+    </div>
+  `;
+};
+
+const renderWorkerLaunchPreflight = (preflight) => {
+  if (!preflight) return "";
+  return `
+    <div class="worker-launch-preflight">
+      <span>Worker launch preflight</span>
+      <strong>${escapeHtml(preflight.worker_launch_preflight_id)}</strong>
+      <p class="muted">${preflight.approved_worker_count.toLocaleString()} workers · ${preflight.approved_worker_token_budget.toLocaleString()} approved worker tokens · outcome ${escapeHtml(preflight.outcome)}.</p>
+      <div class="preflight-grid">
+        <article><span>Policy</span><strong>${escapeHtml(preflight.policy_check)}</strong></article>
+        <article><span>Budget</span><strong>${escapeHtml(preflight.budget_check)}</strong></article>
+        <article><span>Runtime</span><strong>${escapeHtml(preflight.provider_runtime_check)}</strong></article>
+        <article><span>Capability</span><strong>${escapeHtml(preflight.capability_check)}</strong></article>
+      </div>
+      <p class="muted">Worker launch: ${escapeHtml(preflight.worker_launch)} · Coordination write: ${escapeHtml(preflight.coordination_write)} · Projects write: ${escapeHtml(preflight.projects_write)}.</p>
+      <p class="muted">Next required action: ${escapeHtml(preflight.next_required_action)}.</p>
     </div>
   `;
 };
@@ -1132,6 +1167,22 @@ byId("plan-preview").addEventListener("click", async (event) => {
   button
     .closest(".worker-delegation-plan")
     ?.insertAdjacentHTML("afterend", renderWorkerDelegationApproval(approval));
+});
+
+byId("plan-preview").addEventListener("click", async (event) => {
+  const button = event.target.closest(".worker-preflight-button");
+  if (!button) return;
+  button.setAttribute("disabled", "true");
+  const preflight = await preflightApprovedWorkerLaunch();
+  if (!preflight) {
+    button.removeAttribute("disabled");
+    button.textContent = "Worker approval required";
+    return;
+  }
+  button.textContent = "Worker launch preflight recorded";
+  button
+    .closest(".worker-delegation-approval")
+    ?.insertAdjacentHTML("afterend", renderWorkerLaunchPreflight(preflight));
 });
 
 byId("manager-plan-form").addEventListener("submit", (event) => {

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -909,6 +909,37 @@ nav a:hover {
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+.worker-launch-preflight {
+  background: rgba(255, 209, 102, 0.08);
+  border: 1px solid rgba(255, 209, 102, 0.28);
+  border-radius: 16px;
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+.worker-launch-preflight span,
+.preflight-grid span {
+  color: var(--warn);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.preflight-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  min-width: 0;
+}
+.preflight-grid article {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+  padding: 10px;
+}
 .preview-card.approved-preview {
   border-color: rgba(119, 240, 178, 0.48);
 }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -285,6 +285,15 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(blockedWorkerApproval.status, 409);
     assert.equal((await blockedWorkerApproval.json()).code, "worker_delegation_plan_required");
 
+    const blockedWorkerPreflight = await fetch(
+      `${base}/api/manager-plan/worker-launch-preflights`,
+      {
+        method: "POST",
+      },
+    );
+    assert.equal(blockedWorkerPreflight.status, 409);
+    assert.equal((await blockedWorkerPreflight.json()).code, "worker_delegation_approval_required");
+
     const goal = "Persist this sensitive manager plan preview locally";
     const proposed = await fetch(`${base}/api/manager-plan/previews`, {
       method: "POST",
@@ -629,6 +638,85 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(workerApprovalsBody.schema, "yukh-control-plane-worker-delegation-approvals-v1");
     assert.equal(workerApprovalsBody.approvals.length, 1);
 
+    const workerPreflight = await fetch(`${base}/api/manager-plan/worker-launch-preflights`, {
+      method: "POST",
+    });
+    assert.equal(workerPreflight.status, 201);
+    const workerPreflightBody = await workerPreflight.json();
+    assert.equal(
+      workerPreflightBody.worker_launch_preflight.worker_delegation_approval_id,
+      workerApprovalBody.worker_delegation_approval.worker_delegation_approval_id,
+    );
+    assert.equal(
+      workerPreflightBody.worker_launch_preflight.worker_delegation_plan_id,
+      workerPlanBody.worker_delegation_plan.worker_delegation_plan_id,
+    );
+    assert.equal(
+      workerPreflightBody.worker_launch_preflight.manager_ready_receipt_id,
+      readyBody.manager_ready_receipt.manager_ready_receipt_id,
+    );
+    assert.equal(
+      workerPreflightBody.worker_launch_preflight.manager_process_id,
+      processBody.manager_process.manager_process_id,
+    );
+    assert.equal(
+      workerPreflightBody.worker_launch_preflight.manager_run_id,
+      runBody.manager_run.manager_run_id,
+    );
+    assert.equal(workerPreflightBody.worker_launch_preflight.approved_worker_count, 2);
+    assert.equal(
+      workerPreflightBody.worker_launch_preflight.approved_worker_token_budget,
+      workerApprovalBody.worker_delegation_approval.approved_worker_token_budget,
+    );
+    assert.equal(
+      workerPreflightBody.worker_launch_preflight.outcome,
+      "blocked_until_provider_runtime_probe",
+    );
+    assert.equal(
+      workerPreflightBody.worker_launch_preflight.provider_runtime_check,
+      "requires_provider_runtime_probe",
+    );
+    assert.equal(
+      workerPreflightBody.worker_launch_preflight.policy_check,
+      "local_approval_present",
+    );
+    assert.equal(
+      workerPreflightBody.worker_launch_preflight.budget_check,
+      "within_approved_worker_budget",
+    );
+    assert.equal(
+      workerPreflightBody.worker_launch_preflight.capability_check,
+      "requires_provider_capability_inventory",
+    );
+    assert.equal(workerPreflightBody.worker_launch_preflight.worker_launch, "not_performed");
+    assert.equal(workerPreflightBody.worker_launch_preflight.coordination_write, "not_performed");
+    assert.equal(workerPreflightBody.worker_launch_preflight.projects_write, "not_performed");
+    assert.equal(
+      workerPreflightBody.worker_launch_preflight.next_required_action,
+      "probe_provider_runtime",
+    );
+    assert.match(
+      workerPreflightBody.worker_launch_preflight.worker_launch_preflight_id,
+      /^worker-launch-preflight-/u,
+    );
+    assert.doesNotMatch(JSON.stringify(workerPreflightBody), /sensitive manager plan preview/iu);
+
+    const repeatedWorkerPreflight = await fetch(
+      `${base}/api/manager-plan/worker-launch-preflights`,
+      { method: "POST" },
+    );
+    assert.equal(repeatedWorkerPreflight.status, 201);
+    assert.equal(
+      (await repeatedWorkerPreflight.json()).worker_launch_preflight.worker_launch_preflight_id,
+      workerPreflightBody.worker_launch_preflight.worker_launch_preflight_id,
+    );
+
+    const workerPreflights = await fetch(`${base}/api/manager-plan/worker-launch-preflights`);
+    assert.equal(workerPreflights.status, 200);
+    const workerPreflightsBody = await workerPreflights.json();
+    assert.equal(workerPreflightsBody.schema, "yukh-control-plane-worker-launch-preflights-v1");
+    assert.equal(workerPreflightsBody.preflights.length, 1);
+
     const persisted = await fetch(`${base}/api/manager-plan/previews`);
     const persistedBody = await persisted.json();
     assert.equal(persistedBody.previews.length, 2);
@@ -687,6 +775,12 @@ test("control plane preview persists local manager plan previews without leaking
     );
     assert.equal(workerApprovalDenied.status, 405);
     assert.equal(workerApprovalDenied.headers.get("allow"), "GET, POST");
+
+    const workerPreflightDenied = await fetch(`${base}/api/manager-plan/worker-launch-preflights`, {
+      method: "DELETE",
+    });
+    assert.equal(workerPreflightDenied.status, 405);
+    assert.equal(workerPreflightDenied.headers.get("allow"), "GET, POST");
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
@@ -732,6 +826,7 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /api\/manager-plan\/manager-ready-receipts/u);
   assert.match(data, /api\/manager-plan\/worker-delegation-plans/u);
   assert.match(data, /api\/manager-plan\/worker-delegation-approvals/u);
+  assert.match(data, /api\/manager-plan\/worker-launch-preflights/u);
   assert.match(data, /Launch readiness/u);
   assert.match(data, /Launch intent recorded/u);
   assert.match(data, /Manager run planned/u);
@@ -740,10 +835,13 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /Manager ready receipt/u);
   assert.match(data, /Worker delegation plan/u);
   assert.match(data, /Worker delegation approved/u);
+  assert.match(data, /Worker launch preflight/u);
   assert.match(data, /provider_process/u);
   assert.match(data, /worker_delegation/u);
   assert.match(data, /worker_launch/u);
   assert.match(data, /approval_scope/u);
+  assert.match(data, /provider_runtime_check/u);
+  assert.match(data, /capability_check/u);
   assert.match(data, /model_source/u);
   assert.match(data, /coordination_write/u);
   assert.match(data, /projects_write/u);
@@ -796,5 +894,7 @@ test("control plane preview has bounded text containers for operator UI", async 
   assert.match(css, /\.worker-delegation-plan/u);
   assert.match(css, /\.worker-plan-grid/u);
   assert.match(css, /\.worker-delegation-approval/u);
+  assert.match(css, /\.worker-launch-preflight/u);
+  assert.match(css, /\.preflight-grid/u);
   assert.match(css, /@media \(max-width: 640px\)/u);
 });


### PR DESCRIPTION
## What changed

- Adds `GET /api/manager-plan/worker-launch-preflights`.
- Adds `POST /api/manager-plan/worker-launch-preflights`.
- Creates an idempotent launch preflight after worker delegation approval.
- Records local policy and budget checks as satisfied.
- Records provider runtime and capability inventory as requiring a separate probe.
- Shows the preflight receipt in the Control Plane preview UI.
- Documents the lifecycle boundary in a session note.

## Component boundaries

This remains MCP / Control Plane local lifecycle state only.

- MCP / Control Plane: local preflight receipts and budget/policy readiness.
- Coordination: agent message transcript and message receipts. No Coordination write is performed here.
- Projects: work items, admission/policy, roadmap and task metadata. No Projects write is performed here.

The preflight explicitly records `worker_launch: not_performed`, `coordination_write: not_performed`, and `projects_write: not_performed`. Provider/runtime and capability readiness are intentionally blocked pending a separate provider probe.

## Validation

- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
