### PR TITLE
Add Control Plane provider adapter config

### DIFF
--- a/.context/sessions/SESSION-2026-08-19-09-control-plane-provider-adapter-config.md
+++ b/.context/sessions/SESSION-2026-08-19-09-control-plane-provider-adapter-config.md
@@ -1,0 +1,32 @@
+# Control Plane provider adapter configuration
+
+Date: 2026-08-19
+
+## Outcome
+
+Added a bounded Control Plane provider adapter configuration step before provider runtime launch.
+
+## Scope
+
+- Added local provider adapter records for supported manager/worker providers.
+- Added `GET /api/manager-plan/provider-adapters`.
+- Added `POST /api/manager-plan/provider-adapters`.
+- Added UI controls to configure provider, adapter kind, executable path, model list and max run token budget.
+- Updated provider runtime probes so they can distinguish:
+  - missing adapter;
+  - configured SDK adapter;
+  - missing CLI executable;
+  - executable CLI adapter.
+
+## Safety boundary
+
+The increment still does not launch provider processes, workers or external writes.
+It only records local configuration and performs a local executable-path check for CLI adapters.
+
+## Validation
+
+- `npm run format:check`
+- `npm run typecheck`
+- `npm run build`
+- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
+- `git diff --check`

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
 import {
   ControlPlanePlanPreviewStore,
+  type ControlPlaneProviderAdapterInput,
   type ControlPlanePlanPreviewInput,
 } from "./plan-preview-store.js";
 import { createTeamStatus } from "./team-status.js";
@@ -36,6 +37,7 @@ const API_WORKER_DELEGATION_PLANS_PATH = "/api/manager-plan/worker-delegation-pl
 const API_WORKER_DELEGATION_APPROVALS_PATH = "/api/manager-plan/worker-delegation-approvals";
 const API_WORKER_LAUNCH_PREFLIGHTS_PATH = "/api/manager-plan/worker-launch-preflights";
 const API_PROVIDER_RUNTIME_PROBES_PATH = "/api/manager-plan/provider-runtime-probes";
