### PR TITLE
Add Control Plane provider model discovery

### DIFF
--- a/.context/sessions/SESSION-2026-08-19-11-control-plane-provider-model-discovery.md
+++ b/.context/sessions/SESSION-2026-08-19-11-control-plane-provider-model-discovery.md
@@ -1,0 +1,29 @@
+# Control Plane provider model discovery
+
+Date: 2026-08-19
+
+## Outcome
+
+Added a read-only provider model discovery hook for Control Plane capability inventory.
+
+## Scope
+
+- Reused the existing team-control model discovery module.
+- Added a provider model discoverer dependency to the Control Plane plan preview store.
+- Wired the preview server to discover Codex CLI and Copilot SDK worker model catalogs when an adapter has an executable path.
+- Kept model inventory constrained by the configured adapter allowlist.
+- Preserved local adapter config inventory as the fallback when discovery is unavailable.
+
+## Safety boundary
+
+This increment does not launch workers and does not write to Coordination or Projects.
+Provider discovery is only reached from the explicit capability inventory action.
+Discovered models are filtered through the configured adapter allowlist.
+
+## Validation
+
+- `npm run format:check`
+- `npm run typecheck`
+- `npm run build`
+- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
+- `git diff --check`

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -2,10 +2,15 @@ import { createServer, type IncomingMessage, type Server } from "node:http";
 import { readFile } from "node:fs/promises";
 import { dirname, join, normalize } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  discoverCodexModels,
+  discoverCopilotModelCatalog,
+} from "../../../packages/team-control/src/model-discovery.js";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
 import {
   ControlPlanePlanPreviewStore,
   type ControlPlaneProviderAdapterInput,
+  type ControlPlaneProviderModelDiscoverer,
   type ControlPlanePlanPreviewInput,
 } from "./plan-preview-store.js";
 import { createTeamStatus } from "./team-status.js";
@@ -98,6 +103,20 @@ async function readJsonBody(request: IncomingMessage): Promise<unknown> {
   }
   return JSON.parse(Buffer.concat(chunks).toString("utf8"));
 }
