### PR TITLE
Attach Control Plane provider runner

### DIFF
--- a/.context/sessions/SESSION-2026-08-19-16-control-plane-provider-runner-attachment.md
+++ b/.context/sessions/SESSION-2026-08-19-16-control-plane-provider-runner-attachment.md
@@ -1,0 +1,27 @@
+# SESSION 2026-08-19 — Control Plane provider runner attachment
+
+## Outcome
+
+Added the Control Plane step that attaches an authorised provider process start
+request to the existing team runtime supervisor.
+
+## Scope
+
+- Introduces a provider runner attachment record after
+  `provider_worker_process`.
+- Exposes the attachment through the Control Plane API and UI.
+- Wires local Control Plane startup to `TeamStore` + `TeamSupervisor` when
+  `YUKH_COORDINATION_LAUNCHER`, `YUKH_CODEX_EXECUTABLE` and
+  `YUKH_COPILOT_EXECUTABLE` are configured.
+- Keeps tests on an injected fake runner, so no model tokens are spent in CI.
+
+## Token guardrail
+
+The UI can now request a real runner attachment only in a configured local
+runtime. Runtime tests validate the contract with a fake runner and assert
+idempotency so repeated operator clicks do not spawn duplicate workers.
+
+## Next
+
+Observe worker completion from the team store and surface log, exit status and
+token accounting in the Control Plane.

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -7,10 +7,13 @@ import {
   discoverCopilotModelCatalog,
 } from "../../../packages/team-control/src/model-discovery.js";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
+import { teamRuntimeEntrypoints } from "../../../packages/team-control/src/entrypoints.js";
+import { TeamSupervisor } from "../../../packages/team-control/src/supervisor.js";
 import {
   ControlPlanePlanPreviewStore,
   type ControlPlaneProviderAdapterInput,
   type ControlPlaneProviderModelDiscoverer,
+  type ControlPlaneProviderRunner,
   type ControlPlanePlanPreviewInput,
 } from "./plan-preview-store.js";
 import { createTeamStatus } from "./team-status.js";
@@ -48,6 +51,7 @@ const API_PROVIDER_CAPABILITY_INVENTORIES_PATH =
 const API_WORKER_LAUNCH_CANDIDATES_PATH = "/api/manager-plan/worker-launch-candidates";
 const API_WORKER_LAUNCH_RECEIPTS_PATH = "/api/manager-plan/worker-launch-receipts";
 const API_PROVIDER_WORKER_PROCESSES_PATH = "/api/manager-plan/provider-worker-processes";
+const API_PROVIDER_RUNNER_ATTACHMENTS_PATH = "/api/manager-plan/provider-runner-attachments";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
@@ -120,6 +124,80 @@ export const discoverConfiguredProviderModels: ControlPlaneProviderModelDiscover
   }
   return undefined;
 };