+const API_PROVIDER_ADAPTERS_PATH = "/api/manager-plan/provider-adapters";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
@@ -566,6 +568,60 @@ export function createControlPlaneServer(
               schema: 1,
               status: "error",
               code: "worker_launch_preflight_required",
+            }),
+          );
+        }
+        return;
+      }
+      response.writeHead(405, {
+        allow: "GET, POST",
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+      return;
+    }
+
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_PROVIDER_ADAPTERS_PATH
+    ) {
+      if (!options.planPreviewStore) {
+        response.writeHead(503, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "store_unconfigured" }));
+        return;
+      }
+      if (request.method === "GET") {
+        response.writeHead(200, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify(options.planPreviewStore.providerAdapters()));
+        return;
+      }
+      if (request.method === "POST") {
+        try {
+          const record = options.planPreviewStore.configureProviderAdapter(
+            (await readJsonBody(request)) as ControlPlaneProviderAdapterInput,
+          );
+          response.writeHead(201, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(JSON.stringify({ schema: 1, status: "ok", provider_adapter: record }));
+        } catch {
+          response.writeHead(400, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({
+              schema: 1,
+              status: "error",
+              code: "invalid_provider_adapter",
             }),
           );
         }

--- a/apps/control-plane-preview/src/plan-preview-store.ts
+++ b/apps/control-plane-preview/src/plan-preview-store.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { accessSync, constants, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { isAbsolute, join } from "node:path";
 
 export type ControlPlanePlanPreviewState = "proposed" | "approved-preview";
@@ -244,21 +244,52 @@ export type ControlPlaneProviderRuntimeProbeRecord = {
   readonly manager_run_id: string;
   readonly provider: string;
   readonly probe_scope: "local_control_plane_configuration";
-  readonly provider_adapter: "not_configured";
-  readonly executable_check: "not_performed";
-  readonly capability_inventory: "not_requested";
-  readonly outcome: "blocked_provider_adapter_not_configured";
+  readonly provider_adapter: "configured" | "not_configured";
+  readonly executable_check:
+    "executable_found" | "executable_missing" | "not_performed" | "not_required";
+  readonly capability_inventory: "local_inventory_available" | "not_requested";
+  readonly outcome:
+    | "ready_for_worker_launch"
+    | "blocked_provider_adapter_not_configured"
+    | "blocked_provider_executable_missing";
   readonly worker_launch: "not_performed";
   readonly coordination_write: "not_performed";
   readonly projects_write: "not_performed";
   readonly created_at: string;
-  readonly next_required_action: "configure_provider_adapter";
+  readonly next_required_action:
+    "launch_workers" | "configure_provider_adapter" | "fix_provider_executable";
 };
 
 export type ControlPlaneProviderRuntimeProbeStatus = {
   readonly schema: "yukh-control-plane-provider-runtime-probes-v1";
   readonly source: "local-control-plane-store";
   readonly probes: readonly ControlPlaneProviderRuntimeProbeRecord[];
+};
+
+export type ControlPlaneProviderAdapterRecord = {
+  readonly schema: 1;
+  readonly provider_adapter_id: string;
+  readonly provider: string;
+  readonly adapter_kind: "cli" | "sdk";
+  readonly executable_path?: string;
+  readonly models: readonly string[];
+  readonly max_run_token_budget: number;
+  readonly command_policy: "bounded_control_plane_only";
+  readonly configured_at: string;
+};
+
+export type ControlPlaneProviderAdapterStatus = {
+  readonly schema: "yukh-control-plane-provider-adapters-v1";
+  readonly source: "local-control-plane-store";
+  readonly adapters: readonly ControlPlaneProviderAdapterRecord[];
+};
+
+export type ControlPlaneProviderAdapterInput = {
+  readonly provider: string;
+  readonly adapter_kind: "cli" | "sdk";
+  readonly executable_path?: string;
+  readonly models: readonly string[];
+  readonly max_run_token_budget: number;
 };
 
 export type ControlPlanePlanPreviewInput = {
@@ -281,6 +312,7 @@ type Document = {
   readonly worker_delegation_approvals?: readonly ControlPlaneWorkerDelegationApprovalRecord[];
   readonly worker_launch_preflights?: readonly ControlPlaneWorkerLaunchPreflightRecord[];
   readonly provider_runtime_probes?: readonly ControlPlaneProviderRuntimeProbeRecord[];
+  readonly provider_adapters?: readonly ControlPlaneProviderAdapterRecord[];
 };
 
 const validMode = new Set(["plan-first", "delegate, explicit workers"]);
@@ -327,6 +359,47 @@ function validateInput(input: ControlPlanePlanPreviewInput): void {
     (input.state !== undefined && !["proposed", "approved-preview"].includes(input.state))
   ) {
     throw new TypeError("invalid plan preview input");
+  }
+}
+
+function validateProviderAdapterInput(input: ControlPlaneProviderAdapterInput): void {
+  if (
+    !validProvider.has(input.provider) ||
+    !["cli", "sdk"].includes(input.adapter_kind) ||
+    (input.adapter_kind === "cli" &&
+      (!input.executable_path || !isAbsolute(input.executable_path))) ||
+    (input.executable_path !== undefined &&
+      (input.executable_path.length < 1 ||
+        input.executable_path.length > 4_096 ||
+        !isAbsolute(input.executable_path))) ||
+    !Array.isArray(input.models) ||
+    input.models.length < 1 ||
+    input.models.length > 20 ||
+    input.models.some(
+      (model) =>
+        typeof model !== "string" ||
+        model.trim() !== model ||
+        model.length < 1 ||
+        model.length > 128,
+    ) ||
+    !Number.isSafeInteger(input.max_run_token_budget) ||
+    input.max_run_token_budget < 1_000 ||
+    input.max_run_token_budget > 10_000_000
+  ) {
+    throw new TypeError("invalid provider adapter input");
+  }
+}
+
+function executableCheck(
+  adapter: ControlPlaneProviderAdapterRecord,
+): ControlPlaneProviderRuntimeProbeRecord["executable_check"] {
+  if (adapter.adapter_kind === "sdk") return "not_required";
+  if (!adapter.executable_path) return "executable_missing";
+  try {
+    accessSync(adapter.executable_path, constants.X_OK);
+    return "executable_found";
+  } catch {
+    return "executable_missing";
   }
 }
 
@@ -482,6 +555,40 @@ export class ControlPlanePlanPreviewStore {
     };
   }
 
+  providerAdapters(): ControlPlaneProviderAdapterStatus {
+    return {
+      schema: "yukh-control-plane-provider-adapters-v1",
+      source: "local-control-plane-store",
+      adapters: this.#read().provider_adapters ?? [],
+    };
+  }
+
+  configureProviderAdapter(
+    input: ControlPlaneProviderAdapterInput,
+  ): ControlPlaneProviderAdapterRecord {
+    validateProviderAdapterInput(input);
+    const document = this.#read();
+    const record: ControlPlaneProviderAdapterRecord = {
+      schema: 1,
+      provider_adapter_id: `provider-adapter-${randomUUID()}`,
+      provider: input.provider,
+      adapter_kind: input.adapter_kind,
+      ...(input.executable_path ? { executable_path: input.executable_path } : {}),
+      models: [...input.models],
+      max_run_token_budget: input.max_run_token_budget,
+      command_policy: "bounded_control_plane_only",
+      configured_at: new Date().toISOString(),
+    };
+    const retained = (document.provider_adapters ?? []).filter(
+      (adapter) => adapter.provider !== input.provider,
+    );
+    this.#write({
+      ...document,
+      provider_adapters: [record, ...retained].slice(0, 20),
+    });
+    return record;
+  }
+
   probeProviderRuntime(): ControlPlaneProviderRuntimeProbeRecord {
     const document = this.#read();
     const preflight = document.worker_launch_preflights?.[0];
@@ -498,6 +605,12 @@ export class ControlPlanePlanPreviewStore {
     if (!plan) {
       throw new TypeError("missing worker delegation plan");
     }
+    const adapter = document.provider_adapters?.find(
+      (candidate) => candidate.provider === plan.provider,
+    );
+    const check = adapter ? executableCheck(adapter) : "not_performed";
+    const ready =
+      adapter !== undefined && (check === "executable_found" || check === "not_required");
     const record: ControlPlaneProviderRuntimeProbeRecord = {
       schema: 1,
       provider_runtime_probe_id: `provider-runtime-probe-${randomUUID()}`,
@@ -508,27 +621,26 @@ export class ControlPlanePlanPreviewStore {
       manager_run_id: preflight.manager_run_id,
       provider: plan.provider,
       probe_scope: "local_control_plane_configuration",
-      provider_adapter: "not_configured",
-      executable_check: "not_performed",
-      capability_inventory: "not_requested",
-      outcome: "blocked_provider_adapter_not_configured",
+      provider_adapter: adapter ? "configured" : "not_configured",
+      executable_check: check,
+      capability_inventory: adapter ? "local_inventory_available" : "not_requested",
+      outcome: ready
+        ? "ready_for_worker_launch"
+        : adapter
+          ? "blocked_provider_executable_missing"
+          : "blocked_provider_adapter_not_configured",
       worker_launch: "not_performed",
       coordination_write: "not_performed",
       projects_write: "not_performed",
       created_at: new Date().toISOString(),
-      next_required_action: "configure_provider_adapter",
+      next_required_action: ready
+        ? "launch_workers"
+        : adapter
+          ? "fix_provider_executable"
+          : "configure_provider_adapter",
     };
     this.#write({
-      schema: 1,
-      previews: document.previews,
-      launch_intents: document.launch_intents ?? [],
-      manager_runs: document.manager_runs ?? [],
-      manager_runtime_connections: document.manager_runtime_connections ?? [],
-      manager_processes: document.manager_processes ?? [],
-      manager_ready_receipts: document.manager_ready_receipts ?? [],
-      worker_delegation_plans: document.worker_delegation_plans ?? [],
-      worker_delegation_approvals: document.worker_delegation_approvals ?? [],
-      worker_launch_preflights: document.worker_launch_preflights ?? [],
+      ...document,
       provider_runtime_probes: [record, ...(document.provider_runtime_probes ?? [])].slice(0, 20),
     });
     return record;
@@ -971,6 +1083,9 @@ export class ControlPlanePlanPreviewStore {
         provider_runtime_probes: Array.isArray(parsed.provider_runtime_probes)
           ? parsed.provider_runtime_probes.filter((item) => item?.schema === 1)
           : [],
+        provider_adapters: Array.isArray(parsed.provider_adapters)
+          ? parsed.provider_adapters.filter((item) => item?.schema === 1)
+          : [],
       };
     } catch {
       return {
@@ -985,13 +1100,19 @@ export class ControlPlanePlanPreviewStore {
         worker_delegation_approvals: [],
         worker_launch_preflights: [],
         provider_runtime_probes: [],
+        provider_adapters: [],
       };
     }
   }
 
   #write(document: Document): void {