+
+export const discoverConfiguredProviderModels: ControlPlaneProviderModelDiscoverer = async (
+  adapter,
+) => {
+  if (!adapter.executable_path) return undefined;
+  if (adapter.provider === "Codex manager CLI") {
+    return { models: discoverCodexModels(adapter.executable_path), source: "cli" };
+  }
+  if (adapter.provider === "Copilot SDK workers") {
+    const catalog = await discoverCopilotModelCatalog(adapter.executable_path);
+    return { models: catalog.models, source: catalog.source };
+  }
+  return undefined;
+};
 
 export function createControlPlaneServer(
   staticRoot = defaultStaticRoot(),
@@ -660,7 +679,7 @@ export function createControlPlaneServer(
       }
       if (request.method === "POST") {
         try {
-          const record = options.planPreviewStore.inventoryProviderCapabilities();
+          const record = await options.planPreviewStore.inventoryProviderCapabilities();
           response.writeHead(201, {
             "cache-control": "no-store",
             "content-type": "application/json; charset=utf-8",
@@ -805,7 +824,13 @@ export async function startControlPlane(options: ControlPlaneOptions): Promise<S
     options.workspace ?? process.env.YUKH_CONVERSATION_WORKSPACE ?? process.env.YUKH_TEAM_WORKSPACE;
   const server = createControlPlaneServer(options.staticRoot, {
     ...(workspace ? { teamStore: new TeamStore(workspace) } : {}),
-    ...(workspace ? { planPreviewStore: new ControlPlanePlanPreviewStore(workspace) } : {}),
+    ...(workspace
+      ? {
+          planPreviewStore: new ControlPlanePlanPreviewStore(workspace, {
+            discoverProviderModels: discoverConfiguredProviderModels,
+          }),
+        }
+      : {}),
   });
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);

--- a/apps/control-plane-preview/src/plan-preview-store.ts
+++ b/apps/control-plane-preview/src/plan-preview-store.ts
@@ -300,14 +300,28 @@ export type ControlPlaneProviderCapabilityInventoryRecord = {
   readonly adapter_kind: "cli" | "sdk";
   readonly models: readonly {
     readonly model: string;
-    readonly source: "configured_adapter";
+    readonly source: "configured_adapter" | "provider_discovery";
     readonly max_run_token_budget: number;
   }[];
   readonly command_policy: "bounded_control_plane_only";
-  readonly inventory_source: "local_provider_adapter_config";
+  readonly inventory_source:
+    | "local_provider_adapter_config"
+    | "provider_cli"
+    | "provider_sdk"
+    | "provider_env"
+    | "provider_fallback";
   readonly provider_call: "not_performed";
   readonly created_at: string;
 };
+
+export type ControlPlaneProviderModelDiscoveryResult = {
+  readonly models: readonly string[];
+  readonly source: "cli" | "sdk" | "env" | "fallback";
+};
+
+export type ControlPlaneProviderModelDiscoverer = (
+  adapter: ControlPlaneProviderAdapterRecord,
+) => Promise<ControlPlaneProviderModelDiscoveryResult | undefined>;
 
 export type ControlPlaneProviderCapabilityInventoryStatus = {
   readonly schema: "yukh-control-plane-provider-capability-inventories-v1";
@@ -429,12 +443,17 @@ function executableCheck(
 
 export class ControlPlanePlanPreviewStore {
   readonly #path: string;
+  readonly #discoverProviderModels: ControlPlaneProviderModelDiscoverer;
 
-  constructor(workspace: string) {
+  constructor(
+    workspace: string,
+    options: { readonly discoverProviderModels?: ControlPlaneProviderModelDiscoverer } = {},
+  ) {
     if (!isAbsolute(workspace)) throw new TypeError("invalid control plane workspace");
     const root = join(workspace, ".yukh", "control-plane");
     mkdirSync(root, { recursive: true, mode: 0o700 });
     this.#path = join(root, "plan-previews.json");
+    this.#discoverProviderModels = options.discoverProviderModels ?? (async () => undefined);
   }
 
   status(): ControlPlanePlanPreviewStoreStatus {
@@ -595,7 +614,7 @@ export class ControlPlanePlanPreviewStore {
     };
   }
 
-  inventoryProviderCapabilities(): ControlPlaneProviderCapabilityInventoryRecord {
+  async inventoryProviderCapabilities(): Promise<ControlPlaneProviderCapabilityInventoryRecord> {
     const document = this.#read();
     const adapter = document.provider_adapters?.[0];
     if (!adapter) {
@@ -605,19 +624,35 @@ export class ControlPlanePlanPreviewStore {
       (inventory) => inventory.provider_adapter_id === adapter.provider_adapter_id,
     );
     if (existing) return existing;
+    const discovery = await this.#discoverProviderModels(adapter);
+    const discoveredModels =
+      discovery?.models.filter((model) => adapter.models.includes(model)) ?? [];
+    const models = discoveredModels.length > 0 ? discoveredModels : adapter.models;
+    const source = discoveredModels.length > 0 ? "provider_discovery" : "configured_adapter";
+    const inventorySource =
+      discoveredModels.length > 0
+        ? (
+            {
+              cli: "provider_cli",
+              sdk: "provider_sdk",
+              env: "provider_env",
+              fallback: "provider_fallback",
+            } as const
+          )[discovery?.source ?? "fallback"]
+        : "local_provider_adapter_config";
     const record: ControlPlaneProviderCapabilityInventoryRecord = {
       schema: 1,
       provider_capability_inventory_id: `provider-capability-inventory-${randomUUID()}`,
       provider_adapter_id: adapter.provider_adapter_id,
       provider: adapter.provider,
       adapter_kind: adapter.adapter_kind,
-      models: adapter.models.map((model) => ({
+      models: models.map((model) => ({
         model,
-        source: "configured_adapter",
+        source,
         max_run_token_budget: adapter.max_run_token_budget,
       })),
       command_policy: "bounded_control_plane_only",
-      inventory_source: "local_provider_adapter_config",
+      inventory_source: inventorySource,
       provider_call: "not_performed",
       created_at: new Date().toISOString(),
     };

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -970,6 +970,53 @@ test("control plane preview persists local manager plan previews without leaking
   }
 });
 
+test("control plane provider capability inventory can use read-only model discovery", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "yukh-control-plane-model-discovery-"));
+  const executable = join(workspace, "codex");
+  await writeFile(executable, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+  const store = new ControlPlanePlanPreviewStore(workspace, {
+    discoverProviderModels: async (adapter) => {
+      assert.equal(adapter.provider, "Codex manager CLI");
+      assert.equal(adapter.executable_path, executable);
+      return { source: "cli", models: ["gpt-5.6-sol", "not-allowlisted"] };
+    },
+  });
+
+  const adapter = store.configureProviderAdapter({
+    provider: "Codex manager CLI",
+    adapter_kind: "cli",
+    executable_path: executable,
+    models: ["gpt-5.6-sol", "gpt-5.6-terra"],
+    max_run_token_budget: 90_000,
+  });
+  const inventory = await store.inventoryProviderCapabilities();
+
+  assert.equal(inventory.provider_adapter_id, adapter.provider_adapter_id);
+  assert.equal(inventory.provider, "Codex manager CLI");
+  assert.equal(inventory.adapter_kind, "cli");
+  assert.equal(inventory.inventory_source, "provider_cli");
+  assert.equal(inventory.provider_call, "not_performed");
+  assert.deepEqual(
+    inventory.models.map((model) => ({
+      model: model.model,
+      source: model.source,
+      max_run_token_budget: model.max_run_token_budget,
+    })),
+    [
+      {
+        model: "gpt-5.6-sol",
+        source: "provider_discovery",
+        max_run_token_budget: 90_000,
+      },
+    ],
+  );
+
+  assert.equal(
+    (await store.inventoryProviderCapabilities()).provider_capability_inventory_id,
+    inventory.provider_capability_inventory_id,
+  );
+});
+
 test("control plane preview explains runtime topology without Mermaid", async () => {
   const html = await readFile("apps/control-plane-preview/static/index.html", "utf8");
   const data = await readFile("apps/control-plane-preview/static/mock-data.js", "utf8");


### PR DESCRIPTION
## Summary
- add read-only provider model discovery hook for Control Plane capability inventory
- wire Codex CLI and Copilot SDK worker catalog discovery when an adapter executable path is configured
- filter discovered models through the configured provider adapter allowlist

## Validation
- npm run format:check
- npm run typecheck
- npm run build
- node --import tsx --test test/runtime/control-plane-preview.test.ts
- git diff --check

## Safety
No worker launch, Coordination write, or Projects write is performed. Discovery is only reached from the explicit capability inventory action and discovered models are allowlist-filtered.