### PR TITLE
Add Control Plane worker launch candidate

### DIFF
--- a/.context/sessions/SESSION-2026-08-19-12-control-plane-worker-launch-candidate.md
+++ b/.context/sessions/SESSION-2026-08-19-12-control-plane-worker-launch-candidate.md
@@ -1,0 +1,31 @@
+# Control Plane worker launch candidate
+
+Date: 2026-08-19
+
+## Outcome
+
+Added a gated worker launch candidate step to the Control Plane.
+
+## Scope
+
+- Added `GET /api/manager-plan/worker-launch-candidates`.
+- Added `POST /api/manager-plan/worker-launch-candidates`.
+- Added UI action after provider runtime probe readiness.
+- Candidate creation requires:
+  - ready provider runtime probe;
+  - provider capability inventory;
+  - matching worker launch preflight.
+- Candidate records approved worker count, worker token budget, allowlisted models and next action.
+
+## Safety boundary
+
+This increment still does not start provider processes, launch workers, write Coordination events or write Projects events.
+It records only that the launch is ready for a future explicit launch action.
+
+## Validation
+
+- `npm run format:check`
+- `npm run typecheck`
+- `npm run build`
+- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
+- `git diff --check`

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -45,6 +45,7 @@ const API_PROVIDER_RUNTIME_PROBES_PATH = "/api/manager-plan/provider-runtime-pro
 const API_PROVIDER_ADAPTERS_PATH = "/api/manager-plan/provider-adapters";
 const API_PROVIDER_CAPABILITY_INVENTORIES_PATH =
   "/api/manager-plan/provider-capability-inventories";
