### PR TITLE
Add Control Plane provider runtime probe

### DIFF
--- a/.context/sessions/SESSION-2026-08-19-08-control-plane-provider-runtime-probe.md
+++ b/.context/sessions/SESSION-2026-08-19-08-control-plane-provider-runtime-probe.md
@@ -1,0 +1,31 @@
+# SESSION-2026-08-19-08 — Control Plane provider runtime probe
+
+Date: 2026-08-19
+Repository: `nomed/yukh-mcp`
+Branch: `agent/control-plane-provider-runtime-probe`
+
+## Objective
+
+Add the `probe_provider_runtime` gate after worker launch preflight without launching workers or invoking a provider.
+
+## Outcome
+
+- Added `GET /api/manager-plan/provider-runtime-probes`.
+- Added `POST /api/manager-plan/provider-runtime-probes`.
+- Provider runtime probe requires an existing worker launch preflight and otherwise fails with `409 worker_launch_preflight_required`.
+- Repeated probe for the same worker launch preflight returns the existing probe receipt.
+- Probe records that the local Control Plane has no configured provider adapter yet.
+- Probe records executable and capability inventory checks as not performed.
+- The Control Plane preview UI can record and display the provider runtime probe.
+
+## Component boundaries
+
+- MCP / Control Plane owns local provider readiness gates and orchestration receipts.
+- Coordination owns agent message transcript and message receipts.
+- Projects owns governed work items, policy/admission, roadmap and task metadata.
+
+This increment writes only MCP-local lifecycle state.
+
+## Boundaries
+
+No worker process, provider execution, Coordination write, Projects write, task mutation or roadmap mutation was added.

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -35,6 +35,7 @@ const API_MANAGER_READY_RECEIPTS_PATH = "/api/manager-plan/manager-ready-receipt
 const API_WORKER_DELEGATION_PLANS_PATH = "/api/manager-plan/worker-delegation-plans";
 const API_WORKER_DELEGATION_APPROVALS_PATH = "/api/manager-plan/worker-delegation-approvals";
 const API_WORKER_LAUNCH_PREFLIGHTS_PATH = "/api/manager-plan/worker-launch-preflights";
