### PR TITLE
Add Control Plane worker activity adapter

### DIFF
--- a/.context/sessions/SESSION-2026-08-19-19-control-plane-worker-activity-adapter.md
+++ b/.context/sessions/SESSION-2026-08-19-19-control-plane-worker-activity-adapter.md
@@ -1,0 +1,16 @@
+# Session 2026-08-19 19 — Control Plane worker activity adapter
+
+## Summary
+
+Adds a Control Plane preview adapter for the `worker.activity.v1` runtime contract. The UI can now request a bounded worker activity snapshot after a provider runner is attached, and the API persists the resulting CloudEvents-like event in the local preview store.
+
+## Boundaries
+
+- `worker.activity.v1` is the contract shown to the operator.
+- The local TeamStore/file-backed snapshot remains a preview adapter only.
+- JetStream is still the intended distributed source for worker activity; this increment does not add the JetStream publisher or consumer.
+- The Control Plane still does not launch new work from activity reads.
+
+## Next
+
+Replace the preview adapter with a JetStream publisher/consumer path for runtime activity while keeping the same Control Plane activity view.

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -1,4 +1,5 @@
 import { createServer, type IncomingMessage, type Server } from "node:http";
+import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { dirname, join, normalize } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -14,6 +15,7 @@ import {
   type ControlPlaneProviderAdapterInput,
   type ControlPlaneProviderModelDiscoverer,
   type ControlPlaneProviderRunner,
+  type ControlPlaneWorkerActivityAdapter,
   type ControlPlanePlanPreviewInput,
 } from "./plan-preview-store.js";
 import { createTeamStatus } from "./team-status.js";
@@ -52,6 +54,7 @@ const API_WORKER_LAUNCH_CANDIDATES_PATH = "/api/manager-plan/worker-launch-candi
 const API_WORKER_LAUNCH_RECEIPTS_PATH = "/api/manager-plan/worker-launch-receipts";
 const API_PROVIDER_WORKER_PROCESSES_PATH = "/api/manager-plan/provider-worker-processes";
 const API_PROVIDER_RUNNER_ATTACHMENTS_PATH = "/api/manager-plan/provider-runner-attachments";
+const API_WORKER_ACTIVITIES_PATH = "/api/manager-plan/worker-activities";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
@@ -195,6 +198,48 @@ function createConfiguredProviderRunner(
       agent_id: agent.agent_id,
       pid: launched.pid,
       log_path: launched.log,
+    };
+  };
+}
+
+function createConfiguredWorkerActivityAdapter(
+  teamStore: TeamStore,
+): ControlPlaneWorkerActivityAdapter {
+  return async ({ attachment, sequence }) => {
+    const agent = teamStore.agent(attachment.team_id, attachment.agent_id);
+    const observed = new Date().toISOString();
+    const activityKind = agent.usage ? "tokens-observed" : "status-changed";
+    return {
+      specversion: "1.0",
+      id: randomUUID(),
+      source: `yukh://runtime/local-preview/worker/${agent.agent_id}`,
+      type: "worker.activity.v1",
+      subject: `yukh.local.tenant-local.runtime.worker.${agent.agent_id}.${activityKind}.v1`,
+      time: observed,
+      datacontenttype: "application/json",
+      dataschema: "https://yukh.example/schemas/runtime/v1/worker-activity.schema.json",
+      correlationid: attachment.provider_runner_attachment_id,
+      causationid: attachment.provider_worker_process_id,
+      data: {
+        aggregate_type: "WorkerSession",
+        aggregate_id: agent.agent_id,
+        producer_id: "control-plane-preview-adapter",
+        sequence,
+        activity_kind: activityKind,
+        observed_at: observed,
+        worker_state: agent.state,
+        summary:
+          "Preview adapter snapshot; JetStream worker.activity.v1 remains the distributed contract.",
+        ...(agent.usage
+          ? {
+              tokens: {
+                observed: agent.usage.total_tokens,
+                budget: agent.token_budget,
+                budget_outcome: agent.usage.budget_outcome,
+              },
+            }
+          : {}),
+      },
     };
   };
 }