+const API_WORKER_LAUNCH_CANDIDATES_PATH = "/api/manager-plan/worker-launch-candidates";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
@@ -697,6 +698,60 @@ export function createControlPlaneServer(
               schema: 1,
               status: "error",
               code: "provider_adapter_required",
+            }),
+          );
+        }
+        return;
+      }
+      response.writeHead(405, {
+        allow: "GET, POST",
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+      return;
+    }
+
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_WORKER_LAUNCH_CANDIDATES_PATH
+    ) {
+      if (!options.planPreviewStore) {
+        response.writeHead(503, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "store_unconfigured" }));
+        return;
+      }
+      if (request.method === "GET") {
+        response.writeHead(200, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify(options.planPreviewStore.workerLaunchCandidates()));
+        return;
+      }
+      if (request.method === "POST") {
+        try {
+          const record = options.planPreviewStore.createWorkerLaunchCandidate();
+          response.writeHead(201, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({ schema: 1, status: "ok", worker_launch_candidate: record }),
+          );
+        } catch {
+          response.writeHead(409, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({
+              schema: 1,
+              status: "error",
+              code: "worker_launch_candidate_not_ready",
             }),
           );
         }

--- a/apps/control-plane-preview/src/plan-preview-store.ts
+++ b/apps/control-plane-preview/src/plan-preview-store.ts
@@ -329,6 +329,35 @@ export type ControlPlaneProviderCapabilityInventoryStatus = {
   readonly inventories: readonly ControlPlaneProviderCapabilityInventoryRecord[];
 };
 
+export type ControlPlaneWorkerLaunchCandidateRecord = {
+  readonly schema: 1;
+  readonly worker_launch_candidate_id: string;
+  readonly provider_runtime_probe_id: string;
+  readonly provider_capability_inventory_id: string;
+  readonly worker_launch_preflight_id: string;
+  readonly worker_delegation_approval_id: string;
+  readonly worker_delegation_plan_id: string;
+  readonly manager_process_id: string;
+  readonly manager_run_id: string;
+  readonly provider: string;
+  readonly approved_worker_count: number;
+  readonly approved_worker_token_budget: number;
+  readonly models: readonly string[];
+  readonly outcome: "ready_for_explicit_worker_launch";
+  readonly provider_process_start: "not_performed";
+  readonly worker_launch: "not_performed";
+  readonly coordination_write: "not_performed";
+  readonly projects_write: "not_performed";
+  readonly created_at: string;
+  readonly next_required_action: "explicit_worker_launch";
+};
+
+export type ControlPlaneWorkerLaunchCandidateStatus = {
+  readonly schema: "yukh-control-plane-worker-launch-candidates-v1";
+  readonly source: "local-control-plane-store";
+  readonly candidates: readonly ControlPlaneWorkerLaunchCandidateRecord[];
+};
+
 export type ControlPlanePlanPreviewInput = {
   readonly goal: string;
   readonly mode: string;
@@ -351,6 +380,7 @@ type Document = {
   readonly provider_runtime_probes?: readonly ControlPlaneProviderRuntimeProbeRecord[];
   readonly provider_adapters?: readonly ControlPlaneProviderAdapterRecord[];
   readonly provider_capability_inventories?: readonly ControlPlaneProviderCapabilityInventoryRecord[];
+  readonly worker_launch_candidates?: readonly ControlPlaneWorkerLaunchCandidateRecord[];
 };
 
 const validMode = new Set(["plan-first", "delegate, explicit workers"]);
@@ -612,6 +642,67 @@ export class ControlPlanePlanPreviewStore {
       source: "local-control-plane-store",
       inventories: this.#read().provider_capability_inventories ?? [],
     };
+  }
+
+  workerLaunchCandidates(): ControlPlaneWorkerLaunchCandidateStatus {
+    return {
+      schema: "yukh-control-plane-worker-launch-candidates-v1",
+      source: "local-control-plane-store",
+      candidates: this.#read().worker_launch_candidates ?? [],
+    };
+  }
+
+  createWorkerLaunchCandidate(): ControlPlaneWorkerLaunchCandidateRecord {
+    const document = this.#read();
+    const probe = document.provider_runtime_probes?.[0];
+    if (!probe || probe.outcome !== "ready_for_worker_launch") {
+      throw new TypeError("provider runtime probe not ready");
+    }
+    const inventory = document.provider_capability_inventories?.find(
+      (candidate) => candidate.provider === probe.provider,
+    );
+    if (!inventory || inventory.models.length < 1) {
+      throw new TypeError("provider capability inventory required");
+    }
+    const preflight = document.worker_launch_preflights?.find(
+      (candidate) => candidate.worker_launch_preflight_id === probe.worker_launch_preflight_id,
+    );
+    if (!preflight) {
+      throw new TypeError("worker launch preflight required");
+    }
+    const existing = document.worker_launch_candidates?.find(
+      (candidate) =>
+        candidate.provider_runtime_probe_id === probe.provider_runtime_probe_id &&
+        candidate.provider_capability_inventory_id === inventory.provider_capability_inventory_id,
+    );
+    if (existing) return existing;
+    const record: ControlPlaneWorkerLaunchCandidateRecord = {
+      schema: 1,
+      worker_launch_candidate_id: `worker-launch-candidate-${randomUUID()}`,
+      provider_runtime_probe_id: probe.provider_runtime_probe_id,
+      provider_capability_inventory_id: inventory.provider_capability_inventory_id,
+      worker_launch_preflight_id: preflight.worker_launch_preflight_id,
+      worker_delegation_approval_id: preflight.worker_delegation_approval_id,
+      worker_delegation_plan_id: preflight.worker_delegation_plan_id,
+      manager_process_id: preflight.manager_process_id,
+      manager_run_id: preflight.manager_run_id,
+      provider: probe.provider,
+      approved_worker_count: preflight.approved_worker_count,
+      approved_worker_token_budget: preflight.approved_worker_token_budget,
+      models: inventory.models.map((model) => model.model),
+      outcome: "ready_for_explicit_worker_launch",
+      provider_process_start: "not_performed",
+      worker_launch: "not_performed",
+      coordination_write: "not_performed",
+      projects_write: "not_performed",
+      created_at: new Date().toISOString(),
+      next_required_action: "explicit_worker_launch",
+    };
+    this.#write({
+      ...document,
+      worker_launch_candidates: [record, ...(document.worker_launch_candidates ?? [])].slice(0, 20),
+    });
+    return record;
   }
 
   async inventoryProviderCapabilities(): Promise<ControlPlaneProviderCapabilityInventoryRecord> {
@@ -1195,6 +1286,9 @@ export class ControlPlanePlanPreviewStore {
         provider_capability_inventories: Array.isArray(parsed.provider_capability_inventories)
           ? parsed.provider_capability_inventories.filter((item) => item?.schema === 1)
           : [],
+        worker_launch_candidates: Array.isArray(parsed.worker_launch_candidates)
+          ? parsed.worker_launch_candidates.filter((item) => item?.schema === 1)
+          : [],
       };
     } catch {
       return {
@@ -1211,6 +1305,7 @@ export class ControlPlanePlanPreviewStore {
         provider_runtime_probes: [],
         provider_adapters: [],
         provider_capability_inventories: [],
+        worker_launch_candidates: [],
       };
     }
   }
