### PR TITLE
Observe Control Plane provider workers

### DIFF
--- a/.context/sessions/SESSION-2026-08-19-17-control-plane-worker-observation.md
+++ b/.context/sessions/SESSION-2026-08-19-17-control-plane-worker-observation.md
@@ -1,0 +1,24 @@
+# SESSION 2026-08-19 — Control Plane worker observation
+
+## Outcome
+
+Added Control Plane worker observation snapshots after a provider runner is
+attached.
+
+## Scope
+
+- Reads the attached worker from the existing TeamStore.
+- Records worker state, launch state, completion outcome, observed tokens,
+  budget outcome and log path.
+- Exposes observation snapshots through API and UI.
+- Does not relaunch provider workers.
+
+## Token guardrail
+
+Observation is read-only against the team runtime. Repeated observations create
+snapshots and do not spend model tokens.
+
+## Next
+
+Add log tailing/openable log artifacts so the operator can inspect what the
+worker is doing without leaving the Control Plane.

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -14,6 +14,7 @@ import {
   type ControlPlaneProviderAdapterInput,
   type ControlPlaneProviderModelDiscoverer,
   type ControlPlaneProviderRunner,
+  type ControlPlaneProviderWorkerObserver,
   type ControlPlanePlanPreviewInput,
 } from "./plan-preview-store.js";
 import { createTeamStatus } from "./team-status.js";
@@ -52,6 +53,7 @@ const API_WORKER_LAUNCH_CANDIDATES_PATH = "/api/manager-plan/worker-launch-candi
 const API_WORKER_LAUNCH_RECEIPTS_PATH = "/api/manager-plan/worker-launch-receipts";
 const API_PROVIDER_WORKER_PROCESSES_PATH = "/api/manager-plan/provider-worker-processes";
 const API_PROVIDER_RUNNER_ATTACHMENTS_PATH = "/api/manager-plan/provider-runner-attachments";
+const API_PROVIDER_WORKER_OBSERVATIONS_PATH = "/api/manager-plan/provider-worker-observations";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
@@ -195,6 +197,20 @@ function createConfiguredProviderRunner(
       agent_id: agent.agent_id,
       pid: launched.pid,
       log_path: launched.log,
+    };
+  };
+}
+
+function createConfiguredProviderWorkerObserver(
+  teamStore: TeamStore,
+): ControlPlaneProviderWorkerObserver {
+  return async ({ attachment }) => {
+    const agent = teamStore.agent(attachment.team_id, attachment.agent_id);
+    return {
+      worker_state: agent.state,
+      ...(agent.completion ? { completion_outcome: agent.completion.outcome } : {}),
+      observed_tokens: agent.usage?.total_tokens ?? 0,
+      ...(agent.usage ? { budget_outcome: agent.usage.budget_outcome } : {}),
     };
   };
 }