+    const current = this.#read();
+    const normalized: Document = {
+      ...document,
+      provider_adapters: document.provider_adapters ?? current.provider_adapters ?? [],
+    };
     const tmp = `${this.#path}.${process.pid}.${Date.now()}.tmp`;
-    writeFileSync(tmp, `${JSON.stringify(document, null, 2)}\n`, { mode: 0o600 });
+    writeFileSync(tmp, `${JSON.stringify(normalized, null, 2)}\n`, { mode: 0o600 });
     renameSync(tmp, this.#path);
   }
 }

--- a/apps/control-plane-preview/static/index.html
+++ b/apps/control-plane-preview/static/index.html
@@ -262,6 +262,30 @@
                 <h3>New team</h3>
               </div>
             </div>
+            <form class="start-form provider-adapter-form" id="provider-adapter-form">
+              <label
+                >Provider adapter<select id="adapter-provider">
+                  <option>Copilot SDK workers</option>
+                  <option>Codex manager CLI</option>
+                  <option>Codex SDK, planned</option>
+                </select></label
+              >
+              <label
+                >Kind<select id="adapter-kind">
+                  <option>sdk</option>
+                  <option>cli</option>
+                </select></label
+              >
+              <label
+                >Executable path<input id="adapter-executable" placeholder="/absolute/path/for-cli"
+              /></label>
+              <label>Models<input id="adapter-models" value="copilot-sdk-default" /></label>
+              <label
+                >Max tokens<input id="adapter-budget" value="120000" inputmode="numeric"
+              /></label>
+              <button type="submit" class="secondary">Configure provider adapter</button>
+            </form>
+            <div id="provider-adapter-status" class="plan-preview" aria-live="polite"></div>
             <form class="start-form" id="manager-plan-form">
               <label
                 >Goal<textarea id="plan-goal">

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -779,6 +779,27 @@ const preflightApprovedWorkerLaunch = async () => {
   }
 };
 