+const API_PROVIDER_RUNTIME_PROBES_PATH = "/api/manager-plan/provider-runtime-probes";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
@@ -513,6 +514,58 @@ export function createControlPlaneServer(
               schema: 1,
               status: "error",
               code: "worker_delegation_approval_required",
+            }),
+          );
+        }
+        return;
+      }
+      response.writeHead(405, {
+        allow: "GET, POST",
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+      return;
+    }
+
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_PROVIDER_RUNTIME_PROBES_PATH
+    ) {
+      if (!options.planPreviewStore) {
+        response.writeHead(503, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "store_unconfigured" }));
+        return;
+      }
+      if (request.method === "GET") {
+        response.writeHead(200, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify(options.planPreviewStore.providerRuntimeProbes()));
+        return;
+      }
+      if (request.method === "POST") {
+        try {
+          const record = options.planPreviewStore.probeProviderRuntime();
+          response.writeHead(201, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(JSON.stringify({ schema: 1, status: "ok", provider_runtime_probe: record }));
+        } catch {
+          response.writeHead(409, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({
+              schema: 1,
+              status: "error",
+              code: "worker_launch_preflight_required",
             }),
           );
         }

--- a/apps/control-plane-preview/src/plan-preview-store.ts
+++ b/apps/control-plane-preview/src/plan-preview-store.ts
@@ -234,6 +234,33 @@ export type ControlPlaneWorkerLaunchPreflightStatus = {
   readonly preflights: readonly ControlPlaneWorkerLaunchPreflightRecord[];
 };
 
+export type ControlPlaneProviderRuntimeProbeRecord = {
+  readonly schema: 1;
+  readonly provider_runtime_probe_id: string;
+  readonly worker_launch_preflight_id: string;
+  readonly worker_delegation_approval_id: string;
+  readonly worker_delegation_plan_id: string;
+  readonly manager_process_id: string;
+  readonly manager_run_id: string;
+  readonly provider: string;
+  readonly probe_scope: "local_control_plane_configuration";
+  readonly provider_adapter: "not_configured";
+  readonly executable_check: "not_performed";
+  readonly capability_inventory: "not_requested";
+  readonly outcome: "blocked_provider_adapter_not_configured";
+  readonly worker_launch: "not_performed";
+  readonly coordination_write: "not_performed";
+  readonly projects_write: "not_performed";
+  readonly created_at: string;
+  readonly next_required_action: "configure_provider_adapter";
+};
+
+export type ControlPlaneProviderRuntimeProbeStatus = {
+  readonly schema: "yukh-control-plane-provider-runtime-probes-v1";
+  readonly source: "local-control-plane-store";
+  readonly probes: readonly ControlPlaneProviderRuntimeProbeRecord[];
+};
+
 export type ControlPlanePlanPreviewInput = {
   readonly goal: string;
   readonly mode: string;
@@ -253,6 +280,7 @@ type Document = {
   readonly worker_delegation_plans?: readonly ControlPlaneWorkerDelegationPlanRecord[];
   readonly worker_delegation_approvals?: readonly ControlPlaneWorkerDelegationApprovalRecord[];
   readonly worker_launch_preflights?: readonly ControlPlaneWorkerLaunchPreflightRecord[];
+  readonly provider_runtime_probes?: readonly ControlPlaneProviderRuntimeProbeRecord[];
 };
 
 const validMode = new Set(["plan-first", "delegate, explicit workers"]);
@@ -446,6 +474,66 @@ export class ControlPlanePlanPreviewStore {
     };
   }
 
+  providerRuntimeProbes(): ControlPlaneProviderRuntimeProbeStatus {
+    return {
+      schema: "yukh-control-plane-provider-runtime-probes-v1",
+      source: "local-control-plane-store",
+      probes: this.#read().provider_runtime_probes ?? [],
+    };
+  }
+
+  probeProviderRuntime(): ControlPlaneProviderRuntimeProbeRecord {
+    const document = this.#read();
+    const preflight = document.worker_launch_preflights?.[0];
+    if (!preflight) {
+      throw new TypeError("missing worker launch preflight");
+    }
+    const existing = document.provider_runtime_probes?.find(
+      (probe) => probe.worker_launch_preflight_id === preflight.worker_launch_preflight_id,
+    );
+    if (existing) return existing;
+    const plan = document.worker_delegation_plans?.find(
+      (candidate) => candidate.worker_delegation_plan_id === preflight.worker_delegation_plan_id,
+    );
+    if (!plan) {
+      throw new TypeError("missing worker delegation plan");
+    }
+    const record: ControlPlaneProviderRuntimeProbeRecord = {
+      schema: 1,
+      provider_runtime_probe_id: `provider-runtime-probe-${randomUUID()}`,
+      worker_launch_preflight_id: preflight.worker_launch_preflight_id,
+      worker_delegation_approval_id: preflight.worker_delegation_approval_id,
+      worker_delegation_plan_id: preflight.worker_delegation_plan_id,
+      manager_process_id: preflight.manager_process_id,
+      manager_run_id: preflight.manager_run_id,
+      provider: plan.provider,
+      probe_scope: "local_control_plane_configuration",
+      provider_adapter: "not_configured",
+      executable_check: "not_performed",
+      capability_inventory: "not_requested",
+      outcome: "blocked_provider_adapter_not_configured",
+      worker_launch: "not_performed",
+      coordination_write: "not_performed",
+      projects_write: "not_performed",
+      created_at: new Date().toISOString(),
+      next_required_action: "configure_provider_adapter",
+    };
+    this.#write({
+      schema: 1,
+      previews: document.previews,
+      launch_intents: document.launch_intents ?? [],
+      manager_runs: document.manager_runs ?? [],
+      manager_runtime_connections: document.manager_runtime_connections ?? [],
+      manager_processes: document.manager_processes ?? [],
+      manager_ready_receipts: document.manager_ready_receipts ?? [],
+      worker_delegation_plans: document.worker_delegation_plans ?? [],
+      worker_delegation_approvals: document.worker_delegation_approvals ?? [],
+      worker_launch_preflights: document.worker_launch_preflights ?? [],
+      provider_runtime_probes: [record, ...(document.provider_runtime_probes ?? [])].slice(0, 20),
+    });
+    return record;
+  }
+
   preflightApprovedWorkerLaunch(): ControlPlaneWorkerLaunchPreflightRecord {
     const document = this.#read();
     const approval = document.worker_delegation_approvals?.[0];
@@ -489,6 +577,7 @@ export class ControlPlanePlanPreviewStore {
       worker_delegation_plans: document.worker_delegation_plans ?? [],
       worker_delegation_approvals: document.worker_delegation_approvals ?? [],
       worker_launch_preflights: [record, ...(document.worker_launch_preflights ?? [])].slice(0, 20),
+      provider_runtime_probes: document.provider_runtime_probes ?? [],
     });
     return record;
   }
