### PR TITLE
Add Control Plane provider capability inventory

### DIFF
--- a/.context/sessions/SESSION-2026-08-19-10-control-plane-provider-capability-inventory.md
+++ b/.context/sessions/SESSION-2026-08-19-10-control-plane-provider-capability-inventory.md
@@ -1,0 +1,28 @@
+# Control Plane provider capability inventory
+
+Date: 2026-08-19
+
+## Outcome
+
+Added a bounded provider capability inventory step after provider adapter configuration.
+
+## Scope
+
+- Added `GET /api/manager-plan/provider-capability-inventories`.
+- Added `POST /api/manager-plan/provider-capability-inventories`.
+- Added UI action to inventory capabilities from the configured adapter.
+- Records model names and max run token budget from local adapter configuration.
+- Invalidates old capability inventory when a provider adapter is reconfigured.
+
+## Safety boundary
+
+This increment does not invoke Codex, Copilot, SDKs, CLIs or worker processes.
+The inventory source is the local provider adapter config only.
+
+## Validation
+
+- `npm run format:check`
+- `npm run typecheck`
+- `npm run build`
+- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
+- `git diff --check`

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -38,6 +38,8 @@ const API_WORKER_DELEGATION_APPROVALS_PATH = "/api/manager-plan/worker-delegatio
 const API_WORKER_LAUNCH_PREFLIGHTS_PATH = "/api/manager-plan/worker-launch-preflights";
 const API_PROVIDER_RUNTIME_PROBES_PATH = "/api/manager-plan/provider-runtime-probes";
 const API_PROVIDER_ADAPTERS_PATH = "/api/manager-plan/provider-adapters";