@@ -375,6 +391,60 @@ export function createControlPlaneServer(
               : error instanceof TypeError
                 ? "provider_worker_process_required"
                 : "provider_runner_attachment_failed";
+          response.writeHead(409, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(JSON.stringify({ schema: 1, status: "error", code }));
+        }
+        return;
+      }
+      response.writeHead(405, {
+        allow: "GET, POST",
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+      return;
+    }
+
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_PROVIDER_WORKER_OBSERVATIONS_PATH
+    ) {
+      if (!options.planPreviewStore) {
+        response.writeHead(503, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "store_unconfigured" }));
+        return;
+      }
+      if (request.method === "GET") {
+        response.writeHead(200, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify(options.planPreviewStore.providerWorkerObservations()));
+        return;
+      }
+      if (request.method === "POST") {
+        try {
+          const record = await options.planPreviewStore.observeProviderWorker();
+          response.writeHead(201, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(
+            JSON.stringify({ schema: 1, status: "ok", provider_worker_observation: record }),
+          );
+        } catch (error) {
+          const code =
+            error instanceof Error && error.message === "provider_worker_observer_unconfigured"
+              ? "provider_worker_observer_unconfigured"
+              : error instanceof TypeError
+                ? "provider_runner_attachment_required"
+                : "provider_worker_observation_failed";
           response.writeHead(409, {
             "cache-control": "no-store",
             "content-type": "application/json; charset=utf-8",
@@ -1127,6 +1197,7 @@ export async function startControlPlane(options: ControlPlaneOptions): Promise<S
           planPreviewStore: new ControlPlanePlanPreviewStore(workspace, {
             discoverProviderModels: discoverConfiguredProviderModels,
             ...(providerRunner ? { providerRunner } : {}),
+            providerWorkerObserver: createConfiguredProviderWorkerObserver(teamStore),
           }),
         }
       : {}),

--- a/apps/control-plane-preview/src/plan-preview-store.ts
+++ b/apps/control-plane-preview/src/plan-preview-store.ts
@@ -460,6 +460,52 @@ export type ControlPlaneProviderRunnerAttachmentStatus = {
   readonly attachments: readonly ControlPlaneProviderRunnerAttachmentRecord[];
 };
 
+export type ControlPlaneProviderWorkerObservationInput = {
+  readonly attachment: ControlPlaneProviderRunnerAttachmentRecord;
+};
+
+export type ControlPlaneProviderWorkerObservationResult = {
+  readonly worker_state: "defined" | "running" | "completed" | "failed" | "stopped";
+  readonly completion_outcome?: string;
+  readonly observed_tokens: number;
+  readonly budget_outcome?: "within" | "exceeded";
+};
+
+export type ControlPlaneProviderWorkerObserver = (
+  input: ControlPlaneProviderWorkerObservationInput,
+) => Promise<ControlPlaneProviderWorkerObservationResult>;
+
+export type ControlPlaneProviderWorkerObservationRecord = {
+  readonly schema: 1;
+  readonly provider_worker_observation_id: string;
+  readonly provider_runner_attachment_id: string;
+  readonly provider_worker_process_id: string;
+  readonly worker_launch_receipt_id: string;
+  readonly provider: string;
+  readonly runtime: "codex" | "copilot";
+  readonly team_id: string;
+  readonly agent_id: string;
+  readonly pid: number;
+  readonly log_path: string;
+  readonly worker_state: "defined" | "running" | "completed" | "failed" | "stopped";
+  readonly worker_launch: "running" | "completed" | "failed" | "stopped";
+  readonly completion_outcome?: string;
+  readonly observed_tokens: number;
+  readonly token_budget: number;
+  readonly budget_outcome?: "within" | "exceeded";
+  readonly provider_process_start: "observed";
+  readonly coordination_write: "not_performed";
+  readonly projects_write: "not_performed";
+  readonly created_at: string;
+  readonly next_required_action: "continue_observing" | "review_worker_output";
+};
+
+export type ControlPlaneProviderWorkerObservationStatus = {
+  readonly schema: "yukh-control-plane-provider-worker-observations-v1";
+  readonly source: "local-control-plane-store";
+  readonly observations: readonly ControlPlaneProviderWorkerObservationRecord[];
+};
+
 export type ControlPlanePlanPreviewInput = {
   readonly goal: string;
   readonly mode: string;
@@ -486,6 +532,7 @@ type Document = {
   readonly worker_launch_receipts?: readonly ControlPlaneWorkerLaunchReceiptRecord[];
   readonly provider_worker_processes?: readonly ControlPlaneProviderWorkerProcessRecord[];
   readonly provider_runner_attachments?: readonly ControlPlaneProviderRunnerAttachmentRecord[];
+  readonly provider_worker_observations?: readonly ControlPlaneProviderWorkerObservationRecord[];
 };
 
 const validMode = new Set(["plan-first", "delegate, explicit workers"]);
@@ -580,12 +627,14 @@ export class ControlPlanePlanPreviewStore {
   readonly #path: string;
   readonly #discoverProviderModels: ControlPlaneProviderModelDiscoverer;
   readonly #providerRunner: ControlPlaneProviderRunner | undefined;
+  readonly #providerWorkerObserver: ControlPlaneProviderWorkerObserver | undefined;
 
   constructor(
     workspace: string,
     options: {
       readonly discoverProviderModels?: ControlPlaneProviderModelDiscoverer;
       readonly providerRunner?: ControlPlaneProviderRunner;
+      readonly providerWorkerObserver?: ControlPlaneProviderWorkerObserver;
     } = {},
   ) {
     if (!isAbsolute(workspace)) throw new TypeError("invalid control plane workspace");
@@ -594,6 +643,7 @@ export class ControlPlanePlanPreviewStore {
     this.#path = join(root, "plan-previews.json");
     this.#discoverProviderModels = options.discoverProviderModels ?? (async () => undefined);
     this.#providerRunner = options.providerRunner;
+    this.#providerWorkerObserver = options.providerWorkerObserver;
   }
 
   status(): ControlPlanePlanPreviewStoreStatus {
@@ -784,6 +834,65 @@ export class ControlPlanePlanPreviewStore {
       source: "local-control-plane-store",
       attachments: this.#read().provider_runner_attachments ?? [],
     };
+  }
+
+  providerWorkerObservations(): ControlPlaneProviderWorkerObservationStatus {
+    return {
+      schema: "yukh-control-plane-provider-worker-observations-v1",
+      source: "local-control-plane-store",
+      observations: this.#read().provider_worker_observations ?? [],
+    };
+  }
+
+  async observeProviderWorker(): Promise<ControlPlaneProviderWorkerObservationRecord> {
+    const document = this.#read();
+    const attachment = document.provider_runner_attachments?.[0];
+    if (!attachment || attachment.worker_launch !== "running") {
+      throw new TypeError("provider runner attachment required");
+    }
+    if (!this.#providerWorkerObserver) throw new Error("provider_worker_observer_unconfigured");
+    const observed = await this.#providerWorkerObserver({ attachment });
+    const workerLaunch =
+      observed.worker_state === "completed"
+        ? "completed"
+        : observed.worker_state === "failed"
+          ? "failed"
+          : observed.worker_state === "stopped"
+            ? "stopped"
+            : "running";
+    const record: ControlPlaneProviderWorkerObservationRecord = {
+      schema: 1,
+      provider_worker_observation_id: `provider-worker-observation-${randomUUID()}`,
+      provider_runner_attachment_id: attachment.provider_runner_attachment_id,
+      provider_worker_process_id: attachment.provider_worker_process_id,
+      worker_launch_receipt_id: attachment.worker_launch_receipt_id,
+      provider: attachment.provider,
+      runtime: attachment.runtime,
+      team_id: attachment.team_id,
+      agent_id: attachment.agent_id,
+      pid: attachment.pid,
+      log_path: attachment.log_path,
+      worker_state: observed.worker_state,
+      worker_launch: workerLaunch,
+      ...(observed.completion_outcome ? { completion_outcome: observed.completion_outcome } : {}),
+      observed_tokens: observed.observed_tokens,
+      token_budget: attachment.token_budget,
+      ...(observed.budget_outcome ? { budget_outcome: observed.budget_outcome } : {}),
+      provider_process_start: "observed",
+      coordination_write: "not_performed",
+      projects_write: "not_performed",
+      created_at: new Date().toISOString(),
+      next_required_action:
+        workerLaunch === "running" ? "continue_observing" : "review_worker_output",
+    };
+    this.#write({
+      ...document,
+      provider_worker_observations: [
+        record,
+        ...(document.provider_worker_observations ?? []),
+      ].slice(0, 50),
+    });
+    return record;
   }
 
   async attachProviderRunner(): Promise<ControlPlaneProviderRunnerAttachmentRecord> {
@@ -1556,6 +1665,9 @@ export class ControlPlanePlanPreviewStore {
         provider_runner_attachments: Array.isArray(parsed.provider_runner_attachments)
           ? parsed.provider_runner_attachments.filter((item) => item?.schema === 1)
           : [],
+        provider_worker_observations: Array.isArray(parsed.provider_worker_observations)
+          ? parsed.provider_worker_observations.filter((item) => item?.schema === 1)
+          : [],
       };
     } catch {
       return {
@@ -1576,6 +1688,7 @@ export class ControlPlanePlanPreviewStore {
         worker_launch_receipts: [],
         provider_worker_processes: [],
         provider_runner_attachments: [],
+        provider_worker_observations: [],
       };
     }
   }
@@ -1595,6 +1708,8 @@ export class ControlPlanePlanPreviewStore {
         document.provider_worker_processes ?? current.provider_worker_processes ?? [],
       provider_runner_attachments:
         document.provider_runner_attachments ?? current.provider_runner_attachments ?? [],
+      provider_worker_observations:
+        document.provider_worker_observations ?? current.provider_worker_observations ?? [],
     };
     const tmp = `${this.#path}.${process.pid}.${Date.now()}.tmp`;
     writeFileSync(tmp, `${JSON.stringify(normalized, null, 2)}\n`, { mode: 0o600 });

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -890,6 +890,21 @@ const attachProviderRunner = async () => {
   }
 };
 
+const observeProviderWorker = async () => {
+  try {
+    const response = await fetch("./api/manager-plan/provider-worker-observations", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return body?.provider_worker_observation ?? null;
+  } catch {
+    return null;
+  }
+};
+
 const renderProviderAdapter = (adapter) => {
   if (!adapter) return "";
   return `
@@ -1147,6 +1162,25 @@ const renderProviderRunnerAttachment = (attachment) => {
       </div>
       <p class="muted">Log: ${escapeHtml(attachment.log_path)}</p>
       <p class="muted">Tokens reserved: ${attachment.token_budget.toLocaleString()} · next: ${escapeHtml(attachment.next_required_action)}.</p>
+      <button type="button" class="secondary provider-worker-observation-button">Observe worker completion</button>
+    </div>
+  `;
+};
+
+const renderProviderWorkerObservation = (observation) => {
+  if (!observation) return "";
+  return `
+    <div class="provider-worker-observation">
+      <span>Provider worker observation</span>
+      <strong>${escapeHtml(observation.provider_worker_observation_id)}</strong>
+      <p class="muted">${escapeHtml(observation.worker_state)} · launch ${escapeHtml(observation.worker_launch)} · tokens ${observation.observed_tokens.toLocaleString()}/${observation.token_budget.toLocaleString()}.</p>
+      <div class="preflight-grid">
+        <article><span>Runtime</span><strong>${escapeHtml(observation.runtime)}</strong></article>
+        <article><span>Agent</span><strong>${escapeHtml(observation.agent_id)}</strong></article>
+        <article><span>Budget</span><strong>${escapeHtml(observation.budget_outcome ?? "pending")}</strong></article>
+      </div>
+      <p class="muted">Outcome: ${escapeHtml(observation.completion_outcome ?? "pending")} · next: ${escapeHtml(observation.next_required_action)}.</p>
+      <p class="muted">Log: ${escapeHtml(observation.log_path)}</p>
     </div>
   `;
 };
@@ -1508,6 +1542,26 @@ byId("plan-preview").addEventListener("click", async (event) => {
   button
     .closest(".provider-worker-process")
     ?.insertAdjacentHTML("afterend", renderProviderRunnerAttachment(attachment));
+});
+
+byId("plan-preview").addEventListener("click", async (event) => {
+  const button = event.target.closest(".provider-worker-observation-button");
+  if (!button) return;
+  button.setAttribute("disabled", "true");
+  const observation = await observeProviderWorker();
+  if (!observation) {
+    button.removeAttribute("disabled");
+    button.textContent = "Worker observation unavailable";
+    return;
+  }
+  button.removeAttribute("disabled");
+  button.textContent =
+    observation.next_required_action === "continue_observing"
+      ? "Observe worker again"
+      : "Worker output ready";
+  button
+    .closest(".provider-runner-attachment")
+    ?.insertAdjacentHTML("afterend", renderProviderWorkerObservation(observation));
 });
 
 byId("manager-plan-form").addEventListener("submit", (event) => {

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -1052,6 +1052,21 @@ nav a:hover {
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+.provider-worker-observation {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 16px;
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+.provider-worker-observation span {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 .preview-card.approved-preview {
   border-color: rgba(119, 240, 178, 0.48);
 }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -213,6 +213,7 @@ test("control plane preview persists local manager plan previews without leaking
 
   const workspace = await mkdtemp(join(tmpdir(), "yukh-control-plane-plan-workspace-"));
   let providerRunnerCalls = 0;
+  let providerObserverCalls = 0;
   const planPreviewStore = new ControlPlanePlanPreviewStore(workspace, {
     providerRunner: async ({ process }) => {
       providerRunnerCalls += 1;
@@ -223,6 +224,23 @@ test("control plane preview persists local manager plan previews without leaking
         agent_id: "worker-22222222-2222-4222-8222-222222222222",
         pid: 12345,
         log_path: join(workspace, ".yukh", "teams", "fake.log"),
+      };
+    },
+    providerWorkerObserver: async ({ attachment }) => {
+      providerObserverCalls += 1;
+      assert.equal(attachment.provider_process_start, "attached");
+      if (providerObserverCalls === 1) {
+        return {
+          worker_state: "running",
+          observed_tokens: 12_000,
+          budget_outcome: "within",
+        };
+      }
+      return {
+        worker_state: "completed",
+        completion_outcome: "succeeded",
+        observed_tokens: 18_000,
+        budget_outcome: "within",
       };
     },
   });
@@ -358,6 +376,16 @@ test("control plane preview persists local manager plan previews without leaking
     assert.equal(
       (await blockedProviderRunnerAttachment.json()).code,
       "provider_worker_process_required",
+    );
+
+    const blockedProviderWorkerObservation = await fetch(
+      `${base}/api/manager-plan/provider-worker-observations`,
+      { method: "POST" },
+    );
+    assert.equal(blockedProviderWorkerObservation.status, 409);
+    assert.equal(
+      (await blockedProviderWorkerObservation.json()).code,
+      "provider_runner_attachment_required",
     );
 
     const invalidProviderAdapter = await fetch(`${base}/api/manager-plan/provider-adapters`, {
@@ -1204,6 +1232,89 @@ test("control plane preview persists local manager plan previews without leaking
     );
     assert.equal(providerRunnerAttachmentsBody.attachments.length, 1);
 
+    const providerWorkerObservation = await fetch(
+      `${base}/api/manager-plan/provider-worker-observations`,
+      { method: "POST" },
+    );
+    assert.equal(providerWorkerObservation.status, 201);
+    const providerWorkerObservationBody = await providerWorkerObservation.json();
+    assert.equal(providerObserverCalls, 1);
+    assert.equal(
+      providerWorkerObservationBody.provider_worker_observation.provider_runner_attachment_id,
+      providerRunnerAttachmentBody.provider_runner_attachment.provider_runner_attachment_id,
+    );
+    assert.equal(
+      providerWorkerObservationBody.provider_worker_observation.provider_worker_process_id,
+      providerWorkerProcessBody.provider_worker_process.provider_worker_process_id,
+    );
+    assert.equal(
+      providerWorkerObservationBody.provider_worker_observation.worker_launch_receipt_id,
+      workerLaunchReceiptBody.worker_launch_receipt.worker_launch_receipt_id,
+    );
+    assert.equal(providerWorkerObservationBody.provider_worker_observation.runtime, "copilot");
+    assert.equal(
+      providerWorkerObservationBody.provider_worker_observation.team_id,
+      "team-11111111-1111-4111-8111-111111111111",
+    );
+    assert.equal(
+      providerWorkerObservationBody.provider_worker_observation.agent_id,
+      "worker-22222222-2222-4222-8222-222222222222",
+    );
+    assert.equal(providerWorkerObservationBody.provider_worker_observation.worker_state, "running");
+    assert.equal(
+      providerWorkerObservationBody.provider_worker_observation.worker_launch,
+      "running",
+    );
+    assert.equal(providerWorkerObservationBody.provider_worker_observation.observed_tokens, 12_000);
+    assert.equal(providerWorkerObservationBody.provider_worker_observation.token_budget, 66_000);
+    assert.equal(
+      providerWorkerObservationBody.provider_worker_observation.budget_outcome,
+      "within",
+    );
+    assert.equal(
+      providerWorkerObservationBody.provider_worker_observation.next_required_action,
+      "continue_observing",
+    );
+
+    const completedProviderWorkerObservation = await fetch(
+      `${base}/api/manager-plan/provider-worker-observations`,
+      { method: "POST" },
+    );
+    assert.equal(completedProviderWorkerObservation.status, 201);
+    const completedProviderWorkerObservationBody = await completedProviderWorkerObservation.json();
+    assert.equal(providerObserverCalls, 2);
+    assert.equal(
+      completedProviderWorkerObservationBody.provider_worker_observation.worker_state,
+      "completed",
+    );
+    assert.equal(
+      completedProviderWorkerObservationBody.provider_worker_observation.worker_launch,
+      "completed",
+    );
+    assert.equal(
+      completedProviderWorkerObservationBody.provider_worker_observation.completion_outcome,
+      "succeeded",
+    );
+    assert.equal(
+      completedProviderWorkerObservationBody.provider_worker_observation.observed_tokens,
+      18_000,
+    );
+    assert.equal(
+      completedProviderWorkerObservationBody.provider_worker_observation.next_required_action,
+      "review_worker_output",
+    );
+
+    const providerWorkerObservations = await fetch(
+      `${base}/api/manager-plan/provider-worker-observations`,
+    );
+    assert.equal(providerWorkerObservations.status, 200);
+    const providerWorkerObservationsBody = await providerWorkerObservations.json();
+    assert.equal(
+      providerWorkerObservationsBody.schema,
+      "yukh-control-plane-provider-worker-observations-v1",
+    );
+    assert.equal(providerWorkerObservationsBody.observations.length, 2);
+
     const persisted = await fetch(`${base}/api/manager-plan/previews`);
     const persistedBody = await persisted.json();
     assert.equal(persistedBody.previews.length, 2);
@@ -1315,6 +1426,13 @@ test("control plane preview persists local manager plan previews without leaking
     );
     assert.equal(providerRunnerAttachmentDenied.status, 405);
     assert.equal(providerRunnerAttachmentDenied.headers.get("allow"), "GET, POST");
+
+    const providerWorkerObservationDenied = await fetch(
+      `${base}/api/manager-plan/provider-worker-observations`,
+      { method: "DELETE" },
+    );
+    assert.equal(providerWorkerObservationDenied.status, 405);
+    assert.equal(providerWorkerObservationDenied.headers.get("allow"), "GET, POST");
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
@@ -1416,6 +1534,7 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /api\/manager-plan\/worker-launch-receipts/u);
   assert.match(data, /api\/manager-plan\/provider-worker-processes/u);
   assert.match(data, /api\/manager-plan\/provider-runner-attachments/u);
+  assert.match(data, /api\/manager-plan\/provider-worker-observations/u);
   assert.match(data, /Launch readiness/u);
   assert.match(data, /Launch intent recorded/u);
   assert.match(data, /Manager run planned/u);
@@ -1436,6 +1555,8 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /provider-worker-process-button/u);
   assert.match(data, /Provider runner attached/u);
   assert.match(data, /provider-runner-attachment-button/u);
+  assert.match(data, /Provider worker observation/u);
+  assert.match(data, /provider-worker-observation-button/u);
   assert.match(data, /provider_process/u);
   assert.match(data, /worker_delegation/u);
   assert.match(data, /worker_launch/u);
@@ -1502,6 +1623,7 @@ test("control plane preview has bounded text containers for operator UI", async 
   assert.match(css, /\.worker-launch-receipt/u);
   assert.match(css, /\.provider-worker-process/u);
   assert.match(css, /\.provider-runner-attachment/u);
+  assert.match(css, /\.provider-worker-observation/u);
   assert.match(css, /\.preflight-grid/u);
   assert.match(css, /@media \(max-width: 640px\)/u);
 });


### PR DESCRIPTION
## Summary
- add provider worker observation snapshots after a runner attachment
- read attached worker state, completion outcome and token usage from the TeamStore
- expose observation API and Control Plane UI with worker state, token use, budget outcome and log path
- keep observation read-only: repeated observations do not launch providers or spend tokens

## Verification
- npm run format:check
- npm run typecheck
- npm run build
- node --import tsx --test test/runtime/control-plane-preview.test.ts
- git diff --check