@@ -533,6 +622,7 @@ export class ControlPlanePlanPreviewStore {
         20,
       ),
       worker_launch_preflights: document.worker_launch_preflights ?? [],
+      provider_runtime_probes: document.provider_runtime_probes ?? [],
     });
     return record;
   }
@@ -595,6 +685,7 @@ export class ControlPlanePlanPreviewStore {
       worker_delegation_plans: [record, ...(document.worker_delegation_plans ?? [])].slice(0, 20),
       worker_delegation_approvals: document.worker_delegation_approvals ?? [],
       worker_launch_preflights: document.worker_launch_preflights ?? [],
+      provider_runtime_probes: document.provider_runtime_probes ?? [],
     });
     return record;
   }
@@ -633,6 +724,7 @@ export class ControlPlanePlanPreviewStore {
       worker_delegation_plans: document.worker_delegation_plans ?? [],
       worker_delegation_approvals: document.worker_delegation_approvals ?? [],
       worker_launch_preflights: document.worker_launch_preflights ?? [],
+      provider_runtime_probes: document.provider_runtime_probes ?? [],
     });
     return record;
   }
@@ -672,6 +764,7 @@ export class ControlPlanePlanPreviewStore {
       worker_delegation_plans: document.worker_delegation_plans ?? [],
       worker_delegation_approvals: document.worker_delegation_approvals ?? [],
       worker_launch_preflights: document.worker_launch_preflights ?? [],
+      provider_runtime_probes: document.provider_runtime_probes ?? [],
     });
     return record;
   }
@@ -713,6 +806,7 @@ export class ControlPlanePlanPreviewStore {
       worker_delegation_plans: document.worker_delegation_plans ?? [],
       worker_delegation_approvals: document.worker_delegation_approvals ?? [],
       worker_launch_preflights: document.worker_launch_preflights ?? [],
+      provider_runtime_probes: document.provider_runtime_probes ?? [],
     });
     return record;
   }
@@ -756,6 +850,7 @@ export class ControlPlanePlanPreviewStore {
       worker_delegation_plans: document.worker_delegation_plans ?? [],
       worker_delegation_approvals: document.worker_delegation_approvals ?? [],
       worker_launch_preflights: document.worker_launch_preflights ?? [],
+      provider_runtime_probes: document.provider_runtime_probes ?? [],
     });
     return record;
   }
@@ -795,6 +890,7 @@ export class ControlPlanePlanPreviewStore {
       worker_delegation_plans: document.worker_delegation_plans ?? [],
       worker_delegation_approvals: document.worker_delegation_approvals ?? [],
       worker_launch_preflights: document.worker_launch_preflights ?? [],
+      provider_runtime_probes: document.provider_runtime_probes ?? [],
     });
     return record;
   }
@@ -834,6 +930,7 @@ export class ControlPlanePlanPreviewStore {
       worker_delegation_plans: document.worker_delegation_plans ?? [],
       worker_delegation_approvals: document.worker_delegation_approvals ?? [],
       worker_launch_preflights: document.worker_launch_preflights ?? [],
+      provider_runtime_probes: document.provider_runtime_probes ?? [],
     });
     return record;
   }