+const API_PROVIDER_CAPABILITY_INVENTORIES_PATH =
+  "/api/manager-plan/provider-capability-inventories";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
@@ -622,6 +624,60 @@ export function createControlPlaneServer(
               schema: 1,
               status: "error",
               code: "invalid_provider_adapter",
+            }),
+          );
+        }
+        return;
+      }
+      response.writeHead(405, {
+        allow: "GET, POST",
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+      return;
+    }
+
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_PROVIDER_CAPABILITY_INVENTORIES_PATH
+    ) {
+      if (!options.planPreviewStore) {
+        response.writeHead(503, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "store_unconfigured" }));
+        return;
+      }
+      if (request.method === "GET") {
+        response.writeHead(200, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify(options.planPreviewStore.providerCapabilityInventories()));
+        return;
+      }
+      if (request.method === "POST") {
+        try {
+          const record = options.planPreviewStore.inventoryProviderCapabilities();
+          response.writeHead(201, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({ schema: 1, status: "ok", provider_capability_inventory: record }),
+          );
+        } catch {
+          response.writeHead(409, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({
+              schema: 1,
+              status: "error",
+              code: "provider_adapter_required",
             }),
           );
         }

--- a/apps/control-plane-preview/src/plan-preview-store.ts
+++ b/apps/control-plane-preview/src/plan-preview-store.ts
@@ -292,6 +292,29 @@ export type ControlPlaneProviderAdapterInput = {
   readonly max_run_token_budget: number;
 };
 
+export type ControlPlaneProviderCapabilityInventoryRecord = {
+  readonly schema: 1;
+  readonly provider_capability_inventory_id: string;
+  readonly provider_adapter_id: string;
+  readonly provider: string;
+  readonly adapter_kind: "cli" | "sdk";
+  readonly models: readonly {
+    readonly model: string;
+    readonly source: "configured_adapter";
+    readonly max_run_token_budget: number;
+  }[];
+  readonly command_policy: "bounded_control_plane_only";
+  readonly inventory_source: "local_provider_adapter_config";
+  readonly provider_call: "not_performed";
+  readonly created_at: string;
+};
+
+export type ControlPlaneProviderCapabilityInventoryStatus = {
+  readonly schema: "yukh-control-plane-provider-capability-inventories-v1";
+  readonly source: "local-control-plane-store";
+  readonly inventories: readonly ControlPlaneProviderCapabilityInventoryRecord[];
+};
+
 export type ControlPlanePlanPreviewInput = {
   readonly goal: string;
   readonly mode: string;
@@ -313,6 +336,7 @@ type Document = {
   readonly worker_launch_preflights?: readonly ControlPlaneWorkerLaunchPreflightRecord[];
   readonly provider_runtime_probes?: readonly ControlPlaneProviderRuntimeProbeRecord[];
   readonly provider_adapters?: readonly ControlPlaneProviderAdapterRecord[];
+  readonly provider_capability_inventories?: readonly ControlPlaneProviderCapabilityInventoryRecord[];
 };
 
 const validMode = new Set(["plan-first", "delegate, explicit workers"]);
@@ -563,6 +587,50 @@ export class ControlPlanePlanPreviewStore {
     };
   }
 
+  providerCapabilityInventories(): ControlPlaneProviderCapabilityInventoryStatus {
+    return {
+      schema: "yukh-control-plane-provider-capability-inventories-v1",
+      source: "local-control-plane-store",
+      inventories: this.#read().provider_capability_inventories ?? [],
+    };
+  }
+
+  inventoryProviderCapabilities(): ControlPlaneProviderCapabilityInventoryRecord {
+    const document = this.#read();
+    const adapter = document.provider_adapters?.[0];
+    if (!adapter) {
+      throw new TypeError("missing provider adapter");
+    }
+    const existing = document.provider_capability_inventories?.find(
+      (inventory) => inventory.provider_adapter_id === adapter.provider_adapter_id,
+    );
+    if (existing) return existing;
+    const record: ControlPlaneProviderCapabilityInventoryRecord = {
+      schema: 1,
+      provider_capability_inventory_id: `provider-capability-inventory-${randomUUID()}`,
+      provider_adapter_id: adapter.provider_adapter_id,
+      provider: adapter.provider,
+      adapter_kind: adapter.adapter_kind,
+      models: adapter.models.map((model) => ({
+        model,
+        source: "configured_adapter",
+        max_run_token_budget: adapter.max_run_token_budget,
+      })),
+      command_policy: "bounded_control_plane_only",
+      inventory_source: "local_provider_adapter_config",
+      provider_call: "not_performed",
+      created_at: new Date().toISOString(),
+    };
+    this.#write({
+      ...document,
+      provider_capability_inventories: [
+        record,
+        ...(document.provider_capability_inventories ?? []),
+      ].slice(0, 20),
+    });
+    return record;
+  }
+
   configureProviderAdapter(
     input: ControlPlaneProviderAdapterInput,
   ): ControlPlaneProviderAdapterRecord {
@@ -585,6 +653,9 @@ export class ControlPlanePlanPreviewStore {
     this.#write({
       ...document,
       provider_adapters: [record, ...retained].slice(0, 20),
+      provider_capability_inventories: (document.provider_capability_inventories ?? []).filter(
+        (inventory) => inventory.provider !== input.provider,
+      ),
     });
     return record;
   }
@@ -1086,6 +1157,9 @@ export class ControlPlanePlanPreviewStore {
         provider_adapters: Array.isArray(parsed.provider_adapters)
           ? parsed.provider_adapters.filter((item) => item?.schema === 1)
           : [],
+        provider_capability_inventories: Array.isArray(parsed.provider_capability_inventories)
+          ? parsed.provider_capability_inventories.filter((item) => item?.schema === 1)
+          : [],
       };
     } catch {
       return {
@@ -1101,6 +1175,7 @@ export class ControlPlanePlanPreviewStore {
         worker_launch_preflights: [],
         provider_runtime_probes: [],
         provider_adapters: [],
+        provider_capability_inventories: [],
       };
     }
   }
