### PR TITLE
Add Control Plane provider worker process start

### DIFF
--- a/.context/sessions/SESSION-2026-08-19-15-control-plane-provider-worker-process-start.md
+++ b/.context/sessions/SESSION-2026-08-19-15-control-plane-provider-worker-process-start.md
@@ -1,0 +1,23 @@
+# SESSION 2026-08-19 — Control Plane provider worker process start
+
+## Outcome
+
+Added the next Control Plane step after an explicit worker launch receipt: a
+provider worker process start record.
+
+## Scope
+
+- Records the authorised provider worker process start request.
+- Keeps Coordination and Projects writes disabled.
+- Keeps provider worker execution detached from the real Codex/Copilot runner
+  until runner attachment is explicit and supervised.
+
+## Token guardrail
+
+The record is intentionally local and idempotent. It does not launch a provider
+process yet, so the flow can be tested without spending model tokens.
+
+## Next
+
+Attach the provider runner so the recorded start request becomes a supervised
+process with stdout/stderr, exit status and token accounting.

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -47,6 +47,7 @@ const API_PROVIDER_CAPABILITY_INVENTORIES_PATH =
   "/api/manager-plan/provider-capability-inventories";
 const API_WORKER_LAUNCH_CANDIDATES_PATH = "/api/manager-plan/worker-launch-candidates";
 const API_WORKER_LAUNCH_RECEIPTS_PATH = "/api/manager-plan/worker-launch-receipts";