@@ -871,6 +968,9 @@ export class ControlPlanePlanPreviewStore {
         worker_launch_preflights: Array.isArray(parsed.worker_launch_preflights)
           ? parsed.worker_launch_preflights.filter((item) => item?.schema === 1)
           : [],
+        provider_runtime_probes: Array.isArray(parsed.provider_runtime_probes)
+          ? parsed.provider_runtime_probes.filter((item) => item?.schema === 1)
+          : [],
       };
     } catch {
       return {
@@ -884,6 +984,7 @@ export class ControlPlanePlanPreviewStore {
         worker_delegation_plans: [],
         worker_delegation_approvals: [],
         worker_launch_preflights: [],
+        provider_runtime_probes: [],
       };
     }
   }

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -779,6 +779,21 @@ const preflightApprovedWorkerLaunch = async () => {
   }
 };
 
+const probeProviderRuntime = async () => {
+  try {
+    const response = await fetch("./api/manager-plan/provider-runtime-probes", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return body?.provider_runtime_probe ?? null;
+  } catch {
+    return null;
+  }
+};
+
 const renderLaunchIntent = (intent) => {
   if (!intent) return "";
   return `
@@ -902,6 +917,25 @@ const renderWorkerLaunchPreflight = (preflight) => {
       </div>
       <p class="muted">Worker launch: ${escapeHtml(preflight.worker_launch)} · Coordination write: ${escapeHtml(preflight.coordination_write)} · Projects write: ${escapeHtml(preflight.projects_write)}.</p>
       <p class="muted">Next required action: ${escapeHtml(preflight.next_required_action)}.</p>
+      <button type="button" class="secondary provider-probe-button">Probe provider runtime</button>
+    </div>
+  `;
+};
+
+const renderProviderRuntimeProbe = (probe) => {
+  if (!probe) return "";
+  return `
+    <div class="provider-runtime-probe">
+      <span>Provider runtime probe</span>
+      <strong>${escapeHtml(probe.provider_runtime_probe_id)}</strong>
+      <p class="muted">${escapeHtml(probe.provider)} · outcome ${escapeHtml(probe.outcome)} · scope ${escapeHtml(probe.probe_scope)}.</p>
+      <div class="preflight-grid">
+        <article><span>Adapter</span><strong>${escapeHtml(probe.provider_adapter)}</strong></article>
+        <article><span>Executable</span><strong>${escapeHtml(probe.executable_check)}</strong></article>
+        <article><span>Capabilities</span><strong>${escapeHtml(probe.capability_inventory)}</strong></article>
+      </div>
+      <p class="muted">Worker launch: ${escapeHtml(probe.worker_launch)} · Coordination write: ${escapeHtml(probe.coordination_write)} · Projects write: ${escapeHtml(probe.projects_write)}.</p>
+      <p class="muted">Next required action: ${escapeHtml(probe.next_required_action)}.</p>
     </div>
   `;
 };
@@ -1183,6 +1217,22 @@ byId("plan-preview").addEventListener("click", async (event) => {
   button
     .closest(".worker-delegation-approval")
     ?.insertAdjacentHTML("afterend", renderWorkerLaunchPreflight(preflight));
+});
+
+byId("plan-preview").addEventListener("click", async (event) => {
+  const button = event.target.closest(".provider-probe-button");
+  if (!button) return;
+  button.setAttribute("disabled", "true");
+  const probe = await probeProviderRuntime();
+  if (!probe) {
+    button.removeAttribute("disabled");
+    button.textContent = "Worker launch preflight required";
+    return;
+  }
+  button.textContent = "Provider runtime probe recorded";
+  button
+    .closest(".worker-launch-preflight")
+    ?.insertAdjacentHTML("afterend", renderProviderRuntimeProbe(probe));
 });
 
 byId("manager-plan-form").addEventListener("submit", (event) => {

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -940,6 +940,21 @@ nav a:hover {
   min-width: 0;
   padding: 10px;
 }
+.provider-runtime-probe {
+  background: rgba(255, 209, 102, 0.08);
+  border: 1px solid rgba(255, 209, 102, 0.28);
+  border-radius: 16px;
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+.provider-runtime-probe span {
+  color: var(--warn);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 .preview-card.approved-preview {
   border-color: rgba(119, 240, 178, 0.48);
 }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -294,6 +294,12 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(blockedWorkerPreflight.status, 409);
     assert.equal((await blockedWorkerPreflight.json()).code, "worker_delegation_approval_required");
 
+    const blockedProviderProbe = await fetch(`${base}/api/manager-plan/provider-runtime-probes`, {
+      method: "POST",
+    });
+    assert.equal(blockedProviderProbe.status, 409);
+    assert.equal((await blockedProviderProbe.json()).code, "worker_launch_preflight_required");
+
     const goal = "Persist this sensitive manager plan preview locally";
     const proposed = await fetch(`${base}/api/manager-plan/previews`, {
       method: "POST",
@@ -717,6 +723,71 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(workerPreflightsBody.schema, "yukh-control-plane-worker-launch-preflights-v1");
     assert.equal(workerPreflightsBody.preflights.length, 1);
 
+    const providerProbe = await fetch(`${base}/api/manager-plan/provider-runtime-probes`, {
+      method: "POST",
+    });
+    assert.equal(providerProbe.status, 201);
+    const providerProbeBody = await providerProbe.json();
+    assert.equal(
+      providerProbeBody.provider_runtime_probe.worker_launch_preflight_id,
+      workerPreflightBody.worker_launch_preflight.worker_launch_preflight_id,
+    );
+    assert.equal(
+      providerProbeBody.provider_runtime_probe.worker_delegation_approval_id,
+      workerApprovalBody.worker_delegation_approval.worker_delegation_approval_id,
+    );
+    assert.equal(
+      providerProbeBody.provider_runtime_probe.worker_delegation_plan_id,
+      workerPlanBody.worker_delegation_plan.worker_delegation_plan_id,
+    );
+    assert.equal(
+      providerProbeBody.provider_runtime_probe.manager_process_id,
+      processBody.manager_process.manager_process_id,
+    );
+    assert.equal(
+      providerProbeBody.provider_runtime_probe.manager_run_id,
+      runBody.manager_run.manager_run_id,
+    );
+    assert.equal(providerProbeBody.provider_runtime_probe.provider, "Copilot SDK workers");
+    assert.equal(
+      providerProbeBody.provider_runtime_probe.probe_scope,
+      "local_control_plane_configuration",
+    );
+    assert.equal(providerProbeBody.provider_runtime_probe.provider_adapter, "not_configured");
+    assert.equal(providerProbeBody.provider_runtime_probe.executable_check, "not_performed");
+    assert.equal(providerProbeBody.provider_runtime_probe.capability_inventory, "not_requested");
+    assert.equal(
+      providerProbeBody.provider_runtime_probe.outcome,
+      "blocked_provider_adapter_not_configured",
+    );
+    assert.equal(providerProbeBody.provider_runtime_probe.worker_launch, "not_performed");
+    assert.equal(providerProbeBody.provider_runtime_probe.coordination_write, "not_performed");
+    assert.equal(providerProbeBody.provider_runtime_probe.projects_write, "not_performed");
+    assert.equal(
+      providerProbeBody.provider_runtime_probe.next_required_action,
+      "configure_provider_adapter",
+    );
+    assert.match(
+      providerProbeBody.provider_runtime_probe.provider_runtime_probe_id,
+      /^provider-runtime-probe-/u,
+    );
+    assert.doesNotMatch(JSON.stringify(providerProbeBody), /sensitive manager plan preview/iu);
+
+    const repeatedProviderProbe = await fetch(`${base}/api/manager-plan/provider-runtime-probes`, {
+      method: "POST",
+    });
+    assert.equal(repeatedProviderProbe.status, 201);
+    assert.equal(
+      (await repeatedProviderProbe.json()).provider_runtime_probe.provider_runtime_probe_id,
+      providerProbeBody.provider_runtime_probe.provider_runtime_probe_id,
+    );
+
+    const providerProbes = await fetch(`${base}/api/manager-plan/provider-runtime-probes`);
+    assert.equal(providerProbes.status, 200);
+    const providerProbesBody = await providerProbes.json();
+    assert.equal(providerProbesBody.schema, "yukh-control-plane-provider-runtime-probes-v1");
+    assert.equal(providerProbesBody.probes.length, 1);
+
     const persisted = await fetch(`${base}/api/manager-plan/previews`);
     const persistedBody = await persisted.json();
     assert.equal(persistedBody.previews.length, 2);
@@ -781,6 +852,12 @@ test("control plane preview persists local manager plan previews without leaking
     });
     assert.equal(workerPreflightDenied.status, 405);
     assert.equal(workerPreflightDenied.headers.get("allow"), "GET, POST");
+
+    const providerProbeDenied = await fetch(`${base}/api/manager-plan/provider-runtime-probes`, {
+      method: "DELETE",
+    });
+    assert.equal(providerProbeDenied.status, 405);
+    assert.equal(providerProbeDenied.headers.get("allow"), "GET, POST");
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
@@ -827,6 +904,7 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /api\/manager-plan\/worker-delegation-plans/u);
   assert.match(data, /api\/manager-plan\/worker-delegation-approvals/u);
   assert.match(data, /api\/manager-plan\/worker-launch-preflights/u);
+  assert.match(data, /api\/manager-plan\/provider-runtime-probes/u);
   assert.match(data, /Launch readiness/u);
   assert.match(data, /Launch intent recorded/u);
   assert.match(data, /Manager run planned/u);
@@ -836,11 +914,14 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /Worker delegation plan/u);
   assert.match(data, /Worker delegation approved/u);
   assert.match(data, /Worker launch preflight/u);
+  assert.match(data, /Provider runtime probe/u);
   assert.match(data, /provider_process/u);
   assert.match(data, /worker_delegation/u);
   assert.match(data, /worker_launch/u);
   assert.match(data, /approval_scope/u);
   assert.match(data, /provider_runtime_check/u);
+  assert.match(data, /provider_adapter/u);
+  assert.match(data, /capability_inventory/u);
   assert.match(data, /capability_check/u);
   assert.match(data, /model_source/u);
   assert.match(data, /coordination_write/u);
@@ -895,6 +976,7 @@ test("control plane preview has bounded text containers for operator UI", async 
   assert.match(css, /\.worker-plan-grid/u);
   assert.match(css, /\.worker-delegation-approval/u);
   assert.match(css, /\.worker-launch-preflight/u);
+  assert.match(css, /\.provider-runtime-probe/u);
   assert.match(css, /\.preflight-grid/u);
   assert.match(css, /@media \(max-width: 640px\)/u);
 });


### PR DESCRIPTION
## What changed

- Adds `GET /api/manager-plan/provider-runtime-probes`.
- Adds `POST /api/manager-plan/provider-runtime-probes`.
- Creates an idempotent provider runtime probe after worker launch preflight.
- Records the current preview state as blocked because no provider adapter is configured.
- Keeps executable and capability inventory checks explicitly not performed.
- Shows the provider runtime probe in the Control Plane preview UI.
- Documents the lifecycle boundary in a session note.

## Component boundaries

This remains MCP / Control Plane local lifecycle state only.

- MCP / Control Plane: provider readiness gates and orchestration receipts.
- Coordination: agent message transcript and message receipts. No Coordination write is performed here.
- Projects: work items, admission/policy, roadmap and task metadata. No Projects write is performed here.

The probe explicitly records `provider_adapter: not_configured`, `executable_check: not_performed`, `capability_inventory: not_requested`, `worker_launch: not_performed`, `coordination_write: not_performed`, and `projects_write: not_performed`.

## Validation

- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