+const configureProviderAdapter = async ({ provider, kind, executablePath, models, budget }) => {
+  try {
+    const response = await fetch("./api/manager-plan/provider-adapters", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        provider,
+        adapter_kind: kind,
+        ...(executablePath ? { executable_path: executablePath } : {}),
+        models,
+        max_run_token_budget: budget,
+      }),
+    });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return body?.provider_adapter ?? null;
+  } catch {
+    return null;
+  }
+};
+
 const probeProviderRuntime = async () => {
   try {
     const response = await fetch("./api/manager-plan/provider-runtime-probes", {
@@ -792,6 +813,19 @@ const probeProviderRuntime = async () => {
   } catch {
     return null;
   }
+};
+
+const renderProviderAdapter = (adapter) => {
+  if (!adapter) return "";
+  return `
+    <div class="provider-adapter">
+      <span>Provider adapter configured</span>
+      <strong>${escapeHtml(adapter.provider_adapter_id)}</strong>
+      <p class="muted">${escapeHtml(adapter.provider)} · ${escapeHtml(adapter.adapter_kind)} · max ${adapter.max_run_token_budget.toLocaleString()} tokens.</p>
+      <p class="muted">Models: ${adapter.models.map((model) => escapeHtml(model)).join(", ")}</p>
+      <p class="muted">${adapter.executable_path ? `Executable: ${escapeHtml(adapter.executable_path)}` : "SDK adapter: no executable path required at this stage."}</p>
+    </div>
+  `;
 };
 
 const renderLaunchIntent = (intent) => {
@@ -1243,6 +1277,23 @@ byId("manager-plan-form").addEventListener("submit", (event) => {
     provider: byId("plan-provider").value,
     budget: Number.parseInt(byId("plan-budget").value.replaceAll(/[^\d]/g, ""), 10),
   });
+});
+
+byId("provider-adapter-form").addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const adapter = await configureProviderAdapter({
+    provider: byId("adapter-provider").value,
+    kind: byId("adapter-kind").value,
+    executablePath: byId("adapter-executable").value.trim(),
+    models: byId("adapter-models")
+      .value.split(",")
+      .map((model) => model.trim())
+      .filter(Boolean),
+    budget: Number.parseInt(byId("adapter-budget").value.replaceAll(/[^\d]/g, ""), 10),
+  });
+  byId("provider-adapter-status").innerHTML = adapter
+    ? renderProviderAdapter(adapter)
+    : '<div class="provider-adapter"><span>Provider adapter rejected</span><p class="muted">Check provider, adapter kind, absolute CLI path and model list.</p></div>';
 });
 
 const persistedPlan = await loadPersistedPlanPreview();

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -955,6 +955,27 @@ nav a:hover {
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+.provider-adapter-form {
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 18px;
+  padding-bottom: 18px;
+}
+.provider-adapter {
+  background: rgba(125, 211, 252, 0.08);
+  border: 1px solid rgba(125, 211, 252, 0.26);
+  border-radius: 16px;
+  display: grid;
+  gap: 8px;
+  margin-bottom: 18px;
+  padding: 12px;
+}
+.provider-adapter span {
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 .preview-card.approved-preview {
   border-color: rgba(119, 240, 178, 0.48);
 }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -300,6 +300,20 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(blockedProviderProbe.status, 409);
     assert.equal((await blockedProviderProbe.json()).code, "worker_launch_preflight_required");
 
+    const invalidProviderAdapter = await fetch(`${base}/api/manager-plan/provider-adapters`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        provider: "Copilot SDK workers",
+        adapter_kind: "cli",
+        executable_path: "copilot",
+        models: ["copilot-sdk-default"],
+        max_run_token_budget: 120_000,
+      }),
+    });
+    assert.equal(invalidProviderAdapter.status, 400);
+    assert.equal((await invalidProviderAdapter.json()).code, "invalid_provider_adapter");
+
     const goal = "Persist this sensitive manager plan preview locally";
     const proposed = await fetch(`${base}/api/manager-plan/previews`, {
       method: "POST",
@@ -723,6 +737,28 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(workerPreflightsBody.schema, "yukh-control-plane-worker-launch-preflights-v1");
     assert.equal(workerPreflightsBody.preflights.length, 1);
 
+    const providerAdapter = await fetch(`${base}/api/manager-plan/provider-adapters`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        provider: "Copilot SDK workers",
+        adapter_kind: "sdk",
+        models: ["copilot-sdk-default", "copilot-sdk-small"],
+        max_run_token_budget: 120_000,
+      }),
+    });
+    assert.equal(providerAdapter.status, 201);
+    const providerAdapterBody = await providerAdapter.json();
+    assert.equal(providerAdapterBody.provider_adapter.provider, "Copilot SDK workers");
+    assert.equal(providerAdapterBody.provider_adapter.adapter_kind, "sdk");
+    assert.equal(providerAdapterBody.provider_adapter.command_policy, "bounded_control_plane_only");
+
+    const providerAdapters = await fetch(`${base}/api/manager-plan/provider-adapters`);
+    assert.equal(providerAdapters.status, 200);
+    const providerAdaptersBody = await providerAdapters.json();
+    assert.equal(providerAdaptersBody.schema, "yukh-control-plane-provider-adapters-v1");
+    assert.equal(providerAdaptersBody.adapters.length, 1);
+
     const providerProbe = await fetch(`${base}/api/manager-plan/provider-runtime-probes`, {
       method: "POST",
     });