+const API_PROVIDER_WORKER_PROCESSES_PATH = "/api/manager-plan/provider-worker-processes";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
@@ -192,6 +193,60 @@ export function createControlPlaneServer(
           });
           response.end(
             JSON.stringify({ schema: 1, status: "error", code: "launch_readiness_blocked" }),
+          );
+        }
+        return;
+      }
+      response.writeHead(405, {
+        allow: "GET, POST",
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+      return;
+    }
+
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_PROVIDER_WORKER_PROCESSES_PATH
+    ) {
+      if (!options.planPreviewStore) {
+        response.writeHead(503, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "store_unconfigured" }));
+        return;
+      }
+      if (request.method === "GET") {
+        response.writeHead(200, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify(options.planPreviewStore.providerWorkerProcesses()));
+        return;
+      }
+      if (request.method === "POST") {
+        try {
+          const record = options.planPreviewStore.createProviderWorkerProcess();
+          response.writeHead(201, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({ schema: 1, status: "ok", provider_worker_process: record }),
+          );
+        } catch {
+          response.writeHead(409, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({
+              schema: 1,
+              status: "error",
+              code: "worker_launch_receipt_required",
+            }),
           );
         }
         return;

--- a/apps/control-plane-preview/src/plan-preview-store.ts
+++ b/apps/control-plane-preview/src/plan-preview-store.ts
@@ -387,6 +387,36 @@ export type ControlPlaneWorkerLaunchReceiptStatus = {
   readonly receipts: readonly ControlPlaneWorkerLaunchReceiptRecord[];
 };
 
+export type ControlPlaneProviderWorkerProcessRecord = {
+  readonly schema: 1;
+  readonly provider_worker_process_id: string;
+  readonly worker_launch_receipt_id: string;
+  readonly worker_launch_candidate_id: string;
+  readonly provider_runtime_probe_id: string;
+  readonly provider_capability_inventory_id: string;
+  readonly worker_launch_preflight_id: string;
+  readonly worker_delegation_approval_id: string;
+  readonly worker_delegation_plan_id: string;
+  readonly manager_process_id: string;
+  readonly manager_run_id: string;
+  readonly provider: string;
+  readonly approved_worker_count: number;
+  readonly approved_worker_token_budget: number;
+  readonly process_supervision: "control_plane_recorded";
+  readonly provider_process_start: "start_requested";
+  readonly worker_launch: "start_requested_not_running";
+  readonly coordination_write: "not_performed";
+  readonly projects_write: "not_performed";
+  readonly created_at: string;
+  readonly next_required_action: "attach_provider_runner";
+};
+
+export type ControlPlaneProviderWorkerProcessStatus = {
+  readonly schema: "yukh-control-plane-provider-worker-processes-v1";
+  readonly source: "local-control-plane-store";
+  readonly processes: readonly ControlPlaneProviderWorkerProcessRecord[];
+};
+
 export type ControlPlanePlanPreviewInput = {
   readonly goal: string;
   readonly mode: string;
@@ -411,6 +441,7 @@ type Document = {
   readonly provider_capability_inventories?: readonly ControlPlaneProviderCapabilityInventoryRecord[];
   readonly worker_launch_candidates?: readonly ControlPlaneWorkerLaunchCandidateRecord[];
   readonly worker_launch_receipts?: readonly ControlPlaneWorkerLaunchReceiptRecord[];
+  readonly provider_worker_processes?: readonly ControlPlaneProviderWorkerProcessRecord[];
 };
 
 const validMode = new Set(["plan-first", "delegate, explicit workers"]);
@@ -688,6 +719,57 @@ export class ControlPlanePlanPreviewStore {
       source: "local-control-plane-store",
       receipts: this.#read().worker_launch_receipts ?? [],
     };
+  }
+
+  providerWorkerProcesses(): ControlPlaneProviderWorkerProcessStatus {
+    return {
+      schema: "yukh-control-plane-provider-worker-processes-v1",
+      source: "local-control-plane-store",
+      processes: this.#read().provider_worker_processes ?? [],
+    };
+  }
+
+  createProviderWorkerProcess(): ControlPlaneProviderWorkerProcessRecord {
+    const document = this.#read();
+    const receipt = document.worker_launch_receipts?.[0];
+    if (!receipt || receipt.worker_launch !== "authorized_not_started") {
+      throw new TypeError("worker launch receipt required");
+    }
+    const existing = document.provider_worker_processes?.find(
+      (process) => process.worker_launch_receipt_id === receipt.worker_launch_receipt_id,
+    );
+    if (existing) return existing;
+    const record: ControlPlaneProviderWorkerProcessRecord = {
+      schema: 1,
+      provider_worker_process_id: `provider-worker-process-${randomUUID()}`,
+      worker_launch_receipt_id: receipt.worker_launch_receipt_id,
+      worker_launch_candidate_id: receipt.worker_launch_candidate_id,
+      provider_runtime_probe_id: receipt.provider_runtime_probe_id,
+      provider_capability_inventory_id: receipt.provider_capability_inventory_id,
+      worker_launch_preflight_id: receipt.worker_launch_preflight_id,
+      worker_delegation_approval_id: receipt.worker_delegation_approval_id,
+      worker_delegation_plan_id: receipt.worker_delegation_plan_id,
+      manager_process_id: receipt.manager_process_id,
+      manager_run_id: receipt.manager_run_id,
+      provider: receipt.provider,
+      approved_worker_count: receipt.approved_worker_count,
+      approved_worker_token_budget: receipt.approved_worker_token_budget,
+      process_supervision: "control_plane_recorded",
+      provider_process_start: "start_requested",
+      worker_launch: "start_requested_not_running",
+      coordination_write: "not_performed",
+      projects_write: "not_performed",
+      created_at: new Date().toISOString(),
+      next_required_action: "attach_provider_runner",
+    };
+    this.#write({
+      ...document,
+      provider_worker_processes: [record, ...(document.provider_worker_processes ?? [])].slice(
+        0,
+        20,
+      ),
+    });
+    return record;
   }
 
   createWorkerLaunchReceipt(): ControlPlaneWorkerLaunchReceiptRecord {
@@ -1369,6 +1451,9 @@ export class ControlPlanePlanPreviewStore {
         worker_launch_receipts: Array.isArray(parsed.worker_launch_receipts)
           ? parsed.worker_launch_receipts.filter((item) => item?.schema === 1)
           : [],
+        provider_worker_processes: Array.isArray(parsed.provider_worker_processes)
+          ? parsed.provider_worker_processes.filter((item) => item?.schema === 1)
+          : [],
       };
     } catch {
       return {
@@ -1387,6 +1472,7 @@ export class ControlPlanePlanPreviewStore {
         provider_capability_inventories: [],
         worker_launch_candidates: [],
         worker_launch_receipts: [],
+        provider_worker_processes: [],
       };
     }
   }
@@ -1402,6 +1488,8 @@ export class ControlPlanePlanPreviewStore {
         document.worker_launch_candidates ?? current.worker_launch_candidates ?? [],
       worker_launch_receipts:
         document.worker_launch_receipts ?? current.worker_launch_receipts ?? [],
+      provider_worker_processes:
+        document.provider_worker_processes ?? current.provider_worker_processes ?? [],
     };
     const tmp = `${this.#path}.${process.pid}.${Date.now()}.tmp`;
     writeFileSync(tmp, `${JSON.stringify(normalized, null, 2)}\n`, { mode: 0o600 });

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -860,6 +860,21 @@ const createWorkerLaunchReceipt = async () => {
   }
 };
 
