### PR TITLE
Add Control Plane worker launch receipt

### DIFF
--- a/.context/sessions/SESSION-2026-08-19-13-control-plane-worker-launch-receipt.md
+++ b/.context/sessions/SESSION-2026-08-19-13-control-plane-worker-launch-receipt.md
@@ -1,0 +1,27 @@
+# Control Plane worker launch receipt
+
+Date: 2026-08-19
+
+## Outcome
+
+Added a local explicit worker launch receipt step after launch candidate readiness.
+
+## Scope
+
+- Added `GET /api/manager-plan/worker-launch-receipts`.
+- Added `POST /api/manager-plan/worker-launch-receipts`.
+- Added UI action from worker launch candidate.
+- Receipt records local launch authorization and the next required action.
+
+## Safety boundary
+
+This receipt still does not start provider processes, launch workers, write Coordination events or write Projects events.
+It records only that the Control Plane has explicitly authorized a future provider worker process start.
+
+## Validation
+
+- `npm run format:check`
+- `npm run typecheck`
+- `npm run build`
+- `node --import tsx --test test/runtime/control-plane-preview.test.ts`
+- `git diff --check`

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -46,6 +46,7 @@ const API_PROVIDER_ADAPTERS_PATH = "/api/manager-plan/provider-adapters";
 const API_PROVIDER_CAPABILITY_INVENTORIES_PATH =
   "/api/manager-plan/provider-capability-inventories";
 const API_WORKER_LAUNCH_CANDIDATES_PATH = "/api/manager-plan/worker-launch-candidates";