@@ -1110,6 +1185,8 @@ export class ControlPlanePlanPreviewStore {
     const normalized: Document = {
       ...document,
       provider_adapters: document.provider_adapters ?? current.provider_adapters ?? [],
+      provider_capability_inventories:
+        document.provider_capability_inventories ?? current.provider_capability_inventories ?? [],
     };
     const tmp = `${this.#path}.${process.pid}.${Date.now()}.tmp`;
     writeFileSync(tmp, `${JSON.stringify(normalized, null, 2)}\n`, { mode: 0o600 });

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -800,6 +800,21 @@ const configureProviderAdapter = async ({ provider, kind, executablePath, models
   }
 };
 
+const inventoryProviderCapabilities = async () => {
+  try {
+    const response = await fetch("./api/manager-plan/provider-capability-inventories", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return body?.provider_capability_inventory ?? null;
+  } catch {
+    return null;
+  }
+};
+
 const probeProviderRuntime = async () => {
   try {
     const response = await fetch("./api/manager-plan/provider-runtime-probes", {
@@ -824,6 +839,32 @@ const renderProviderAdapter = (adapter) => {
       <p class="muted">${escapeHtml(adapter.provider)} · ${escapeHtml(adapter.adapter_kind)} · max ${adapter.max_run_token_budget.toLocaleString()} tokens.</p>
       <p class="muted">Models: ${adapter.models.map((model) => escapeHtml(model)).join(", ")}</p>
       <p class="muted">${adapter.executable_path ? `Executable: ${escapeHtml(adapter.executable_path)}` : "SDK adapter: no executable path required at this stage."}</p>
+      <button type="button" class="secondary provider-inventory-button">Inventory capabilities</button>
+    </div>
+  `;
+};
+
+const renderProviderCapabilityInventory = (inventory) => {
+  if (!inventory) return "";
+  return `
+    <div class="provider-capability-inventory">
+      <span>Provider capability inventory</span>
+      <strong>${escapeHtml(inventory.provider_capability_inventory_id)}</strong>
+      <p class="muted">${escapeHtml(inventory.provider)} · ${escapeHtml(inventory.adapter_kind)} · source ${escapeHtml(inventory.inventory_source)}.</p>
+      <div class="preflight-grid">
+        ${inventory.models
+          .map(
+            (model) => `
+              <article>
+                <span>${escapeHtml(model.source)}</span>
+                <strong>${escapeHtml(model.model)}</strong>
+                <p class="muted">Max ${model.max_run_token_budget.toLocaleString()} tokens.</p>
+              </article>
+            `,
+          )
+          .join("")}
+      </div>
+      <p class="muted">Provider call: ${escapeHtml(inventory.provider_call)} · commands ${escapeHtml(inventory.command_policy)}.</p>
     </div>
   `;
 };
@@ -1294,6 +1335,22 @@ byId("provider-adapter-form").addEventListener("submit", async (event) => {
   byId("provider-adapter-status").innerHTML = adapter
     ? renderProviderAdapter(adapter)
     : '<div class="provider-adapter"><span>Provider adapter rejected</span><p class="muted">Check provider, adapter kind, absolute CLI path and model list.</p></div>';
+});
+
+byId("provider-adapter-status").addEventListener("click", async (event) => {
+  const button = event.target.closest(".provider-inventory-button");
+  if (!button) return;
+  button.setAttribute("disabled", "true");
+  const inventory = await inventoryProviderCapabilities();
+  if (!inventory) {
+    button.removeAttribute("disabled");
+    button.textContent = "Provider adapter required";
+    return;
+  }
+  button.textContent = "Capability inventory recorded";
+  button
+    .closest(".provider-adapter")
+    ?.insertAdjacentHTML("afterend", renderProviderCapabilityInventory(inventory));
 });
 
 const persistedPlan = await loadPersistedPlanPreview();

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -976,6 +976,22 @@ nav a:hover {
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+.provider-capability-inventory {
+  background: rgba(119, 240, 178, 0.08);
+  border: 1px solid rgba(119, 240, 178, 0.28);
+  border-radius: 16px;
+  display: grid;
+  gap: 10px;
+  margin-bottom: 18px;
+  padding: 12px;
+}
+.provider-capability-inventory span {
+  color: var(--ok);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 .preview-card.approved-preview {
   border-color: rgba(119, 240, 178, 0.48);
 }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -300,6 +300,13 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(blockedProviderProbe.status, 409);
     assert.equal((await blockedProviderProbe.json()).code, "worker_launch_preflight_required");
 
+    const blockedProviderInventory = await fetch(
+      `${base}/api/manager-plan/provider-capability-inventories`,
+      { method: "POST" },
+    );
+    assert.equal(blockedProviderInventory.status, 409);
+    assert.equal((await blockedProviderInventory.json()).code, "provider_adapter_required");
+
     const invalidProviderAdapter = await fetch(`${base}/api/manager-plan/provider-adapters`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -759,6 +766,58 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(providerAdaptersBody.schema, "yukh-control-plane-provider-adapters-v1");
     assert.equal(providerAdaptersBody.adapters.length, 1);
 
+    const providerInventory = await fetch(
+      `${base}/api/manager-plan/provider-capability-inventories`,
+      { method: "POST" },
+    );
+    assert.equal(providerInventory.status, 201);
+    const providerInventoryBody = await providerInventory.json();
+    assert.equal(
+      providerInventoryBody.provider_capability_inventory.provider_adapter_id,
+      providerAdapterBody.provider_adapter.provider_adapter_id,
+    );
+    assert.equal(
+      providerInventoryBody.provider_capability_inventory.provider,
+      "Copilot SDK workers",
+    );
+    assert.equal(providerInventoryBody.provider_capability_inventory.adapter_kind, "sdk");
+    assert.equal(
+      providerInventoryBody.provider_capability_inventory.inventory_source,
+      "local_provider_adapter_config",
+    );
+    assert.equal(
+      providerInventoryBody.provider_capability_inventory.provider_call,
+      "not_performed",
+    );
+    assert.deepEqual(
+      providerInventoryBody.provider_capability_inventory.models.map(
+        (model: { readonly model: string }) => model.model,
+      ),
+      ["copilot-sdk-default", "copilot-sdk-small"],
+    );
+
+    const repeatedProviderInventory = await fetch(
+      `${base}/api/manager-plan/provider-capability-inventories`,
+      { method: "POST" },
+    );
+    assert.equal(repeatedProviderInventory.status, 201);
+    assert.equal(
+      (await repeatedProviderInventory.json()).provider_capability_inventory
+        .provider_capability_inventory_id,
+      providerInventoryBody.provider_capability_inventory.provider_capability_inventory_id,
+    );
+
+    const providerInventories = await fetch(
+      `${base}/api/manager-plan/provider-capability-inventories`,
+    );
+    assert.equal(providerInventories.status, 200);
+    const providerInventoriesBody = await providerInventories.json();
+    assert.equal(
+      providerInventoriesBody.schema,
+      "yukh-control-plane-provider-capability-inventories-v1",
+    );
+    assert.equal(providerInventoriesBody.inventories.length, 1);
+
     const providerProbe = await fetch(`${base}/api/manager-plan/provider-runtime-probes`, {
       method: "POST",
     });
@@ -897,6 +956,13 @@ test("control plane preview persists local manager plan previews without leaking
     });
     assert.equal(providerAdapterDenied.status, 405);
     assert.equal(providerAdapterDenied.headers.get("allow"), "GET, POST");
+
+    const providerInventoryDenied = await fetch(
+      `${base}/api/manager-plan/provider-capability-inventories`,
+      { method: "DELETE" },
+    );
+    assert.equal(providerInventoryDenied.status, 405);
+    assert.equal(providerInventoryDenied.headers.get("allow"), "GET, POST");
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
@@ -946,6 +1012,7 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /api\/manager-plan\/worker-launch-preflights/u);
   assert.match(data, /api\/manager-plan\/provider-runtime-probes/u);
   assert.match(data, /api\/manager-plan\/provider-adapters/u);
+  assert.match(data, /api\/manager-plan\/provider-capability-inventories/u);
   assert.match(data, /Launch readiness/u);
   assert.match(data, /Launch intent recorded/u);
   assert.match(data, /Manager run planned/u);
@@ -957,6 +1024,7 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /Worker launch preflight/u);
   assert.match(data, /Provider runtime probe/u);
   assert.match(data, /Provider adapter configured/u);
+  assert.match(data, /Provider capability inventory/u);
   assert.match(data, /provider_process/u);
   assert.match(data, /worker_delegation/u);
   assert.match(data, /worker_launch/u);


### PR DESCRIPTION
## Summary
- add bounded provider capability inventory API
- surface adapter model inventory in the Control Plane UI
- invalidate old inventories when provider adapters are reconfigured

## Validation
- npm run format:check
- npm run typecheck
- npm run build
- node --import tsx --test test/runtime/control-plane-preview.test.ts
- git diff --check

## Safety
No provider SDK/CLI call, worker launch, Coordination write, or Projects write is performed by this increment.