@@ -753,20 +789,17 @@ test("control plane preview persists local manager plan previews without leaking
       providerProbeBody.provider_runtime_probe.probe_scope,
       "local_control_plane_configuration",
     );
-    assert.equal(providerProbeBody.provider_runtime_probe.provider_adapter, "not_configured");
-    assert.equal(providerProbeBody.provider_runtime_probe.executable_check, "not_performed");
-    assert.equal(providerProbeBody.provider_runtime_probe.capability_inventory, "not_requested");
+    assert.equal(providerProbeBody.provider_runtime_probe.provider_adapter, "configured");
+    assert.equal(providerProbeBody.provider_runtime_probe.executable_check, "not_required");
     assert.equal(
-      providerProbeBody.provider_runtime_probe.outcome,
-      "blocked_provider_adapter_not_configured",
+      providerProbeBody.provider_runtime_probe.capability_inventory,
+      "local_inventory_available",
     );
+    assert.equal(providerProbeBody.provider_runtime_probe.outcome, "ready_for_worker_launch");
     assert.equal(providerProbeBody.provider_runtime_probe.worker_launch, "not_performed");
     assert.equal(providerProbeBody.provider_runtime_probe.coordination_write, "not_performed");
     assert.equal(providerProbeBody.provider_runtime_probe.projects_write, "not_performed");