+const API_WORKER_LAUNCH_RECEIPTS_PATH = "/api/manager-plan/worker-launch-receipts";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
@@ -752,6 +753,58 @@ export function createControlPlaneServer(
               schema: 1,
               status: "error",
               code: "worker_launch_candidate_not_ready",
+            }),
+          );
+        }
+        return;
+      }
+      response.writeHead(405, {
+        allow: "GET, POST",
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+      return;
+    }
+
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_WORKER_LAUNCH_RECEIPTS_PATH
+    ) {
+      if (!options.planPreviewStore) {
+        response.writeHead(503, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "store_unconfigured" }));
+        return;
+      }
+      if (request.method === "GET") {
+        response.writeHead(200, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify(options.planPreviewStore.workerLaunchReceipts()));
+        return;
+      }
+      if (request.method === "POST") {
+        try {
+          const record = options.planPreviewStore.createWorkerLaunchReceipt();
+          response.writeHead(201, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(JSON.stringify({ schema: 1, status: "ok", worker_launch_receipt: record }));
+        } catch {
+          response.writeHead(409, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({
+              schema: 1,
+              status: "error",
+              code: "worker_launch_candidate_required",
             }),
           );
         }

--- a/apps/control-plane-preview/src/plan-preview-store.ts
+++ b/apps/control-plane-preview/src/plan-preview-store.ts
@@ -358,6 +358,35 @@ export type ControlPlaneWorkerLaunchCandidateStatus = {
   readonly candidates: readonly ControlPlaneWorkerLaunchCandidateRecord[];
 };
 
+export type ControlPlaneWorkerLaunchReceiptRecord = {
+  readonly schema: 1;
+  readonly worker_launch_receipt_id: string;
+  readonly worker_launch_candidate_id: string;
+  readonly provider_runtime_probe_id: string;
+  readonly provider_capability_inventory_id: string;
+  readonly worker_launch_preflight_id: string;
+  readonly worker_delegation_approval_id: string;
+  readonly worker_delegation_plan_id: string;
+  readonly manager_process_id: string;
+  readonly manager_run_id: string;
+  readonly provider: string;
+  readonly approved_worker_count: number;
+  readonly approved_worker_token_budget: number;
+  readonly launch_authorization: "local_control_plane_explicit";
+  readonly provider_process_start: "not_performed";
+  readonly worker_launch: "authorized_not_started";
+  readonly coordination_write: "not_performed";
+  readonly projects_write: "not_performed";
+  readonly created_at: string;
+  readonly next_required_action: "start_provider_worker_process";
+};
+
+export type ControlPlaneWorkerLaunchReceiptStatus = {
+  readonly schema: "yukh-control-plane-worker-launch-receipts-v1";
+  readonly source: "local-control-plane-store";
+  readonly receipts: readonly ControlPlaneWorkerLaunchReceiptRecord[];
+};
+
 export type ControlPlanePlanPreviewInput = {
   readonly goal: string;
   readonly mode: string;
@@ -381,6 +410,7 @@ type Document = {
   readonly provider_adapters?: readonly ControlPlaneProviderAdapterRecord[];
   readonly provider_capability_inventories?: readonly ControlPlaneProviderCapabilityInventoryRecord[];
   readonly worker_launch_candidates?: readonly ControlPlaneWorkerLaunchCandidateRecord[];
+  readonly worker_launch_receipts?: readonly ControlPlaneWorkerLaunchReceiptRecord[];
 };
 
 const validMode = new Set(["plan-first", "delegate, explicit workers"]);
@@ -650,6 +680,53 @@ export class ControlPlanePlanPreviewStore {
       source: "local-control-plane-store",
       candidates: this.#read().worker_launch_candidates ?? [],
     };
+  }
+
+  workerLaunchReceipts(): ControlPlaneWorkerLaunchReceiptStatus {
+    return {
+      schema: "yukh-control-plane-worker-launch-receipts-v1",
+      source: "local-control-plane-store",
+      receipts: this.#read().worker_launch_receipts ?? [],
+    };
+  }
+
+  createWorkerLaunchReceipt(): ControlPlaneWorkerLaunchReceiptRecord {
+    const document = this.#read();
+    const candidate = document.worker_launch_candidates?.[0];
+    if (!candidate || candidate.outcome !== "ready_for_explicit_worker_launch") {
+      throw new TypeError("worker launch candidate required");
+    }
+    const existing = document.worker_launch_receipts?.find(
+      (receipt) => receipt.worker_launch_candidate_id === candidate.worker_launch_candidate_id,
+    );
+    if (existing) return existing;
+    const record: ControlPlaneWorkerLaunchReceiptRecord = {
+      schema: 1,
+      worker_launch_receipt_id: `worker-launch-receipt-${randomUUID()}`,
+      worker_launch_candidate_id: candidate.worker_launch_candidate_id,
+      provider_runtime_probe_id: candidate.provider_runtime_probe_id,
+      provider_capability_inventory_id: candidate.provider_capability_inventory_id,
+      worker_launch_preflight_id: candidate.worker_launch_preflight_id,
+      worker_delegation_approval_id: candidate.worker_delegation_approval_id,
+      worker_delegation_plan_id: candidate.worker_delegation_plan_id,
+      manager_process_id: candidate.manager_process_id,
+      manager_run_id: candidate.manager_run_id,
+      provider: candidate.provider,
+      approved_worker_count: candidate.approved_worker_count,
+      approved_worker_token_budget: candidate.approved_worker_token_budget,
+      launch_authorization: "local_control_plane_explicit",
+      provider_process_start: "not_performed",
+      worker_launch: "authorized_not_started",
+      coordination_write: "not_performed",
+      projects_write: "not_performed",
+      created_at: new Date().toISOString(),
+      next_required_action: "start_provider_worker_process",
+    };
+    this.#write({
+      ...document,
+      worker_launch_receipts: [record, ...(document.worker_launch_receipts ?? [])].slice(0, 20),
+    });
+    return record;
   }
 
   createWorkerLaunchCandidate(): ControlPlaneWorkerLaunchCandidateRecord {
@@ -1289,6 +1366,9 @@ export class ControlPlanePlanPreviewStore {
         worker_launch_candidates: Array.isArray(parsed.worker_launch_candidates)
           ? parsed.worker_launch_candidates.filter((item) => item?.schema === 1)
           : [],
+        worker_launch_receipts: Array.isArray(parsed.worker_launch_receipts)
+          ? parsed.worker_launch_receipts.filter((item) => item?.schema === 1)
+          : [],
       };
     } catch {
       return {
@@ -1306,6 +1386,7 @@ export class ControlPlanePlanPreviewStore {
         provider_adapters: [],
         provider_capability_inventories: [],
         worker_launch_candidates: [],
+        worker_launch_receipts: [],
       };
     }
   }
@@ -1319,6 +1400,8 @@ export class ControlPlanePlanPreviewStore {
         document.provider_capability_inventories ?? current.provider_capability_inventories ?? [],
       worker_launch_candidates:
         document.worker_launch_candidates ?? current.worker_launch_candidates ?? [],
+      worker_launch_receipts:
+        document.worker_launch_receipts ?? current.worker_launch_receipts ?? [],
     };
     const tmp = `${this.#path}.${process.pid}.${Date.now()}.tmp`;
     writeFileSync(tmp, `${JSON.stringify(normalized, null, 2)}\n`, { mode: 0o600 });

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -845,6 +845,21 @@ const createWorkerLaunchCandidate = async () => {
   }
 };
 