+
+function runtimeForProvider(provider: string): "codex" | "copilot" {
+  return provider === "Copilot SDK workers" ? "copilot" : "codex";
+}
+
+function createConfiguredProviderRunner(
+  workspace: string,
+  teamStore: TeamStore,
+): ControlPlaneProviderRunner | undefined {
+  const launcher = process.env.YUKH_COORDINATION_LAUNCHER;
+  const codex = process.env.YUKH_CODEX_EXECUTABLE;
+  const copilot = process.env.YUKH_COPILOT_EXECUTABLE;
+  if (!launcher || !codex || !copilot) return undefined;
+
+  const entrypoints = teamRuntimeEntrypoints();
+  const supervisor = new TeamSupervisor({
+    node: process.execPath,
+    worker: entrypoints.worker,
+    coordinationMcp: entrypoints.coordinationMcp,
+    teamControlMcp: entrypoints.teamControlMcp,
+    launcher,
+    codex,
+    copilot,
+    workspace,
+    profileEnvironment: {
+      ...(process.env.YUKH_PREVIEW_RUNTIME
+        ? { YUKH_PREVIEW_RUNTIME: process.env.YUKH_PREVIEW_RUNTIME }
+        : {}),
+      ...(process.env.YUKH_COPILOT_WORKER_PROVIDER
+        ? { YUKH_COPILOT_WORKER_PROVIDER: process.env.YUKH_COPILOT_WORKER_PROVIDER }
+        : {}),
+      ...(process.env.YUKH_CODEX_WORKER_PROVIDER
+        ? { YUKH_CODEX_WORKER_PROVIDER: process.env.YUKH_CODEX_WORKER_PROVIDER }
+        : {}),
+      ...(process.env.YUKH_CODEX_PYTHON_EXECUTABLE
+        ? { YUKH_CODEX_PYTHON_EXECUTABLE: process.env.YUKH_CODEX_PYTHON_EXECUTABLE }
+        : {}),
+    },
+  });
+
+  return async ({ process: providerProcess }) => {
+    const runtime = runtimeForProvider(providerProcess.provider);
+    const tokenBudget = providerProcess.approved_worker_token_budget;
+    const team = teamStore.create(
+      `Control Plane provider runner attachment ${providerProcess.provider_worker_process_id}`,
+      runtime,
+      Math.max(1, providerProcess.approved_worker_count),
+      1,
+      tokenBudget,
+    );
+    const workerBudget = Math.max(
+      1_000,
+      Math.floor(tokenBudget / providerProcess.approved_worker_count),
+    );
+    const agent = teamStore.spawn(team.team_id, {
+      runtime,
+      role: "provider-runner",
+      task: "Attach the provider worker runtime to the Yukh Control Plane. Do not modify files. Confirm readiness and report the Coordination identity, runtime and next observable status.",
+      can_spawn: false,
+      token_budget: workerBudget,
+      model_tool_mode: "none",
+      max_commands: 0,
+      timeout_ms: 60_000,
+    });
+    const launched = supervisor.launch(agent);
+    return {
+      runtime,
+      team_id: team.team_id,
+      agent_id: agent.agent_id,
+      pid: launched.pid,
+      log_path: launched.log,
+    };
+  };
+}
 
 export function createControlPlaneServer(
   staticRoot = defaultStaticRoot(),
@@ -248,6 +326,60 @@ export function createControlPlaneServer(
               code: "worker_launch_receipt_required",
             }),
           );