@@ -375,6 +420,58 @@ export function createControlPlaneServer(
               : error instanceof TypeError
                 ? "provider_worker_process_required"
                 : "provider_runner_attachment_failed";
+          response.writeHead(409, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(JSON.stringify({ schema: 1, status: "error", code }));
+        }
+        return;
+      }
+      response.writeHead(405, {
+        allow: "GET, POST",
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+      return;
+    }
+
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_WORKER_ACTIVITIES_PATH
+    ) {
+      if (!options.planPreviewStore) {
+        response.writeHead(503, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "store_unconfigured" }));
+        return;
+      }
+      if (request.method === "GET") {
+        response.writeHead(200, {
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify(options.planPreviewStore.workerActivities()));
+        return;
+      }
+      if (request.method === "POST") {
+        try {
+          const record = await options.planPreviewStore.recordWorkerActivity();
+          response.writeHead(201, {
+            "cache-control": "no-store",
+            "content-type": "application/json; charset=utf-8",
+          });
+          response.end(JSON.stringify({ schema: 1, status: "ok", worker_activity: record }));
+        } catch (error) {
+          const code =
+            error instanceof Error && error.message === "worker_activity_adapter_unconfigured"
+              ? "worker_activity_adapter_unconfigured"
+              : error instanceof TypeError
+                ? "provider_runner_attachment_required"
+                : "worker_activity_failed";
           response.writeHead(409, {
             "cache-control": "no-store",
             "content-type": "application/json; charset=utf-8",
@@ -1127,6 +1224,7 @@ export async function startControlPlane(options: ControlPlaneOptions): Promise<S
           planPreviewStore: new ControlPlanePlanPreviewStore(workspace, {
             discoverProviderModels: discoverConfiguredProviderModels,
             ...(providerRunner ? { providerRunner } : {}),
+            workerActivityAdapter: createConfiguredWorkerActivityAdapter(teamStore),
           }),
         }
       : {}),

--- a/apps/control-plane-preview/src/plan-preview-store.ts
+++ b/apps/control-plane-preview/src/plan-preview-store.ts
@@ -460,6 +460,51 @@ export type ControlPlaneProviderRunnerAttachmentStatus = {
   readonly attachments: readonly ControlPlaneProviderRunnerAttachmentRecord[];
 };
 
+export type ControlPlaneWorkerActivityEvent = {
+  readonly specversion: "1.0";
+  readonly id: string;
+  readonly source: string;
+  readonly type: "worker.activity.v1";
+  readonly subject: string;
+  readonly time: string;
+  readonly datacontenttype: "application/json";
+  readonly dataschema: "https://yukh.example/schemas/runtime/v1/worker-activity.schema.json";
+  readonly correlationid?: string;
+  readonly causationid?: string;
+  readonly data: {
+    readonly aggregate_type: "WorkerSession";
+    readonly aggregate_id: string;
+    readonly producer_id: string;
+    readonly sequence: number;
+    readonly activity_kind:
+      "heartbeat" | "log-chunked" | "status-changed" | "tokens-observed" | "artifact-recorded";
+    readonly observed_at: string;
+    readonly worker_state?: "defined" | "running" | "completed" | "failed" | "stopped";
+    readonly summary?: string;
+    readonly artifact_ref?: string;
+    readonly tokens?: {
+      readonly observed: number;
+      readonly budget: number;
+      readonly budget_outcome?: "within" | "exceeded";
+    };
+  };
+};
+
+export type ControlPlaneWorkerActivityInput = {
+  readonly attachment: ControlPlaneProviderRunnerAttachmentRecord;
+  readonly sequence: number;
+};
+
+export type ControlPlaneWorkerActivityAdapter = (
+  input: ControlPlaneWorkerActivityInput,
+) => Promise<ControlPlaneWorkerActivityEvent>;
+
+export type ControlPlaneWorkerActivityStatus = {
+  readonly schema: "yukh-control-plane-worker-activities-v1";
+  readonly source: "worker.activity.v1-preview-adapter";
+  readonly activities: readonly ControlPlaneWorkerActivityEvent[];
+};
+
 export type ControlPlanePlanPreviewInput = {
   readonly goal: string;
   readonly mode: string;
@@ -486,6 +531,7 @@ type Document = {
   readonly worker_launch_receipts?: readonly ControlPlaneWorkerLaunchReceiptRecord[];
   readonly provider_worker_processes?: readonly ControlPlaneProviderWorkerProcessRecord[];
   readonly provider_runner_attachments?: readonly ControlPlaneProviderRunnerAttachmentRecord[];
+  readonly worker_activities?: readonly ControlPlaneWorkerActivityEvent[];
 };
 
 const validMode = new Set(["plan-first", "delegate, explicit workers"]);
@@ -580,12 +626,14 @@ export class ControlPlanePlanPreviewStore {
   readonly #path: string;
   readonly #discoverProviderModels: ControlPlaneProviderModelDiscoverer;
   readonly #providerRunner: ControlPlaneProviderRunner | undefined;
+  readonly #workerActivityAdapter: ControlPlaneWorkerActivityAdapter | undefined;
 
   constructor(
     workspace: string,
     options: {
       readonly discoverProviderModels?: ControlPlaneProviderModelDiscoverer;
       readonly providerRunner?: ControlPlaneProviderRunner;
+      readonly workerActivityAdapter?: ControlPlaneWorkerActivityAdapter;
     } = {},
   ) {
     if (!isAbsolute(workspace)) throw new TypeError("invalid control plane workspace");
@@ -594,6 +642,7 @@ export class ControlPlanePlanPreviewStore {
     this.#path = join(root, "plan-previews.json");
     this.#discoverProviderModels = options.discoverProviderModels ?? (async () => undefined);
     this.#providerRunner = options.providerRunner;
+    this.#workerActivityAdapter = options.workerActivityAdapter;
   }
 
   status(): ControlPlanePlanPreviewStoreStatus {
@@ -784,6 +833,32 @@ export class ControlPlanePlanPreviewStore {
       source: "local-control-plane-store",
       attachments: this.#read().provider_runner_attachments ?? [],
     };
+  }
+
+  workerActivities(): ControlPlaneWorkerActivityStatus {
+    return {
+      schema: "yukh-control-plane-worker-activities-v1",
+      source: "worker.activity.v1-preview-adapter",
+      activities: this.#read().worker_activities ?? [],
+    };
+  }
+
+  async recordWorkerActivity(): Promise<ControlPlaneWorkerActivityEvent> {
+    const document = this.#read();
+    const attachment = document.provider_runner_attachments?.[0];
+    if (!attachment || attachment.worker_launch !== "running") {
+      throw new TypeError("provider runner attachment required");
+    }
+    if (!this.#workerActivityAdapter) throw new Error("worker_activity_adapter_unconfigured");
+    const event = await this.#workerActivityAdapter({
+      attachment,
+      sequence: (document.worker_activities ?? []).length + 1,
+    });
+    this.#write({
+      ...document,
+      worker_activities: [event, ...(document.worker_activities ?? [])].slice(0, 50),
+    });
+    return event;
   }
 
   async attachProviderRunner(): Promise<ControlPlaneProviderRunnerAttachmentRecord> {
@@ -1556,6 +1631,9 @@ export class ControlPlanePlanPreviewStore {
         provider_runner_attachments: Array.isArray(parsed.provider_runner_attachments)
           ? parsed.provider_runner_attachments.filter((item) => item?.schema === 1)
           : [],
+        worker_activities: Array.isArray(parsed.worker_activities)
+          ? parsed.worker_activities.filter((item) => item?.type === "worker.activity.v1")
+          : [],
       };
     } catch {
       return {
@@ -1576,6 +1654,7 @@ export class ControlPlanePlanPreviewStore {
         worker_launch_receipts: [],
         provider_worker_processes: [],
         provider_runner_attachments: [],
+        worker_activities: [],
       };
     }
   }
@@ -1595,6 +1674,7 @@ export class ControlPlanePlanPreviewStore {
         document.provider_worker_processes ?? current.provider_worker_processes ?? [],
       provider_runner_attachments:
         document.provider_runner_attachments ?? current.provider_runner_attachments ?? [],
+      worker_activities: document.worker_activities ?? current.worker_activities ?? [],
     };
     const tmp = `${this.#path}.${process.pid}.${Date.now()}.tmp`;
     writeFileSync(tmp, `${JSON.stringify(normalized, null, 2)}\n`, { mode: 0o600 });

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -890,6 +890,21 @@ const attachProviderRunner = async () => {
   }
 };
 
+const recordWorkerActivity = async () => {
+  try {
+    const response = await fetch("./api/manager-plan/worker-activities", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    if (!response.ok) return null;
+    const body = await response.json();
+    return body?.worker_activity ?? null;
+  } catch {
+    return null;
+  }
+};
+
 const renderProviderAdapter = (adapter) => {
   if (!adapter) return "";
   return `
@@ -1146,7 +1161,25 @@ const renderProviderRunnerAttachment = (attachment) => {
         <article><span>Launch</span><strong>${escapeHtml(attachment.worker_launch)}</strong></article>
       </div>
       <p class="muted">Log: ${escapeHtml(attachment.log_path)}</p>
-      <p class="muted">Tokens reserved: ${attachment.token_budget.toLocaleString()} · next: ${escapeHtml(attachment.next_required_action)}.</p>
+      <p class="muted">Tokens reserved: ${attachment.token_budget.toLocaleString()} · next: read worker.activity.v1.</p>
+      <button type="button" class="secondary worker-activity-button">Read worker activity</button>
+    </div>
+  `;
+};
+
+const renderWorkerActivity = (activity) => {
+  if (!activity) return "";
+  return `
+    <div class="worker-activity">
+      <span>worker.activity.v1</span>
+      <strong>${escapeHtml(activity.id)}</strong>
+      <p class="muted">${escapeHtml(activity.subject)} · source ${escapeHtml(activity.source)}.</p>
+      <div class="preflight-grid">
+        <article><span>Kind</span><strong>${escapeHtml(activity.data.activity_kind)}</strong></article>
+        <article><span>State</span><strong>${escapeHtml(activity.data.worker_state ?? "pending")}</strong></article>
+        <article><span>Tokens</span><strong>${activity.data.tokens ? `${activity.data.tokens.observed.toLocaleString()}/${activity.data.tokens.budget.toLocaleString()}` : "pending"}</strong></article>
+      </div>
+      <p class="muted">${escapeHtml(activity.data.summary ?? "Activity snapshot from the preview adapter.")}</p>
     </div>
   `;
 };
@@ -1508,6 +1541,23 @@ byId("plan-preview").addEventListener("click", async (event) => {
   button
     .closest(".provider-worker-process")
     ?.insertAdjacentHTML("afterend", renderProviderRunnerAttachment(attachment));
+});
+
+byId("plan-preview").addEventListener("click", async (event) => {
+  const button = event.target.closest(".worker-activity-button");
+  if (!button) return;
+  button.setAttribute("disabled", "true");
+  const activity = await recordWorkerActivity();
+  if (!activity) {
+    button.removeAttribute("disabled");
+    button.textContent = "Worker activity unavailable";
+    return;
+  }
+  button.removeAttribute("disabled");
+  button.textContent = "Read worker activity again";
+  button
+    .closest(".provider-runner-attachment")
+    ?.insertAdjacentHTML("afterend", renderWorkerActivity(activity));
 });
 
 byId("manager-plan-form").addEventListener("submit", (event) => {

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -1052,6 +1052,21 @@ nav a:hover {
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+.worker-activity {
+  background: rgba(251, 191, 36, 0.12);
+  border: 1px solid rgba(251, 191, 36, 0.34);
+  border-radius: 16px;
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+.worker-activity span {
+  color: var(--warn);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 .preview-card.approved-preview {
   border-color: rgba(119, 240, 178, 0.48);
 }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -213,6 +213,7 @@ test("control plane preview persists local manager plan previews without leaking
 
   const workspace = await mkdtemp(join(tmpdir(), "yukh-control-plane-plan-workspace-"));
   let providerRunnerCalls = 0;
+  let workerActivityCalls = 0;
   const planPreviewStore = new ControlPlanePlanPreviewStore(workspace, {
     providerRunner: async ({ process }) => {
       providerRunnerCalls += 1;
@@ -223,6 +224,39 @@ test("control plane preview persists local manager plan previews without leaking
         agent_id: "worker-22222222-2222-4222-8222-222222222222",
         pid: 12345,
         log_path: join(workspace, ".yukh", "teams", "fake.log"),
+      };
+    },
+    workerActivityAdapter: async ({ attachment, sequence }) => {
+      workerActivityCalls += 1;
+      assert.equal(attachment.agent_id, "worker-22222222-2222-4222-8222-222222222222");
+      assert.equal(attachment.worker_launch, "running");
+      return {
+        specversion: "1.0",
+        id: "worker-activity-11111111-1111-4111-8111-111111111111",
+        source: "yukh://runtime/local-preview/worker/worker-22222222-2222-4222-8222-222222222222",
+        type: "worker.activity.v1",
+        subject:
+          "yukh.local.tenant-local.runtime.worker.worker-22222222-2222-4222-8222-222222222222.tokens-observed.v1",
+        time: "2026-08-19T12:00:00.000Z",
+        datacontenttype: "application/json",
+        dataschema: "https://yukh.example/schemas/runtime/v1/worker-activity.schema.json",
+        correlationid: attachment.provider_runner_attachment_id,
+        causationid: attachment.provider_worker_process_id,
+        data: {
+          aggregate_type: "WorkerSession",
+          aggregate_id: attachment.agent_id,
+          producer_id: "control-plane-preview-adapter",
+          sequence,
+          activity_kind: "tokens-observed",
+          observed_at: "2026-08-19T12:00:00.000Z",
+          worker_state: "running",
+          summary: "Preview adapter snapshot.",
+          tokens: {
+            observed: 12_000,
+            budget: attachment.token_budget,
+            budget_outcome: "within",
+          },
+        },
       };
     },
   });
@@ -359,6 +393,12 @@ test("control plane preview persists local manager plan previews without leaking
       (await blockedProviderRunnerAttachment.json()).code,
       "provider_worker_process_required",
     );
+
+    const blockedWorkerActivity = await fetch(`${base}/api/manager-plan/worker-activities`, {
+      method: "POST",
+    });
+    assert.equal(blockedWorkerActivity.status, 409);
+    assert.equal((await blockedWorkerActivity.json()).code, "provider_runner_attachment_required");
 
     const invalidProviderAdapter = await fetch(`${base}/api/manager-plan/provider-adapters`, {
       method: "POST",
@@ -1204,6 +1244,40 @@ test("control plane preview persists local manager plan previews without leaking
     );
     assert.equal(providerRunnerAttachmentsBody.attachments.length, 1);
 
+    const workerActivity = await fetch(`${base}/api/manager-plan/worker-activities`, {
+      method: "POST",
+    });
+    assert.equal(workerActivity.status, 201);
+    const workerActivityBody = await workerActivity.json();
+    assert.equal(workerActivityCalls, 1);
+    assert.equal(workerActivityBody.worker_activity.type, "worker.activity.v1");
+    assert.equal(
+      workerActivityBody.worker_activity.correlationid,
+      providerRunnerAttachmentBody.provider_runner_attachment.provider_runner_attachment_id,
+    );
+    assert.equal(
+      workerActivityBody.worker_activity.causationid,
+      providerWorkerProcessBody.provider_worker_process.provider_worker_process_id,
+    );
+    assert.equal(workerActivityBody.worker_activity.data.aggregate_type, "WorkerSession");
+    assert.equal(
+      workerActivityBody.worker_activity.data.aggregate_id,
+      providerRunnerAttachmentBody.provider_runner_attachment.agent_id,
+    );
+    assert.equal(workerActivityBody.worker_activity.data.sequence, 1);
+    assert.equal(workerActivityBody.worker_activity.data.activity_kind, "tokens-observed");
+    assert.equal(workerActivityBody.worker_activity.data.tokens.observed, 12_000);
+    assert.equal(workerActivityBody.worker_activity.data.tokens.budget, 66_000);
+    assert.doesNotMatch(JSON.stringify(workerActivityBody), /sensitive manager plan preview/iu);
+
+    const workerActivities = await fetch(`${base}/api/manager-plan/worker-activities`);
+    assert.equal(workerActivities.status, 200);
+    const workerActivitiesBody = await workerActivities.json();
+    assert.equal(workerActivitiesBody.schema, "yukh-control-plane-worker-activities-v1");
+    assert.equal(workerActivitiesBody.source, "worker.activity.v1-preview-adapter");
+    assert.equal(workerActivitiesBody.activities.length, 1);
+    assert.equal(workerActivitiesBody.activities[0].id, workerActivityBody.worker_activity.id);
+
     const persisted = await fetch(`${base}/api/manager-plan/previews`);
     const persistedBody = await persisted.json();
     assert.equal(persistedBody.previews.length, 2);
@@ -1315,6 +1389,12 @@ test("control plane preview persists local manager plan previews without leaking
     );
     assert.equal(providerRunnerAttachmentDenied.status, 405);
     assert.equal(providerRunnerAttachmentDenied.headers.get("allow"), "GET, POST");
+
+    const workerActivityDenied = await fetch(`${base}/api/manager-plan/worker-activities`, {
+      method: "DELETE",
+    });
+    assert.equal(workerActivityDenied.status, 405);
+    assert.equal(workerActivityDenied.headers.get("allow"), "GET, POST");
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
@@ -1416,6 +1496,7 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /api\/manager-plan\/worker-launch-receipts/u);
   assert.match(data, /api\/manager-plan\/provider-worker-processes/u);
   assert.match(data, /api\/manager-plan\/provider-runner-attachments/u);
+  assert.match(data, /api\/manager-plan\/worker-activities/u);
   assert.match(data, /Launch readiness/u);
   assert.match(data, /Launch intent recorded/u);
   assert.match(data, /Manager run planned/u);
@@ -1436,6 +1517,8 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /provider-worker-process-button/u);
   assert.match(data, /Provider runner attached/u);
   assert.match(data, /provider-runner-attachment-button/u);
+  assert.match(data, /worker\.activity\.v1/u);
+  assert.match(data, /worker-activity-button/u);
   assert.match(data, /provider_process/u);
   assert.match(data, /worker_delegation/u);
   assert.match(data, /worker_launch/u);
@@ -1464,6 +1547,9 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /YKP_WORK_EVENTS_V1/u);
   assert.match(data, /message is evidence, not work authority/u);
   assert.doesNotMatch(`${html}\n${data}`, /mermaid/iu);
+
+  const styles = await readFile("apps/control-plane-preview/static/styles.css", "utf8");
+  assert.match(styles, /\.worker-activity/u);
 });
 
 test("control plane preview has bounded text containers for operator UI", async () => {
@@ -1502,6 +1588,7 @@ test("control plane preview has bounded text containers for operator UI", async 
   assert.match(css, /\.worker-launch-receipt/u);
   assert.match(css, /\.provider-worker-process/u);
   assert.match(css, /\.provider-runner-attachment/u);
+  assert.match(css, /\.worker-activity/u);
   assert.match(css, /\.preflight-grid/u);
   assert.match(css, /@media \(max-width: 640px\)/u);
 });


### PR DESCRIPTION
## Summary
- add a Control Plane preview API for worker.activity.v1 snapshots
- surface worker activity from the provider runner attachment card
- persist bounded preview activity records while keeping JetStream as the distributed contract

## Validation
- npm run format:check
- npm run typecheck
- npm run build
- npm run test:contracts
- node --import tsx --test test/runtime/control-plane-preview.test.ts
- npm test (outside sandbox; 325 pass)