+const createWorkerLaunchReceipt = async () => {
+  try {
+    const response = await fetch("./api/manager-plan/worker-launch-receipts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return body?.worker_launch_receipt ?? null;
+  } catch {
+    return null;
+  }
+};
+
 const renderProviderAdapter = (adapter) => {
   if (!adapter) return "";
   return `
@@ -1045,6 +1060,25 @@ const renderWorkerLaunchCandidate = (candidate) => {
       </div>
       <p class="muted">Worker launch: ${escapeHtml(candidate.worker_launch)} · Coordination write: ${escapeHtml(candidate.coordination_write)} · Projects write: ${escapeHtml(candidate.projects_write)}.</p>
       <p class="muted">Next required action: ${escapeHtml(candidate.next_required_action)}.</p>
+      <button type="button" class="secondary worker-launch-receipt-button">Authorize launch receipt</button>
+    </div>
+  `;
+};
+
+const renderWorkerLaunchReceipt = (receipt) => {
+  if (!receipt) return "";
+  return `
+    <div class="worker-launch-receipt">
+      <span>Worker launch receipt</span>
+      <strong>${escapeHtml(receipt.worker_launch_receipt_id)}</strong>
+      <p class="muted">${receipt.approved_worker_count.toLocaleString()} workers · ${receipt.approved_worker_token_budget.toLocaleString()} worker tokens · ${escapeHtml(receipt.launch_authorization)}.</p>
+      <div class="preflight-grid">
+        <article><span>Provider</span><strong>${escapeHtml(receipt.provider)}</strong></article>
+        <article><span>Process</span><strong>${escapeHtml(receipt.provider_process_start)}</strong></article>
+        <article><span>Launch</span><strong>${escapeHtml(receipt.worker_launch)}</strong></article>
+      </div>
+      <p class="muted">Coordination write: ${escapeHtml(receipt.coordination_write)} · Projects write: ${escapeHtml(receipt.projects_write)}.</p>
+      <p class="muted">Next required action: ${escapeHtml(receipt.next_required_action)}.</p>
     </div>
   `;
 };
@@ -1358,6 +1392,22 @@ byId("plan-preview").addEventListener("click", async (event) => {
   button
     .closest(".provider-runtime-probe")
     ?.insertAdjacentHTML("afterend", renderWorkerLaunchCandidate(candidate));
+});
+
+byId("plan-preview").addEventListener("click", async (event) => {
+  const button = event.target.closest(".worker-launch-receipt-button");
+  if (!button) return;
+  button.setAttribute("disabled", "true");
+  const receipt = await createWorkerLaunchReceipt();
+  if (!receipt) {
+    button.removeAttribute("disabled");
+    button.textContent = "Worker launch candidate required";
+    return;
+  }
+  button.textContent = "Worker launch receipt recorded";
+  button
+    .closest(".worker-launch-candidate")
+    ?.insertAdjacentHTML("afterend", renderWorkerLaunchReceipt(receipt));
 });
 
 byId("manager-plan-form").addEventListener("submit", (event) => {

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -1007,6 +1007,21 @@ nav a:hover {
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+.worker-launch-receipt {
+  background: rgba(119, 240, 178, 0.14);
+  border: 1px solid rgba(119, 240, 178, 0.42);
+  border-radius: 16px;
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+.worker-launch-receipt span {
+  color: var(--ok);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 .preview-card.approved-preview {
   border-color: rgba(119, 240, 178, 0.48);
 }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -317,6 +317,16 @@ test("control plane preview persists local manager plan previews without leaking
       "worker_launch_candidate_not_ready",
     );
 
+    const blockedWorkerLaunchReceipt = await fetch(
+      `${base}/api/manager-plan/worker-launch-receipts`,
+      { method: "POST" },
+    );
+    assert.equal(blockedWorkerLaunchReceipt.status, 409);
+    assert.equal(
+      (await blockedWorkerLaunchReceipt.json()).code,
+      "worker_launch_candidate_required",
+    );
+
     const invalidProviderAdapter = await fetch(`${base}/api/manager-plan/provider-adapters`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -956,6 +966,64 @@ test("control plane preview persists local manager plan previews without leaking
     );
     assert.equal(workerLaunchCandidatesBody.candidates.length, 1);
 
+    const workerLaunchReceipt = await fetch(`${base}/api/manager-plan/worker-launch-receipts`, {
+      method: "POST",
+    });
+    assert.equal(workerLaunchReceipt.status, 201);
+    const workerLaunchReceiptBody = await workerLaunchReceipt.json();
+    assert.equal(
+      workerLaunchReceiptBody.worker_launch_receipt.worker_launch_candidate_id,
+      workerLaunchCandidateBody.worker_launch_candidate.worker_launch_candidate_id,
+    );
+    assert.equal(
+      workerLaunchReceiptBody.worker_launch_receipt.provider_runtime_probe_id,
+      providerProbeBody.provider_runtime_probe.provider_runtime_probe_id,
+    );
+    assert.equal(
+      workerLaunchReceiptBody.worker_launch_receipt.provider_capability_inventory_id,
+      providerInventoryBody.provider_capability_inventory.provider_capability_inventory_id,
+    );
+    assert.equal(workerLaunchReceiptBody.worker_launch_receipt.provider, "Copilot SDK workers");
+    assert.equal(workerLaunchReceiptBody.worker_launch_receipt.approved_worker_count, 2);
+    assert.equal(
+      workerLaunchReceiptBody.worker_launch_receipt.approved_worker_token_budget,
+      66_000,
+    );
+    assert.equal(
+      workerLaunchReceiptBody.worker_launch_receipt.launch_authorization,
+      "local_control_plane_explicit",
+    );
+    assert.equal(
+      workerLaunchReceiptBody.worker_launch_receipt.provider_process_start,
+      "not_performed",
+    );
+    assert.equal(
+      workerLaunchReceiptBody.worker_launch_receipt.worker_launch,
+      "authorized_not_started",
+    );
+    assert.equal(workerLaunchReceiptBody.worker_launch_receipt.coordination_write, "not_performed");
+    assert.equal(workerLaunchReceiptBody.worker_launch_receipt.projects_write, "not_performed");
+    assert.equal(
+      workerLaunchReceiptBody.worker_launch_receipt.next_required_action,
+      "start_provider_worker_process",
+    );
+
+    const repeatedWorkerLaunchReceipt = await fetch(
+      `${base}/api/manager-plan/worker-launch-receipts`,
+      { method: "POST" },
+    );
+    assert.equal(repeatedWorkerLaunchReceipt.status, 201);
+    assert.equal(
+      (await repeatedWorkerLaunchReceipt.json()).worker_launch_receipt.worker_launch_receipt_id,
+      workerLaunchReceiptBody.worker_launch_receipt.worker_launch_receipt_id,
+    );
+
+    const workerLaunchReceipts = await fetch(`${base}/api/manager-plan/worker-launch-receipts`);
+    assert.equal(workerLaunchReceipts.status, 200);
+    const workerLaunchReceiptsBody = await workerLaunchReceipts.json();
+    assert.equal(workerLaunchReceiptsBody.schema, "yukh-control-plane-worker-launch-receipts-v1");
+    assert.equal(workerLaunchReceiptsBody.receipts.length, 1);
+
     const persisted = await fetch(`${base}/api/manager-plan/previews`);
     const persistedBody = await persisted.json();
     assert.equal(persistedBody.previews.length, 2);
@@ -1046,6 +1114,13 @@ test("control plane preview persists local manager plan previews without leaking
     );
     assert.equal(workerLaunchCandidateDenied.status, 405);
     assert.equal(workerLaunchCandidateDenied.headers.get("allow"), "GET, POST");
+
+    const workerLaunchReceiptDenied = await fetch(
+      `${base}/api/manager-plan/worker-launch-receipts`,
+      { method: "DELETE" },
+    );
+    assert.equal(workerLaunchReceiptDenied.status, 405);
+    assert.equal(workerLaunchReceiptDenied.headers.get("allow"), "GET, POST");
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
@@ -1144,6 +1219,7 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /api\/manager-plan\/provider-adapters/u);
   assert.match(data, /api\/manager-plan\/provider-capability-inventories/u);
   assert.match(data, /api\/manager-plan\/worker-launch-candidates/u);
+  assert.match(data, /api\/manager-plan\/worker-launch-receipts/u);
   assert.match(data, /Launch readiness/u);
   assert.match(data, /Launch intent recorded/u);
   assert.match(data, /Manager run planned/u);
@@ -1158,6 +1234,8 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /Provider capability inventory/u);
   assert.match(data, /Worker launch candidate/u);
   assert.match(data, /worker-launch-candidate-button/u);
+  assert.match(data, /Worker launch receipt/u);
+  assert.match(data, /worker-launch-receipt-button/u);
   assert.match(data, /provider_process/u);
   assert.match(data, /worker_delegation/u);
   assert.match(data, /worker_launch/u);


### PR DESCRIPTION
## Summary
- add local explicit worker launch receipt API and UI step
- require a worker launch candidate before recording launch authorization
- keep provider process start and external writes not performed

## Validation
- npm run format:check
- npm run typecheck
- npm run build
- node --import tsx --test test/runtime/control-plane-preview.test.ts
- git diff --check

## Safety
No provider process start, worker launch, Coordination write, or Projects write is performed. This records only explicit local authorization for a future worker process start.