+        }
+        return;
+      }
+      response.writeHead(405, {
+        allow: "GET, POST",
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+      return;
+    }
+
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_PROVIDER_RUNNER_ATTACHMENTS_PATH
+    ) {
+      if (!options.planPreviewStore) {
+        response.writeHead(503, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "store_unconfigured" }));
+        return;
+      }
+      if (request.method === "GET") {
+        response.writeHead(200, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify(options.planPreviewStore.providerRunnerAttachments()));
+        return;
+      }
+      if (request.method === "POST") {
+        try {
+          const record = await options.planPreviewStore.attachProviderRunner();
+          response.writeHead(201, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({ schema: 1, status: "ok", provider_runner_attachment: record }),
+          );
+        } catch (error) {
+          const code =
+            error instanceof Error && error.message === "provider_runner_unconfigured"
+              ? "provider_runner_unconfigured"
+              : error instanceof TypeError
+                ? "provider_worker_process_required"
+                : "provider_runner_attachment_failed";
+          response.writeHead(409, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(JSON.stringify({ schema: 1, status: "error", code }));
         }
         return;
       }
@@ -985,12 +1117,16 @@ export function createControlPlaneServer(
 export async function startControlPlane(options: ControlPlaneOptions): Promise<Server> {
   const workspace =
     options.workspace ?? process.env.YUKH_CONVERSATION_WORKSPACE ?? process.env.YUKH_TEAM_WORKSPACE;
+  const teamStore = workspace ? new TeamStore(workspace) : undefined;
+  const providerRunner =
+    workspace && teamStore ? createConfiguredProviderRunner(workspace, teamStore) : undefined;
   const server = createControlPlaneServer(options.staticRoot, {
-    ...(workspace ? { teamStore: new TeamStore(workspace) } : {}),
-    ...(workspace
+    ...(teamStore ? { teamStore } : {}),
+    ...(workspace && teamStore
       ? {
           planPreviewStore: new ControlPlanePlanPreviewStore(workspace, {
             discoverProviderModels: discoverConfiguredProviderModels,
+            ...(providerRunner ? { providerRunner } : {}),
           }),
         }
       : {}),

--- a/apps/control-plane-preview/src/plan-preview-store.ts
+++ b/apps/control-plane-preview/src/plan-preview-store.ts
@@ -417,6 +417,49 @@ export type ControlPlaneProviderWorkerProcessStatus = {
   readonly processes: readonly ControlPlaneProviderWorkerProcessRecord[];
 };
 
+export type ControlPlaneProviderRunnerAttachmentInput = {
+  readonly process: ControlPlaneProviderWorkerProcessRecord;
+};
+
+export type ControlPlaneProviderRunnerAttachmentResult = {
+  readonly runtime: "codex" | "copilot";
+  readonly team_id: string;
+  readonly agent_id: string;
+  readonly pid: number;
+  readonly log_path: string;
+};
+
+export type ControlPlaneProviderRunner = (
+  input: ControlPlaneProviderRunnerAttachmentInput,
+) => Promise<ControlPlaneProviderRunnerAttachmentResult>;
+
+export type ControlPlaneProviderRunnerAttachmentRecord = {
+  readonly schema: 1;
+  readonly provider_runner_attachment_id: string;
+  readonly provider_worker_process_id: string;
+  readonly worker_launch_receipt_id: string;
+  readonly worker_launch_candidate_id: string;
+  readonly provider: string;
+  readonly runtime: "codex" | "copilot";
+  readonly team_id: string;
+  readonly agent_id: string;
+  readonly pid: number;
+  readonly log_path: string;
+  readonly token_budget: number;
+  readonly provider_process_start: "attached";
+  readonly worker_launch: "running";
+  readonly coordination_write: "not_performed";
+  readonly projects_write: "not_performed";
+  readonly created_at: string;
+  readonly next_required_action: "observe_worker_completion";
+};
+
+export type ControlPlaneProviderRunnerAttachmentStatus = {
+  readonly schema: "yukh-control-plane-provider-runner-attachments-v1";
+  readonly source: "local-control-plane-store";
+  readonly attachments: readonly ControlPlaneProviderRunnerAttachmentRecord[];
+};
+
 export type ControlPlanePlanPreviewInput = {
   readonly goal: string;
   readonly mode: string;
@@ -442,6 +485,7 @@ type Document = {
   readonly worker_launch_candidates?: readonly ControlPlaneWorkerLaunchCandidateRecord[];
   readonly worker_launch_receipts?: readonly ControlPlaneWorkerLaunchReceiptRecord[];
   readonly provider_worker_processes?: readonly ControlPlaneProviderWorkerProcessRecord[];
+  readonly provider_runner_attachments?: readonly ControlPlaneProviderRunnerAttachmentRecord[];
 };
 
 const validMode = new Set(["plan-first", "delegate, explicit workers"]);
@@ -535,16 +579,21 @@ function executableCheck(
 export class ControlPlanePlanPreviewStore {
   readonly #path: string;
   readonly #discoverProviderModels: ControlPlaneProviderModelDiscoverer;
+  readonly #providerRunner: ControlPlaneProviderRunner | undefined;
 
   constructor(
     workspace: string,
-    options: { readonly discoverProviderModels?: ControlPlaneProviderModelDiscoverer } = {},
+    options: {
+      readonly discoverProviderModels?: ControlPlaneProviderModelDiscoverer;
+      readonly providerRunner?: ControlPlaneProviderRunner;
+    } = {},
   ) {
     if (!isAbsolute(workspace)) throw new TypeError("invalid control plane workspace");
     const root = join(workspace, ".yukh", "control-plane");
     mkdirSync(root, { recursive: true, mode: 0o700 });
     this.#path = join(root, "plan-previews.json");
     this.#discoverProviderModels = options.discoverProviderModels ?? (async () => undefined);
+    this.#providerRunner = options.providerRunner;
   }
 
   status(): ControlPlanePlanPreviewStoreStatus {
@@ -727,6 +776,56 @@ export class ControlPlanePlanPreviewStore {
       source: "local-control-plane-store",
       processes: this.#read().provider_worker_processes ?? [],
     };
+  }
+
+  providerRunnerAttachments(): ControlPlaneProviderRunnerAttachmentStatus {
+    return {
+      schema: "yukh-control-plane-provider-runner-attachments-v1",
+      source: "local-control-plane-store",
+      attachments: this.#read().provider_runner_attachments ?? [],
+    };
+  }
+
+  async attachProviderRunner(): Promise<ControlPlaneProviderRunnerAttachmentRecord> {
+    const document = this.#read();
+    const process = document.provider_worker_processes?.[0];
+    if (!process || process.worker_launch !== "start_requested_not_running") {
+      throw new TypeError("provider worker process required");
+    }
+    const existing = document.provider_runner_attachments?.find(
+      (attachment) => attachment.provider_worker_process_id === process.provider_worker_process_id,
+    );
+    if (existing) return existing;
+    if (!this.#providerRunner) throw new Error("provider_runner_unconfigured");
+    const result = await this.#providerRunner({ process });
+    const record: ControlPlaneProviderRunnerAttachmentRecord = {
+      schema: 1,
+      provider_runner_attachment_id: `provider-runner-attachment-${randomUUID()}`,
+      provider_worker_process_id: process.provider_worker_process_id,
+      worker_launch_receipt_id: process.worker_launch_receipt_id,
+      worker_launch_candidate_id: process.worker_launch_candidate_id,
+      provider: process.provider,
+      runtime: result.runtime,
+      team_id: result.team_id,
+      agent_id: result.agent_id,
+      pid: result.pid,
+      log_path: result.log_path,
+      token_budget: process.approved_worker_token_budget,
+      provider_process_start: "attached",
+      worker_launch: "running",
+      coordination_write: "not_performed",
+      projects_write: "not_performed",
+      created_at: new Date().toISOString(),
+      next_required_action: "observe_worker_completion",
+    };
+    this.#write({
+      ...document,
+      provider_runner_attachments: [record, ...(document.provider_runner_attachments ?? [])].slice(
+        0,
+        20,
+      ),
+    });
+    return record;
   }
 
   createProviderWorkerProcess(): ControlPlaneProviderWorkerProcessRecord {
@@ -1454,6 +1553,9 @@ export class ControlPlanePlanPreviewStore {
         provider_worker_processes: Array.isArray(parsed.provider_worker_processes)
           ? parsed.provider_worker_processes.filter((item) => item?.schema === 1)
           : [],
+        provider_runner_attachments: Array.isArray(parsed.provider_runner_attachments)
+          ? parsed.provider_runner_attachments.filter((item) => item?.schema === 1)
+          : [],
       };
     } catch {
       return {
@@ -1473,6 +1575,7 @@ export class ControlPlanePlanPreviewStore {
         worker_launch_candidates: [],
         worker_launch_receipts: [],
         provider_worker_processes: [],
+        provider_runner_attachments: [],
       };
     }
   }
@@ -1490,6 +1593,8 @@ export class ControlPlanePlanPreviewStore {
         document.worker_launch_receipts ?? current.worker_launch_receipts ?? [],
       provider_worker_processes:
         document.provider_worker_processes ?? current.provider_worker_processes ?? [],
+      provider_runner_attachments:
+        document.provider_runner_attachments ?? current.provider_runner_attachments ?? [],
     };
     const tmp = `${this.#path}.${process.pid}.${Date.now()}.tmp`;
     writeFileSync(tmp, `${JSON.stringify(normalized, null, 2)}\n`, { mode: 0o600 });

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -875,6 +875,21 @@ const createProviderWorkerProcess = async () => {
   }
 };
 
+const attachProviderRunner = async () => {
+  try {
+    const response = await fetch("./api/manager-plan/provider-runner-attachments", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return body?.provider_runner_attachment ?? null;
+  } catch {
+    return null;
+  }
+};
+
 const renderProviderAdapter = (adapter) => {
   if (!adapter) return "";
   return `
@@ -1113,6 +1128,25 @@ const renderProviderWorkerProcess = (process) => {
       </div>
       <p class="muted">Coordination write: ${escapeHtml(process.coordination_write)} · Projects write: ${escapeHtml(process.projects_write)}.</p>
       <p class="muted">Next required action: ${escapeHtml(process.next_required_action)}.</p>
+      <button type="button" class="secondary provider-runner-attachment-button">Attach provider runner</button>
+    </div>
+  `;
+};
+
+const renderProviderRunnerAttachment = (attachment) => {
+  if (!attachment) return "";
+  return `
+    <div class="provider-runner-attachment">
+      <span>Provider runner attached</span>
+      <strong>${escapeHtml(attachment.provider_runner_attachment_id)}</strong>
+      <p class="muted">${escapeHtml(attachment.runtime)} · pid ${attachment.pid.toLocaleString()} · team ${escapeHtml(attachment.team_id)}.</p>
+      <div class="preflight-grid">
+        <article><span>Agent</span><strong>${escapeHtml(attachment.agent_id)}</strong></article>
+        <article><span>Process</span><strong>${escapeHtml(attachment.provider_process_start)}</strong></article>
+        <article><span>Launch</span><strong>${escapeHtml(attachment.worker_launch)}</strong></article>
+      </div>
+      <p class="muted">Log: ${escapeHtml(attachment.log_path)}</p>
+      <p class="muted">Tokens reserved: ${attachment.token_budget.toLocaleString()} · next: ${escapeHtml(attachment.next_required_action)}.</p>
     </div>
   `;
 };
@@ -1458,6 +1492,22 @@ byId("plan-preview").addEventListener("click", async (event) => {
   button
     .closest(".worker-launch-receipt")
     ?.insertAdjacentHTML("afterend", renderProviderWorkerProcess(process));
+});
+
+byId("plan-preview").addEventListener("click", async (event) => {
+  const button = event.target.closest(".provider-runner-attachment-button");
+  if (!button) return;
+  button.setAttribute("disabled", "true");
+  const attachment = await attachProviderRunner();
+  if (!attachment) {
+    button.removeAttribute("disabled");
+    button.textContent = "Provider runner unavailable";
+    return;
+  }
+  button.textContent = "Provider runner attached";
+  button
+    .closest(".provider-worker-process")
+    ?.insertAdjacentHTML("afterend", renderProviderRunnerAttachment(attachment));
 });
 
 byId("manager-plan-form").addEventListener("submit", (event) => {

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -1037,6 +1037,21 @@ nav a:hover {
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+.provider-runner-attachment {
+  background: rgba(119, 240, 178, 0.16);
+  border: 1px solid rgba(119, 240, 178, 0.44);
+  border-radius: 16px;
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+.provider-runner-attachment span {
+  color: var(--ok);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 .preview-card.approved-preview {
   border-color: rgba(119, 240, 178, 0.48);
 }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -212,7 +212,20 @@ test("control plane preview persists local manager plan previews without leaking
   await writeFile(join(root, "mock-data.js"), "export {};");
 
   const workspace = await mkdtemp(join(tmpdir(), "yukh-control-plane-plan-workspace-"));
-  const planPreviewStore = new ControlPlanePlanPreviewStore(workspace);
+  let providerRunnerCalls = 0;
+  const planPreviewStore = new ControlPlanePlanPreviewStore(workspace, {
+    providerRunner: async ({ process }) => {
+      providerRunnerCalls += 1;
+      assert.equal(process.provider_process_start, "start_requested");
+      return {
+        runtime: "copilot",
+        team_id: "team-11111111-1111-4111-8111-111111111111",
+        agent_id: "worker-22222222-2222-4222-8222-222222222222",
+        pid: 12345,
+        log_path: join(workspace, ".yukh", "teams", "fake.log"),
+      };
+    },
+  });
   const server = createControlPlaneServer(root, { planPreviewStore });
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
@@ -335,6 +348,16 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(
       (await blockedProviderWorkerProcess.json()).code,
       "worker_launch_receipt_required",
+    );
+
+    const blockedProviderRunnerAttachment = await fetch(
+      `${base}/api/manager-plan/provider-runner-attachments`,
+      { method: "POST" },
+    );
+    assert.equal(blockedProviderRunnerAttachment.status, 409);
+    assert.equal(
+      (await blockedProviderRunnerAttachment.json()).code,
+      "provider_worker_process_required",
     );
 
     const invalidProviderAdapter = await fetch(`${base}/api/manager-plan/provider-adapters`, {
@@ -1106,6 +1129,81 @@ test("control plane preview persists local manager plan previews without leaking
     );
     assert.equal(providerWorkerProcessesBody.processes.length, 1);
 
+    const providerRunnerAttachment = await fetch(
+      `${base}/api/manager-plan/provider-runner-attachments`,
+      { method: "POST" },
+    );
+    assert.equal(providerRunnerAttachment.status, 201);
+    const providerRunnerAttachmentBody = await providerRunnerAttachment.json();
+    assert.equal(providerRunnerCalls, 1);
+    assert.equal(
+      providerRunnerAttachmentBody.provider_runner_attachment.provider_worker_process_id,
+      providerWorkerProcessBody.provider_worker_process.provider_worker_process_id,
+    );
+    assert.equal(
+      providerRunnerAttachmentBody.provider_runner_attachment.worker_launch_receipt_id,
+      workerLaunchReceiptBody.worker_launch_receipt.worker_launch_receipt_id,
+    );
+    assert.equal(
+      providerRunnerAttachmentBody.provider_runner_attachment.worker_launch_candidate_id,
+      workerLaunchCandidateBody.worker_launch_candidate.worker_launch_candidate_id,
+    );
+    assert.equal(
+      providerRunnerAttachmentBody.provider_runner_attachment.provider,
+      "Copilot SDK workers",
+    );
+    assert.equal(providerRunnerAttachmentBody.provider_runner_attachment.runtime, "copilot");
+    assert.equal(
+      providerRunnerAttachmentBody.provider_runner_attachment.team_id,
+      "team-11111111-1111-4111-8111-111111111111",
+    );
+    assert.equal(
+      providerRunnerAttachmentBody.provider_runner_attachment.agent_id,
+      "worker-22222222-2222-4222-8222-222222222222",
+    );
+    assert.equal(providerRunnerAttachmentBody.provider_runner_attachment.pid, 12345);
+    assert.equal(providerRunnerAttachmentBody.provider_runner_attachment.token_budget, 66_000);
+    assert.equal(
+      providerRunnerAttachmentBody.provider_runner_attachment.provider_process_start,
+      "attached",
+    );
+    assert.equal(providerRunnerAttachmentBody.provider_runner_attachment.worker_launch, "running");
+    assert.equal(
+      providerRunnerAttachmentBody.provider_runner_attachment.coordination_write,
+      "not_performed",
+    );
+    assert.equal(
+      providerRunnerAttachmentBody.provider_runner_attachment.projects_write,
+      "not_performed",
+    );
+    assert.equal(
+      providerRunnerAttachmentBody.provider_runner_attachment.next_required_action,
+      "observe_worker_completion",
+    );
+
+    const repeatedProviderRunnerAttachment = await fetch(
+      `${base}/api/manager-plan/provider-runner-attachments`,
+      { method: "POST" },
+    );
+    assert.equal(repeatedProviderRunnerAttachment.status, 201);
+    assert.equal(providerRunnerCalls, 1);
+    assert.equal(
+      (await repeatedProviderRunnerAttachment.json()).provider_runner_attachment
+        .provider_runner_attachment_id,
+      providerRunnerAttachmentBody.provider_runner_attachment.provider_runner_attachment_id,
+    );
+
+    const providerRunnerAttachments = await fetch(
+      `${base}/api/manager-plan/provider-runner-attachments`,
+    );
+    assert.equal(providerRunnerAttachments.status, 200);
+    const providerRunnerAttachmentsBody = await providerRunnerAttachments.json();
+    assert.equal(
+      providerRunnerAttachmentsBody.schema,
+      "yukh-control-plane-provider-runner-attachments-v1",
+    );
+    assert.equal(providerRunnerAttachmentsBody.attachments.length, 1);
+
     const persisted = await fetch(`${base}/api/manager-plan/previews`);
     const persistedBody = await persisted.json();
     assert.equal(persistedBody.previews.length, 2);
@@ -1210,6 +1308,13 @@ test("control plane preview persists local manager plan previews without leaking
     );
     assert.equal(providerWorkerProcessDenied.status, 405);
     assert.equal(providerWorkerProcessDenied.headers.get("allow"), "GET, POST");
+
+    const providerRunnerAttachmentDenied = await fetch(
+      `${base}/api/manager-plan/provider-runner-attachments`,
+      { method: "DELETE" },
+    );
+    assert.equal(providerRunnerAttachmentDenied.status, 405);
+    assert.equal(providerRunnerAttachmentDenied.headers.get("allow"), "GET, POST");
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
@@ -1310,6 +1415,7 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /api\/manager-plan\/worker-launch-candidates/u);
   assert.match(data, /api\/manager-plan\/worker-launch-receipts/u);
   assert.match(data, /api\/manager-plan\/provider-worker-processes/u);
+  assert.match(data, /api\/manager-plan\/provider-runner-attachments/u);
   assert.match(data, /Launch readiness/u);
   assert.match(data, /Launch intent recorded/u);
   assert.match(data, /Manager run planned/u);
@@ -1328,6 +1434,8 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /worker-launch-receipt-button/u);
   assert.match(data, /Provider worker process/u);
   assert.match(data, /provider-worker-process-button/u);
+  assert.match(data, /Provider runner attached/u);
+  assert.match(data, /provider-runner-attachment-button/u);
   assert.match(data, /provider_process/u);
   assert.match(data, /worker_delegation/u);
   assert.match(data, /worker_launch/u);
@@ -1393,6 +1501,7 @@ test("control plane preview has bounded text containers for operator UI", async 
   assert.match(css, /\.worker-launch-candidate/u);
   assert.match(css, /\.worker-launch-receipt/u);
   assert.match(css, /\.provider-worker-process/u);
+  assert.match(css, /\.provider-runner-attachment/u);
   assert.match(css, /\.preflight-grid/u);
   assert.match(css, /@media \(max-width: 640px\)/u);
 });


### PR DESCRIPTION
## Summary
- add provider runner attachment records after provider worker process start requests
- wire configured Control Plane startup to TeamStore + TeamSupervisor so real attachments reuse the team-worker runtime
- add Control Plane UI for runner attachment with team, agent, pid, log path and token budget
- keep CI/runtime tests on an injected fake runner so no model tokens are spent

## Verification
- npm run format:check
- npm run typecheck
- npm run build
- node --import tsx --test test/runtime/control-plane-preview.test.ts
- git diff --check