-    assert.equal(
-      providerProbeBody.provider_runtime_probe.next_required_action,
-      "configure_provider_adapter",
-    );
+    assert.equal(providerProbeBody.provider_runtime_probe.next_required_action, "launch_workers");
     assert.match(
       providerProbeBody.provider_runtime_probe.provider_runtime_probe_id,
       /^provider-runtime-probe-/u,
@@ -858,6 +891,12 @@ test("control plane preview persists local manager plan previews without leaking
     });
     assert.equal(providerProbeDenied.status, 405);
     assert.equal(providerProbeDenied.headers.get("allow"), "GET, POST");
+
+    const providerAdapterDenied = await fetch(`${base}/api/manager-plan/provider-adapters`, {
+      method: "DELETE",
+    });
+    assert.equal(providerAdapterDenied.status, 405);
+    assert.equal(providerAdapterDenied.headers.get("allow"), "GET, POST");
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
@@ -879,6 +918,7 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(html, /Team detail/u);
   assert.match(html, /Plan, workers, tokens and next action/u);
   assert.match(html, /manager-plan-form/u);
+  assert.match(html, /provider-adapter-form/u);
   assert.match(html, /plan-preview/u);
   assert.match(html, /Yukh Projects/u);
   assert.match(html, /Yukh MCP/u);
@@ -905,6 +945,7 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /api\/manager-plan\/worker-delegation-approvals/u);
   assert.match(data, /api\/manager-plan\/worker-launch-preflights/u);
   assert.match(data, /api\/manager-plan\/provider-runtime-probes/u);
+  assert.match(data, /api\/manager-plan\/provider-adapters/u);
   assert.match(data, /Launch readiness/u);
   assert.match(data, /Launch intent recorded/u);
   assert.match(data, /Manager run planned/u);
@@ -915,6 +956,7 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /Worker delegation approved/u);
   assert.match(data, /Worker launch preflight/u);
   assert.match(data, /Provider runtime probe/u);
+  assert.match(data, /Provider adapter configured/u);
   assert.match(data, /provider_process/u);
   assert.match(data, /worker_delegation/u);
   assert.match(data, /worker_launch/u);


### PR DESCRIPTION
## Summary
- add bounded Control Plane provider adapter configuration records and API
- expose provider adapter setup in the preview UI
- let provider runtime probes distinguish missing adapters, SDK adapters, missing CLI executables, and ready local inventory

## Validation
- npm run format:check
- npm run typecheck
- npm run build
- node --import tsx --test test/runtime/control-plane-preview.test.ts
- git diff --check

## Safety
No provider process, worker launch, Coordination write, or Projects write is performed by this increment.