@@ -1222,6 +1317,8 @@ export class ControlPlanePlanPreviewStore {
       provider_adapters: document.provider_adapters ?? current.provider_adapters ?? [],
       provider_capability_inventories:
         document.provider_capability_inventories ?? current.provider_capability_inventories ?? [],
+      worker_launch_candidates:
+        document.worker_launch_candidates ?? current.worker_launch_candidates ?? [],
     };
     const tmp = `${this.#path}.${process.pid}.${Date.now()}.tmp`;
     writeFileSync(tmp, `${JSON.stringify(normalized, null, 2)}\n`, { mode: 0o600 });

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -830,6 +830,21 @@ const probeProviderRuntime = async () => {
   }
 };
 
+const createWorkerLaunchCandidate = async () => {
+  try {
+    const response = await fetch("./api/manager-plan/worker-launch-candidates", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return body?.worker_launch_candidate ?? null;
+  } catch {
+    return null;
+  }
+};
+
 const renderProviderAdapter = (adapter) => {
   if (!adapter) return "";
   return `
@@ -1011,6 +1026,25 @@ const renderProviderRuntimeProbe = (probe) => {
       </div>
       <p class="muted">Worker launch: ${escapeHtml(probe.worker_launch)} · Coordination write: ${escapeHtml(probe.coordination_write)} · Projects write: ${escapeHtml(probe.projects_write)}.</p>
       <p class="muted">Next required action: ${escapeHtml(probe.next_required_action)}.</p>
+      <button type="button" class="secondary worker-launch-candidate-button">Create launch candidate</button>
+    </div>
+  `;
+};
+
+const renderWorkerLaunchCandidate = (candidate) => {
+  if (!candidate) return "";
+  return `
+    <div class="worker-launch-candidate">
+      <span>Worker launch candidate</span>
+      <strong>${escapeHtml(candidate.worker_launch_candidate_id)}</strong>
+      <p class="muted">${candidate.approved_worker_count.toLocaleString()} workers · ${candidate.approved_worker_token_budget.toLocaleString()} worker tokens · outcome ${escapeHtml(candidate.outcome)}.</p>
+      <div class="preflight-grid">
+        <article><span>Provider</span><strong>${escapeHtml(candidate.provider)}</strong></article>
+        <article><span>Models</span><strong>${candidate.models.map((model) => escapeHtml(model)).join(", ")}</strong></article>
+        <article><span>Process</span><strong>${escapeHtml(candidate.provider_process_start)}</strong></article>
+      </div>
+      <p class="muted">Worker launch: ${escapeHtml(candidate.worker_launch)} · Coordination write: ${escapeHtml(candidate.coordination_write)} · Projects write: ${escapeHtml(candidate.projects_write)}.</p>
+      <p class="muted">Next required action: ${escapeHtml(candidate.next_required_action)}.</p>
     </div>
   `;
 };
@@ -1308,6 +1342,22 @@ byId("plan-preview").addEventListener("click", async (event) => {
   button
     .closest(".worker-launch-preflight")
     ?.insertAdjacentHTML("afterend", renderProviderRuntimeProbe(probe));
+});
+
+byId("plan-preview").addEventListener("click", async (event) => {
+  const button = event.target.closest(".worker-launch-candidate-button");
+  if (!button) return;
+  button.setAttribute("disabled", "true");
+  const candidate = await createWorkerLaunchCandidate();
+  if (!candidate) {
+    button.removeAttribute("disabled");
+    button.textContent = "Runtime probe and capability inventory required";
+    return;
+  }
+  button.textContent = "Worker launch candidate recorded";
+  button
+    .closest(".provider-runtime-probe")
+    ?.insertAdjacentHTML("afterend", renderWorkerLaunchCandidate(candidate));
 });
 
 byId("manager-plan-form").addEventListener("submit", (event) => {

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -992,6 +992,21 @@ nav a:hover {
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+.worker-launch-candidate {
+  background: rgba(119, 240, 178, 0.1);
+  border: 1px solid rgba(119, 240, 178, 0.34);
+  border-radius: 16px;
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+.worker-launch-candidate span {
+  color: var(--ok);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 .preview-card.approved-preview {
   border-color: rgba(119, 240, 178, 0.48);
 }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -307,6 +307,16 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(blockedProviderInventory.status, 409);
     assert.equal((await blockedProviderInventory.json()).code, "provider_adapter_required");
 
+    const blockedWorkerLaunchCandidate = await fetch(
+      `${base}/api/manager-plan/worker-launch-candidates`,
+      { method: "POST" },
+    );
+    assert.equal(blockedWorkerLaunchCandidate.status, 409);
+    assert.equal(
+      (await blockedWorkerLaunchCandidate.json()).code,
+      "worker_launch_candidate_not_ready",
+    );
+
     const invalidProviderAdapter = await fetch(`${base}/api/manager-plan/provider-adapters`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -880,6 +890,72 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(providerProbesBody.schema, "yukh-control-plane-provider-runtime-probes-v1");
     assert.equal(providerProbesBody.probes.length, 1);
 
+    const workerLaunchCandidate = await fetch(`${base}/api/manager-plan/worker-launch-candidates`, {
+      method: "POST",
+    });
+    assert.equal(workerLaunchCandidate.status, 201);
+    const workerLaunchCandidateBody = await workerLaunchCandidate.json();
+    assert.equal(
+      workerLaunchCandidateBody.worker_launch_candidate.provider_runtime_probe_id,
+      providerProbeBody.provider_runtime_probe.provider_runtime_probe_id,
+    );
+    assert.equal(
+      workerLaunchCandidateBody.worker_launch_candidate.provider_capability_inventory_id,
+      providerInventoryBody.provider_capability_inventory.provider_capability_inventory_id,
+    );
+    assert.equal(
+      workerLaunchCandidateBody.worker_launch_candidate.worker_launch_preflight_id,
+      workerPreflightBody.worker_launch_preflight.worker_launch_preflight_id,
+    );
+    assert.equal(workerLaunchCandidateBody.worker_launch_candidate.provider, "Copilot SDK workers");
+    assert.equal(workerLaunchCandidateBody.worker_launch_candidate.approved_worker_count, 2);
+    assert.equal(
+      workerLaunchCandidateBody.worker_launch_candidate.approved_worker_token_budget,
+      66_000,
+    );
+    assert.deepEqual(workerLaunchCandidateBody.worker_launch_candidate.models, [
+      "copilot-sdk-default",
+      "copilot-sdk-small",
+    ]);
+    assert.equal(
+      workerLaunchCandidateBody.worker_launch_candidate.outcome,
+      "ready_for_explicit_worker_launch",
+    );
+    assert.equal(
+      workerLaunchCandidateBody.worker_launch_candidate.provider_process_start,
+      "not_performed",
+    );
+    assert.equal(workerLaunchCandidateBody.worker_launch_candidate.worker_launch, "not_performed");
+    assert.equal(
+      workerLaunchCandidateBody.worker_launch_candidate.coordination_write,
+      "not_performed",
+    );
+    assert.equal(workerLaunchCandidateBody.worker_launch_candidate.projects_write, "not_performed");
+    assert.equal(
+      workerLaunchCandidateBody.worker_launch_candidate.next_required_action,
+      "explicit_worker_launch",
+    );
+
+    const repeatedWorkerLaunchCandidate = await fetch(
+      `${base}/api/manager-plan/worker-launch-candidates`,
+      { method: "POST" },
+    );
+    assert.equal(repeatedWorkerLaunchCandidate.status, 201);
+    assert.equal(
+      (await repeatedWorkerLaunchCandidate.json()).worker_launch_candidate
+        .worker_launch_candidate_id,
+      workerLaunchCandidateBody.worker_launch_candidate.worker_launch_candidate_id,
+    );
+
+    const workerLaunchCandidates = await fetch(`${base}/api/manager-plan/worker-launch-candidates`);
+    assert.equal(workerLaunchCandidates.status, 200);
+    const workerLaunchCandidatesBody = await workerLaunchCandidates.json();
+    assert.equal(
+      workerLaunchCandidatesBody.schema,
+      "yukh-control-plane-worker-launch-candidates-v1",
+    );
+    assert.equal(workerLaunchCandidatesBody.candidates.length, 1);
+
     const persisted = await fetch(`${base}/api/manager-plan/previews`);
     const persistedBody = await persisted.json();
     assert.equal(persistedBody.previews.length, 2);
@@ -963,6 +1039,13 @@ test("control plane preview persists local manager plan previews without leaking
     );
     assert.equal(providerInventoryDenied.status, 405);
     assert.equal(providerInventoryDenied.headers.get("allow"), "GET, POST");
+
+    const workerLaunchCandidateDenied = await fetch(
+      `${base}/api/manager-plan/worker-launch-candidates`,
+      { method: "DELETE" },
+    );
+    assert.equal(workerLaunchCandidateDenied.status, 405);
+    assert.equal(workerLaunchCandidateDenied.headers.get("allow"), "GET, POST");
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
@@ -1060,6 +1143,7 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /api\/manager-plan\/provider-runtime-probes/u);
   assert.match(data, /api\/manager-plan\/provider-adapters/u);
   assert.match(data, /api\/manager-plan\/provider-capability-inventories/u);
+  assert.match(data, /api\/manager-plan\/worker-launch-candidates/u);
   assert.match(data, /Launch readiness/u);
   assert.match(data, /Launch intent recorded/u);
   assert.match(data, /Manager run planned/u);
@@ -1072,6 +1156,8 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /Provider runtime probe/u);
   assert.match(data, /Provider adapter configured/u);
   assert.match(data, /Provider capability inventory/u);
+  assert.match(data, /Worker launch candidate/u);
+  assert.match(data, /worker-launch-candidate-button/u);
   assert.match(data, /provider_process/u);
   assert.match(data, /worker_delegation/u);
   assert.match(data, /worker_launch/u);


### PR DESCRIPTION
## Summary
- add a gated worker launch candidate endpoint and UI step
- require provider runtime readiness, capability inventory, and worker launch preflight before candidate creation
- record approved workers, token budget, allowlisted models, and next explicit launch action

## Validation
- npm run format:check
- npm run typecheck
- npm run build
- node --import tsx --test test/runtime/control-plane-preview.test.ts
- git diff --check

## Safety
No provider process start, worker launch, Coordination write, or Projects write is performed. This records only readiness for a future explicit launch action.