+const createProviderWorkerProcess = async () => {
+  try {
+    const response = await fetch("./api/manager-plan/provider-worker-processes", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return body?.provider_worker_process ?? null;
+  } catch {
+    return null;
+  }
+};
+
 const renderProviderAdapter = (adapter) => {
   if (!adapter) return "";
   return `
@@ -1079,6 +1094,25 @@ const renderWorkerLaunchReceipt = (receipt) => {
       </div>
       <p class="muted">Coordination write: ${escapeHtml(receipt.coordination_write)} · Projects write: ${escapeHtml(receipt.projects_write)}.</p>
       <p class="muted">Next required action: ${escapeHtml(receipt.next_required_action)}.</p>
+      <button type="button" class="secondary provider-worker-process-button">Request provider process start</button>
+    </div>
+  `;
+};
+
+const renderProviderWorkerProcess = (process) => {
+  if (!process) return "";
+  return `
+    <div class="provider-worker-process">
+      <span>Provider worker process</span>
+      <strong>${escapeHtml(process.provider_worker_process_id)}</strong>
+      <p class="muted">${process.approved_worker_count.toLocaleString()} workers · ${process.approved_worker_token_budget.toLocaleString()} worker tokens · ${escapeHtml(process.process_supervision)}.</p>
+      <div class="preflight-grid">
+        <article><span>Provider</span><strong>${escapeHtml(process.provider)}</strong></article>
+        <article><span>Process</span><strong>${escapeHtml(process.provider_process_start)}</strong></article>
+        <article><span>Launch</span><strong>${escapeHtml(process.worker_launch)}</strong></article>
+      </div>
+      <p class="muted">Coordination write: ${escapeHtml(process.coordination_write)} · Projects write: ${escapeHtml(process.projects_write)}.</p>
+      <p class="muted">Next required action: ${escapeHtml(process.next_required_action)}.</p>
     </div>
   `;
 };
@@ -1408,6 +1442,22 @@ byId("plan-preview").addEventListener("click", async (event) => {
   button
     .closest(".worker-launch-candidate")
     ?.insertAdjacentHTML("afterend", renderWorkerLaunchReceipt(receipt));
+});
+
+byId("plan-preview").addEventListener("click", async (event) => {
+  const button = event.target.closest(".provider-worker-process-button");
+  if (!button) return;
+  button.setAttribute("disabled", "true");
+  const process = await createProviderWorkerProcess();
+  if (!process) {
+    button.removeAttribute("disabled");
+    button.textContent = "Worker launch receipt required";
+    return;
+  }
+  button.textContent = "Provider process start requested";
+  button
+    .closest(".worker-launch-receipt")
+    ?.insertAdjacentHTML("afterend", renderProviderWorkerProcess(process));
 });
 
 byId("manager-plan-form").addEventListener("submit", (event) => {

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -1022,6 +1022,21 @@ nav a:hover {
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+.provider-worker-process {
+  background: rgba(125, 211, 252, 0.1);
+  border: 1px solid rgba(125, 211, 252, 0.34);
+  border-radius: 16px;
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+.provider-worker-process span {
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 .preview-card.approved-preview {
   border-color: rgba(119, 240, 178, 0.48);
 }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -327,6 +327,16 @@ test("control plane preview persists local manager plan previews without leaking
       "worker_launch_candidate_required",
     );
 
+    const blockedProviderWorkerProcess = await fetch(
+      `${base}/api/manager-plan/provider-worker-processes`,
+      { method: "POST" },
+    );
+    assert.equal(blockedProviderWorkerProcess.status, 409);
+    assert.equal(
+      (await blockedProviderWorkerProcess.json()).code,
+      "worker_launch_receipt_required",
+    );
+
     const invalidProviderAdapter = await fetch(`${base}/api/manager-plan/provider-adapters`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -1024,6 +1034,78 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(workerLaunchReceiptsBody.schema, "yukh-control-plane-worker-launch-receipts-v1");
     assert.equal(workerLaunchReceiptsBody.receipts.length, 1);
 
+    const providerWorkerProcess = await fetch(
+      `${base}/api/manager-plan/provider-worker-processes`,
+      { method: "POST" },
+    );
+    assert.equal(providerWorkerProcess.status, 201);
+    const providerWorkerProcessBody = await providerWorkerProcess.json();
+    assert.equal(
+      providerWorkerProcessBody.provider_worker_process.worker_launch_receipt_id,
+      workerLaunchReceiptBody.worker_launch_receipt.worker_launch_receipt_id,
+    );
+    assert.equal(
+      providerWorkerProcessBody.provider_worker_process.worker_launch_candidate_id,
+      workerLaunchCandidateBody.worker_launch_candidate.worker_launch_candidate_id,
+    );
+    assert.equal(
+      providerWorkerProcessBody.provider_worker_process.provider_runtime_probe_id,
+      providerProbeBody.provider_runtime_probe.provider_runtime_probe_id,
+    );
+    assert.equal(
+      providerWorkerProcessBody.provider_worker_process.provider_capability_inventory_id,
+      providerInventoryBody.provider_capability_inventory.provider_capability_inventory_id,
+    );
+    assert.equal(providerWorkerProcessBody.provider_worker_process.provider, "Copilot SDK workers");
+    assert.equal(providerWorkerProcessBody.provider_worker_process.approved_worker_count, 2);
+    assert.equal(
+      providerWorkerProcessBody.provider_worker_process.approved_worker_token_budget,
+      66_000,
+    );
+    assert.equal(
+      providerWorkerProcessBody.provider_worker_process.process_supervision,
+      "control_plane_recorded",
+    );
+    assert.equal(
+      providerWorkerProcessBody.provider_worker_process.provider_process_start,
+      "start_requested",
+    );
+    assert.equal(
+      providerWorkerProcessBody.provider_worker_process.worker_launch,
+      "start_requested_not_running",
+    );
+    assert.equal(
+      providerWorkerProcessBody.provider_worker_process.coordination_write,
+      "not_performed",
+    );
+    assert.equal(providerWorkerProcessBody.provider_worker_process.projects_write, "not_performed");
+    assert.equal(
+      providerWorkerProcessBody.provider_worker_process.next_required_action,
+      "attach_provider_runner",
+    );
+
+    const repeatedProviderWorkerProcess = await fetch(
+      `${base}/api/manager-plan/provider-worker-processes`,
+      { method: "POST" },
+    );
+    assert.equal(repeatedProviderWorkerProcess.status, 201);
+    assert.equal(
+      (await repeatedProviderWorkerProcess.json()).provider_worker_process
+        .provider_worker_process_id,
+      providerWorkerProcessBody.provider_worker_process.provider_worker_process_id,
+    );
+
+    const providerWorkerProcesses = await fetch(
+      `${base}/api/manager-plan/provider-worker-processes`,
+    );
+    assert.equal(providerWorkerProcesses.status, 200);
+    const providerWorkerProcessesBody = await providerWorkerProcesses.json();
+    assert.equal(
+      providerWorkerProcessesBody.schema,
+      "yukh-control-plane-provider-worker-processes-v1",
+    );
+    assert.equal(providerWorkerProcessesBody.processes.length, 1);
+
     const persisted = await fetch(`${base}/api/manager-plan/previews`);
     const persistedBody = await persisted.json();
     assert.equal(persistedBody.previews.length, 2);
@@ -1121,6 +1203,13 @@ test("control plane preview persists local manager plan previews without leaking
     );
     assert.equal(workerLaunchReceiptDenied.status, 405);
     assert.equal(workerLaunchReceiptDenied.headers.get("allow"), "GET, POST");
+
+    const providerWorkerProcessDenied = await fetch(
+      `${base}/api/manager-plan/provider-worker-processes`,
+      { method: "DELETE" },
+    );
+    assert.equal(providerWorkerProcessDenied.status, 405);
+    assert.equal(providerWorkerProcessDenied.headers.get("allow"), "GET, POST");
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
@@ -1220,6 +1309,7 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /api\/manager-plan\/provider-capability-inventories/u);
   assert.match(data, /api\/manager-plan\/worker-launch-candidates/u);
   assert.match(data, /api\/manager-plan\/worker-launch-receipts/u);
+  assert.match(data, /api\/manager-plan\/provider-worker-processes/u);
   assert.match(data, /Launch readiness/u);
   assert.match(data, /Launch intent recorded/u);
   assert.match(data, /Manager run planned/u);
@@ -1236,6 +1326,8 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /worker-launch-candidate-button/u);
   assert.match(data, /Worker launch receipt/u);
   assert.match(data, /worker-launch-receipt-button/u);
+  assert.match(data, /Provider worker process/u);
+  assert.match(data, /provider-worker-process-button/u);
   assert.match(data, /provider_process/u);
   assert.match(data, /worker_delegation/u);
   assert.match(data, /worker_launch/u);
@@ -1298,6 +1390,9 @@ test("control plane preview has bounded text containers for operator UI", async 
   assert.match(css, /\.worker-delegation-approval/u);
   assert.match(css, /\.worker-launch-preflight/u);
   assert.match(css, /\.provider-runtime-probe/u);
+  assert.match(css, /\.worker-launch-candidate/u);
+  assert.match(css, /\.worker-launch-receipt/u);
+  assert.match(css, /\.provider-worker-process/u);
   assert.match(css, /\.preflight-grid/u);
   assert.match(css, /@media \(max-width: 640px\)/u);
 });


### PR DESCRIPTION
## Summary
- add a provider worker process start record after explicit worker launch receipt
- expose GET/POST APIs and Control Plane UI rendering for the recorded process start request
- keep provider execution, Coordination writes and Projects writes disabled until runner attachment is explicit

## Verification
- npm run format:check
- npm run typecheck
- npm run build
- node --import tsx --test test/runtime/control-plane-preview.test.ts
- git diff --check