### PR TITLE
Add worker activity JetStream adapter

### DIFF
--- a/.context/sessions/SESSION-2026-08-19-20-worker-activity-jetstream-adapter.md
+++ b/.context/sessions/SESSION-2026-08-19-20-worker-activity-jetstream-adapter.md
@@ -1,0 +1,23 @@
+# Session 2026-08-19 20 — Worker activity JetStream adapter
+
+## Summary
+
+Adds the first real JetStream adapter for `worker.activity.v1`. The Control
+Plane can now publish a bounded worker activity event to `YKR_WORKER_EVENTS_V1`
+and read recent worker activity from the same stream when
+`YUKH_WORKER_ACTIVITY_JETSTREAM=1` is enabled.
+
+## Boundaries
+
+- JetStream is opt-in for the preview server.
+- Local preview activity remains available when JetStream is not configured or
+  temporarily unavailable.
+- The adapter uses `msgID = event.id` for idempotent publish.
+- No raw stdout tailing or node-local path is promoted to a distributed
+  contract.
+
+## Next
+
+Move actual provider-worker lifecycle observations into this event bus so the
+Control Plane receives activity continuously, not only when the preview button
+requests a snapshot.

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -11,6 +11,11 @@ import { TeamStore } from "../../../packages/team-control/src/store.js";
 import { teamRuntimeEntrypoints } from "../../../packages/team-control/src/entrypoints.js";
 import { TeamSupervisor } from "../../../packages/team-control/src/supervisor.js";
 import {
+  WorkerActivityJetStreamBus,
+  WORKER_ACTIVITY_SCHEMA,
+  workerActivitySubject,
+} from "../../../packages/runtime-events/src/worker-activity.js";
+import {
   ControlPlanePlanPreviewStore,
   type ControlPlaneProviderAdapterInput,
   type ControlPlaneProviderModelDiscoverer,
@@ -214,10 +219,15 @@ function createConfiguredWorkerActivityAdapter(
       id: randomUUID(),
       source: `yukh://runtime/local-preview/worker/${agent.agent_id}`,
       type: "worker.activity.v1",
-      subject: `yukh.local.tenant-local.runtime.worker.${agent.agent_id}.${activityKind}.v1`,
+      subject: workerActivitySubject({
+        env: "local",
+        tenant: "tenant-local",
+        workerId: agent.agent_id,
+        kind: activityKind,
+      }),
       time: observed,
       datacontenttype: "application/json",
-      dataschema: "https://yukh.example/schemas/runtime/v1/worker-activity.schema.json",
+      dataschema: WORKER_ACTIVITY_SCHEMA,
       correlationid: attachment.provider_runner_attachment_id,
       causationid: attachment.provider_worker_process_id,
       data: {
@@ -242,6 +252,25 @@ function createConfiguredWorkerActivityAdapter(
       },
     };
   };
+}
+
+async function createConfiguredWorkerActivityBus(): Promise<
+  WorkerActivityJetStreamBus | undefined
+> {
+  if (process.env.YUKH_WORKER_ACTIVITY_JETSTREAM !== "1") return undefined;
+  try {
+    return await WorkerActivityJetStreamBus.connect({
+      servers: process.env.YUKH_NATS_URL ?? "nats://127.0.0.1:4222",
+      createStream: process.env.YUKH_WORKER_ACTIVITY_CREATE_STREAM !== "0",
+    });
+  } catch (error) {
+    process.stderr.write(
+      `Yukh Control Plane worker activity JetStream unavailable; using preview adapter only: ${
+        error instanceof Error ? error.message : "unknown error"
+      }\n`,
+    );
+    return undefined;
+  }
 }
 
 export function createControlPlaneServer(
@@ -454,7 +483,7 @@ export function createControlPlaneServer(
           "cache-control": "no-store",
           "content-type": "application/json; charset=utf-8",
         });
-        response.end(JSON.stringify(options.planPreviewStore.workerActivities()));
+        response.end(JSON.stringify(await options.planPreviewStore.workerActivities()));
         return;
       }
       if (request.method === "POST") {
@@ -1217,6 +1246,7 @@ export async function startControlPlane(options: ControlPlaneOptions): Promise<S
   const teamStore = workspace ? new TeamStore(workspace) : undefined;
   const providerRunner =
     workspace && teamStore ? createConfiguredProviderRunner(workspace, teamStore) : undefined;
+  const workerActivityBus = await createConfiguredWorkerActivityBus();
   const server = createControlPlaneServer(options.staticRoot, {
     ...(teamStore ? { teamStore } : {}),
     ...(workspace && teamStore
@@ -1225,9 +1255,13 @@ export async function startControlPlane(options: ControlPlaneOptions): Promise<S
             discoverProviderModels: discoverConfiguredProviderModels,
             ...(providerRunner ? { providerRunner } : {}),
             workerActivityAdapter: createConfiguredWorkerActivityAdapter(teamStore),
+            ...(workerActivityBus ? { workerActivityBus } : {}),
           }),
         }
       : {}),
+  });
+  server.on("close", () => {
+    void workerActivityBus?.close();
   });
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);

--- a/apps/control-plane-preview/src/plan-preview-store.ts
+++ b/apps/control-plane-preview/src/plan-preview-store.ts
@@ -1,6 +1,10 @@
 import { createHash, randomUUID } from "node:crypto";
 import { accessSync, constants, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { isAbsolute, join } from "node:path";
+import {
+  type WorkerActivityEvent,
+  type WorkerActivityEventBus,
+} from "../../../packages/runtime-events/src/worker-activity.js";
 
 export type ControlPlanePlanPreviewState = "proposed" | "approved-preview";
 
@@ -460,35 +464,7 @@ export type ControlPlaneProviderRunnerAttachmentStatus = {
   readonly attachments: readonly ControlPlaneProviderRunnerAttachmentRecord[];
 };
 
-export type ControlPlaneWorkerActivityEvent = {
-  readonly specversion: "1.0";
-  readonly id: string;
-  readonly source: string;
-  readonly type: "worker.activity.v1";
-  readonly subject: string;
-  readonly time: string;
-  readonly datacontenttype: "application/json";
-  readonly dataschema: "https://yukh.example/schemas/runtime/v1/worker-activity.schema.json";
-  readonly correlationid?: string;
-  readonly causationid?: string;
-  readonly data: {
-    readonly aggregate_type: "WorkerSession";
-    readonly aggregate_id: string;
-    readonly producer_id: string;
-    readonly sequence: number;
-    readonly activity_kind:
-      "heartbeat" | "log-chunked" | "status-changed" | "tokens-observed" | "artifact-recorded";
-    readonly observed_at: string;
-    readonly worker_state?: "defined" | "running" | "completed" | "failed" | "stopped";
-    readonly summary?: string;
-    readonly artifact_ref?: string;
-    readonly tokens?: {
-      readonly observed: number;
-      readonly budget: number;
-      readonly budget_outcome?: "within" | "exceeded";
-    };
-  };
-};
+export type ControlPlaneWorkerActivityEvent = WorkerActivityEvent;
 
 export type ControlPlaneWorkerActivityInput = {
   readonly attachment: ControlPlaneProviderRunnerAttachmentRecord;
@@ -501,7 +477,7 @@ export type ControlPlaneWorkerActivityAdapter = (
 
 export type ControlPlaneWorkerActivityStatus = {
   readonly schema: "yukh-control-plane-worker-activities-v1";
-  readonly source: "worker.activity.v1-preview-adapter";
+  readonly source: "worker.activity.v1-preview-adapter" | "worker.activity.v1-jetstream";
   readonly activities: readonly ControlPlaneWorkerActivityEvent[];
 };
 
@@ -627,6 +603,7 @@ export class ControlPlanePlanPreviewStore {
   readonly #discoverProviderModels: ControlPlaneProviderModelDiscoverer;
   readonly #providerRunner: ControlPlaneProviderRunner | undefined;
   readonly #workerActivityAdapter: ControlPlaneWorkerActivityAdapter | undefined;
+  readonly #workerActivityBus: WorkerActivityEventBus | undefined;
 
   constructor(
     workspace: string,
@@ -634,6 +611,7 @@ export class ControlPlanePlanPreviewStore {
       readonly discoverProviderModels?: ControlPlaneProviderModelDiscoverer;
       readonly providerRunner?: ControlPlaneProviderRunner;
       readonly workerActivityAdapter?: ControlPlaneWorkerActivityAdapter;
+      readonly workerActivityBus?: WorkerActivityEventBus;
     } = {},
   ) {
     if (!isAbsolute(workspace)) throw new TypeError("invalid control plane workspace");
@@ -643,6 +621,7 @@ export class ControlPlanePlanPreviewStore {
     this.#discoverProviderModels = options.discoverProviderModels ?? (async () => undefined);
     this.#providerRunner = options.providerRunner;
     this.#workerActivityAdapter = options.workerActivityAdapter;
+    this.#workerActivityBus = options.workerActivityBus;
   }
 
   status(): ControlPlanePlanPreviewStoreStatus {
@@ -835,7 +814,14 @@ export class ControlPlanePlanPreviewStore {
     };
   }
 
-  workerActivities(): ControlPlaneWorkerActivityStatus {
+  async workerActivities(): Promise<ControlPlaneWorkerActivityStatus> {
+    if (this.#workerActivityBus) {
+      return {
+        schema: "yukh-control-plane-worker-activities-v1",
+        source: "worker.activity.v1-jetstream",
+        activities: await this.#workerActivityBus.recent(50),
+      };
+    }
     return {
       schema: "yukh-control-plane-worker-activities-v1",
       source: "worker.activity.v1-preview-adapter",
@@ -854,6 +840,7 @@ export class ControlPlanePlanPreviewStore {
       attachment,
       sequence: (document.worker_activities ?? []).length + 1,
     });
+    await this.#workerActivityBus?.publish(event);
     this.#write({
       ...document,
       worker_activities: [event, ...(document.worker_activities ?? [])].slice(0, 50),

--- a/docs/architecture/event-subject-policy.md
+++ b/docs/architecture/event-subject-policy.md
@@ -78,6 +78,20 @@ Local files are preview adapters only. A local path may help one-node
 development, but it is not a distributed contract and must not be required by
 the Control Plane.
 
+The Control Plane can publish and read runtime activity through the JetStream
+adapter when explicitly enabled:
+
+```text
+YUKH_WORKER_ACTIVITY_JETSTREAM=1
+YUKH_NATS_URL=nats://127.0.0.1:4222
+YUKH_WORKER_ACTIVITY_CREATE_STREAM=1
+```
+
+If the adapter is not enabled, the preview UI keeps using the local preview
+adapter and labels the source accordingly. Enabling JetStream creates or uses
+`YKR_WORKER_EVENTS_V1` with subject `yukh.*.*.runtime.worker.*.*.v1`; events
+are published with `msgID = event.id` for idempotent delivery.
+
 ## Resource and resilience policy
 
 - Emit compact activity events; do not publish every stdout byte as an event.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@github/copilot-sdk": "^1.0.11",
         "@modelcontextprotocol/server": "2.0.0",
+        "@nats-io/jetstream": "^3.4.0",
+        "@nats-io/transport-node": "^3.4.0",
         "ajv": "8.20.0",
         "zod": "4.4.3"
       },
@@ -919,6 +921,60 @@
         "node": ">=20"
       }
     },
+    "node_modules/@nats-io/jetstream": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@nats-io/jetstream/-/jetstream-3.4.0.tgz",
+      "integrity": "sha512-GzHQodNJ942+R5LRb8PuZ5ugVWVWMRiufxUYLLVWkXKfwDXYN+Owo0d7L/b9O7BPyrbYD7jQWAC6+ZVuXa9Gyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nats-io/nats-core": "3.4.0"
+      }
+    },
+    "node_modules/@nats-io/nats-core": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@nats-io/nats-core/-/nats-core-3.4.0.tgz",
+      "integrity": "sha512-QMDM86EUNm+wudlKC67HLar/KHHQUvJGLfb4jbahje3pUk3K9afeck9fwsxBZF0eUFox6T/TA6m/t+lQqf+QsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nats-io/nkeys": "2.0.3",
+        "@nats-io/nuid": "3.0.0"
+      }
+    },
+    "node_modules/@nats-io/nkeys": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nats-io/nkeys/-/nkeys-2.0.3.tgz",
+      "integrity": "sha512-JVt56GuE6Z89KUkI4TXUbSI9fmIfAmk6PMPknijmuL72GcD+UgIomTcRWiNvvJKxA01sBbmIPStqJs5cMRBC3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tweetnacl": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@nats-io/nuid": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nats-io/nuid/-/nuid-3.0.0.tgz",
+      "integrity": "sha512-QbXZDrxmYlrn5AD06gYcUTmEHwxn96HBQMIk7XTjDlEcx6FPzVBBPjp4AMRh1lEv6B4iJ6Xb/Uz61JugPXFRQg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 22.x"
+      }
+    },
+    "node_modules/@nats-io/transport-node": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@nats-io/transport-node/-/transport-node-3.4.0.tgz",
+      "integrity": "sha512-hH7u7ejIBTFEJIZ8rIcMrHJI6wl+HhpO5sVFs1+ppmXa8RuB2+Lh1+UwTzZ5xTNNm1TKcRkYy+2qCV56qp8RxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nats-io/nats-core": "3.4.0",
+        "@nats-io/nkeys": "2.0.3",
+        "@nats-io/nuid": "3.0.0"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "24.10.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
@@ -1571,6 +1627,12 @@
       "optionalDependencies": {
         "fsevents": "~2.3.3"
       }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
     },
     "node_modules/typescript": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   "dependencies": {
     "@github/copilot-sdk": "^1.0.11",
     "@modelcontextprotocol/server": "2.0.0",
+    "@nats-io/jetstream": "^3.4.0",
+    "@nats-io/transport-node": "^3.4.0",
     "ajv": "8.20.0",
     "zod": "4.4.3"
   },

--- a/packages/runtime-events/src/worker-activity.ts
+++ b/packages/runtime-events/src/worker-activity.ts
@@ -1,0 +1,256 @@
+export const WORKER_ACTIVITY_STREAM = "YKR_WORKER_EVENTS_V1";
+export const WORKER_ACTIVITY_SUBJECT = "yukh.*.*.runtime.worker.*.*.v1";
+export const WORKER_ACTIVITY_SCHEMA =
+  "https://yukh.example/schemas/runtime/v1/worker-activity.schema.json";
+export const WORKER_ACTIVITY_MAX_PAYLOAD_BYTES = 8_192;
+
+export type WorkerActivityKind =
+  "heartbeat" | "log-chunked" | "status-changed" | "tokens-observed" | "artifact-recorded";
+
+export type WorkerActivityEvent = {
+  readonly specversion: "1.0";
+  readonly id: string;
+  readonly source: string;
+  readonly type: "worker.activity.v1";
+  readonly subject: string;
+  readonly time: string;
+  readonly datacontenttype: "application/json";
+  readonly dataschema: typeof WORKER_ACTIVITY_SCHEMA;
+  readonly correlationid?: string;
+  readonly causationid?: string;
+  readonly data: {
+    readonly aggregate_type: "WorkerSession";
+    readonly aggregate_id: string;
+    readonly producer_id: string;
+    readonly sequence: number;
+    readonly activity_kind: WorkerActivityKind;
+    readonly observed_at: string;
+    readonly worker_state?: "defined" | "running" | "completed" | "failed" | "stopped";
+    readonly summary?: string;
+    readonly artifact_ref?: string;
+    readonly tokens?: {
+      readonly observed: number;
+      readonly budget: number;
+      readonly budget_outcome?: "within" | "exceeded";
+    };
+  };
+};
+
+export type WorkerActivityPublishReceipt = {
+  readonly stream: typeof WORKER_ACTIVITY_STREAM;
+  readonly sequence: number;
+  readonly duplicate: boolean;
+};
+
+export interface WorkerActivityEventBus {
+  publish(event: WorkerActivityEvent): Promise<WorkerActivityPublishReceipt>;
+  recent(limit: number): Promise<readonly WorkerActivityEvent[]>;
+  close(): Promise<void>;
+}
+
+const idPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const nameSegmentPattern = /^[a-z0-9][a-z0-9-]{0,127}$/u;
+const tenantPattern = /^[a-z0-9][a-z0-9-]{0,63}$/u;
+const timePattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u;
+const subjectPattern =
+  /^yukh\.(local|dev|staging|prod)\.[a-z0-9][a-z0-9-]{0,63}\.runtime\.worker\.[a-z0-9][a-z0-9-]{0,127}\.(heartbeat|log-chunked|status-changed|tokens-observed|artifact-recorded)\.v1$/u;
+const sourcePattern =
+  /^yukh:\/\/runtime\/[a-z0-9][a-z0-9-]{0,63}\/worker\/[a-z0-9][a-z0-9-]{0,127}$/u;
+const identifierPattern = /^[a-z][a-z0-9._:-]{0,127}$/u;
+
+export function workerActivitySubject(input: {
+  readonly env: "local" | "dev" | "staging" | "prod";
+  readonly tenant: string;
+  readonly workerId: string;
+  readonly kind: WorkerActivityKind;
+}): string {
+  if (!tenantPattern.test(input.tenant) || !nameSegmentPattern.test(input.workerId)) {
+    throw new TypeError("invalid worker activity subject input");
+  }
+  return `yukh.${input.env}.${input.tenant}.runtime.worker.${input.workerId}.${input.kind}.v1`;
+}
+
+export function validateWorkerActivityEvent(event: WorkerActivityEvent): void {
+  if (
+    event.specversion !== "1.0" ||
+    !idPattern.test(event.id) ||
+    !sourcePattern.test(event.source) ||
+    event.type !== "worker.activity.v1" ||
+    !subjectPattern.test(event.subject) ||
+    !timePattern.test(event.time) ||
+    event.datacontenttype !== "application/json" ||
+    event.dataschema !== WORKER_ACTIVITY_SCHEMA ||
+    !identifierPattern.test(event.data.aggregate_id) ||
+    !identifierPattern.test(event.data.producer_id) ||
+    event.data.aggregate_type !== "WorkerSession" ||
+    !Number.isSafeInteger(event.data.sequence) ||
+    event.data.sequence < 1 ||
+    (event.correlationid !== undefined && !identifierPattern.test(event.correlationid)) ||
+    (event.causationid !== undefined && !identifierPattern.test(event.causationid)) ||
+    (event.data.summary !== undefined && event.data.summary.length > 2_048) ||
+    (event.data.activity_kind === "artifact-recorded" && !event.data.artifact_ref) ||
+    (event.data.activity_kind === "tokens-observed" && !event.data.tokens) ||
+    (event.data.activity_kind === "status-changed" && !event.data.worker_state)
+  ) {
+    throw new TypeError("invalid worker activity event");
+  }
+}
+
+export function encodeWorkerActivityEvent(event: WorkerActivityEvent): Uint8Array {
+  validateWorkerActivityEvent(event);
+  const payload = new TextEncoder().encode(JSON.stringify(event));
+  if (payload.byteLength > WORKER_ACTIVITY_MAX_PAYLOAD_BYTES) {
+    throw new TypeError("worker activity payload too large");
+  }
+  return payload;
+}
+
+function decodeWorkerActivityEvent(payload: Uint8Array): WorkerActivityEvent | null {
+  if (payload.byteLength > WORKER_ACTIVITY_MAX_PAYLOAD_BYTES) return null;
+  try {
+    const value = JSON.parse(new TextDecoder().decode(payload)) as WorkerActivityEvent;
+    validateWorkerActivityEvent(value);
+    return value;
+  } catch {
+    return null;
+  }
+}
+
+export type WorkerActivityJetStreamOptions = {
+  readonly servers: string | readonly string[];
+  readonly stream?: typeof WORKER_ACTIVITY_STREAM;
+  readonly createStream?: boolean;
+  readonly maxMessages?: number;
+  readonly maxBytes?: number;
+  readonly maxAgeNanos?: number;
+};
+
+type NatsConnectionLike = {
+  close(): Promise<void>;
+};
+
+type JetStreamPublishAck = {
+  readonly stream: string;
+  readonly seq: number;
+  readonly duplicate: boolean;
+};
+
+type JetStreamLike = {
+  publish(
+    subject: string,
+    payload: Uint8Array,
+    options: { readonly msgID: string },
+  ): Promise<JetStreamPublishAck>;
+  streams: {
+    get(stream: string): Promise<{
+      info(): Promise<{
+        readonly state: { readonly first_seq: number; readonly last_seq: number };
+      }>;
+      getMessage(query: { readonly seq: number }): Promise<{ readonly data: Uint8Array } | null>;
+    }>;
+  };
+};
+
+type JetStreamManagerLike = {
+  streams: {
+    info(stream: string): Promise<unknown>;
+    add(config: Record<string, unknown>): Promise<unknown>;
+  };
+};
+
+const dynamicImport = new Function("specifier", "return import(specifier)") as (
+  specifier: string,
+) => Promise<Record<string, unknown>>;
+
+export class WorkerActivityJetStreamBus implements WorkerActivityEventBus {
+  readonly #connection: NatsConnectionLike;
+  readonly #jetstream: JetStreamLike;
+  readonly #jetstreamManager: () => Promise<JetStreamManagerLike>;
+
+  private constructor(
+    connection: NatsConnectionLike,
+    jetstreamClient: JetStreamLike,
+    jetstreamManagerFactory: () => Promise<JetStreamManagerLike>,
+  ) {
+    this.#connection = connection;
+    this.#jetstream = jetstreamClient;
+    this.#jetstreamManager = jetstreamManagerFactory;
+  }
+
+  static async connect(
+    options: WorkerActivityJetStreamOptions,
+  ): Promise<WorkerActivityJetStreamBus> {
+    const transport = await dynamicImport("@nats-io/transport-node");
+    const jetstreamModule = await dynamicImport("@nats-io/jetstream");
+    const connect = transport.connect as (input: {
+      readonly servers?: string | readonly string[];
+    }) => Promise<NatsConnectionLike>;
+    const createJetStream = jetstreamModule.jetstream as (
+      connection: NatsConnectionLike,
+    ) => JetStreamLike;
+    const createJetStreamManager = jetstreamModule.jetstreamManager as (
+      connection: NatsConnectionLike,
+    ) => Promise<JetStreamManagerLike>;
+    const connection = await connect({ servers: options.servers });
+    const bus = new WorkerActivityJetStreamBus(connection, createJetStream(connection), () =>
+      createJetStreamManager(connection),
+    );
+    if (options.createStream ?? true) {
+      await bus.ensureStream(options);
+    }
+    return bus;
+  }
+
+  async ensureStream(options: WorkerActivityJetStreamOptions): Promise<void> {
+    const manager = await this.#jetstreamManager();
+    try {
+      await manager.streams.info(options.stream ?? WORKER_ACTIVITY_STREAM);
+      return;
+    } catch {
+      await manager.streams.add({
+        name: options.stream ?? WORKER_ACTIVITY_STREAM,
+        subjects: [WORKER_ACTIVITY_SUBJECT],
+        retention: "limits",
+        storage: "file",
+        discard: "old",
+        max_msgs: options.maxMessages ?? 10_000,
+        max_bytes: options.maxBytes ?? 64 * 1024 * 1024,
+        max_age: options.maxAgeNanos ?? 7 * 24 * 60 * 60 * 1_000_000_000,
+        max_msg_size: WORKER_ACTIVITY_MAX_PAYLOAD_BYTES,
+        allow_direct: true,
+        description: "Yukh bounded runtime worker activity events v1",
+      });
+    }
+  }
+
+  async publish(event: WorkerActivityEvent): Promise<WorkerActivityPublishReceipt> {
+    const ack = await this.#jetstream.publish(event.subject, encodeWorkerActivityEvent(event), {
+      msgID: event.id,
+    });
+    if (ack.stream !== WORKER_ACTIVITY_STREAM) throw new Error("worker_activity_stream_mismatch");
+    return { stream: WORKER_ACTIVITY_STREAM, sequence: ack.seq, duplicate: ack.duplicate };
+  }
+
+  async recent(limit: number): Promise<readonly WorkerActivityEvent[]> {
+    const bounded = Math.max(0, Math.min(50, Math.trunc(limit)));
+    if (bounded === 0) return [];
+    const stream = await this.#jetstream.streams.get(WORKER_ACTIVITY_STREAM);
+    const info = await stream.info();
+    const events: WorkerActivityEvent[] = [];
+    for (
+      let sequence = info.state.last_seq;
+      sequence >= info.state.first_seq && events.length < bounded;
+      sequence -= 1
+    ) {
+      const message = await stream.getMessage({ seq: sequence }).catch(() => null);
+      if (!message) continue;
+      const event = decodeWorkerActivityEvent(message.data);
+      if (event) events.push(event);
+    }
+    return events;
+  }
+
+  async close(): Promise<void> {
+    await this.#connection.close();
+  }
+}

--- a/test/runtime/worker-activity-events.test.ts
+++ b/test/runtime/worker-activity-events.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { ControlPlanePlanPreviewStore } from "../../apps/control-plane-preview/src/plan-preview-store.js";
+import {
+  encodeWorkerActivityEvent,
+  validateWorkerActivityEvent,
+  WORKER_ACTIVITY_MAX_PAYLOAD_BYTES,
+  WORKER_ACTIVITY_SCHEMA,
+  WORKER_ACTIVITY_STREAM,
+  workerActivitySubject,
+  type WorkerActivityEvent,
+  type WorkerActivityEventBus,
+} from "../../packages/runtime-events/src/worker-activity.js";
+
+const activity = (sequence = 1): WorkerActivityEvent => ({
+  specversion: "1.0",
+  id: "11111111-1111-4111-8111-111111111111",
+  source: "yukh://runtime/local-preview/worker/worker-22222222-2222-4222-8222-222222222222",
+  type: "worker.activity.v1",
+  subject: workerActivitySubject({
+    env: "local",
+    tenant: "tenant-local",
+    workerId: "worker-22222222-2222-4222-8222-222222222222",
+    kind: "tokens-observed",
+  }),
+  time: "2026-08-19T12:00:00.000Z",
+  datacontenttype: "application/json",
+  dataschema: WORKER_ACTIVITY_SCHEMA,
+  correlationid: "provider-runner-attachment:demo",
+  causationid: "provider-worker-process:demo",
+  data: {
+    aggregate_type: "WorkerSession",
+    aggregate_id: "worker-22222222-2222-4222-8222-222222222222",
+    producer_id: "control-plane-preview-adapter",
+    sequence,
+    activity_kind: "tokens-observed",
+    observed_at: "2026-08-19T12:00:00.000Z",
+    worker_state: "running",
+    summary: "Observed bounded token usage.",
+    tokens: {
+      observed: 12_000,
+      budget: 66_000,
+      budget_outcome: "within",
+    },
+  },
+});
+
+test("worker activity subject and payload stay within the JetStream policy", () => {
+  const event = activity();
+  assert.equal(
+    event.subject,
+    "yukh.local.tenant-local.runtime.worker.worker-22222222-2222-4222-8222-222222222222.tokens-observed.v1",
+  );
+  assert.doesNotMatch(event.subject, /[*>]/u);
+  assert.doesNotMatch(event.subject, /\\/u);
+  assert.doesNotThrow(() => validateWorkerActivityEvent(event));
+  assert.ok(encodeWorkerActivityEvent(event).byteLength < WORKER_ACTIVITY_MAX_PAYLOAD_BYTES);
+  assert.throws(
+    () =>
+      workerActivitySubject({
+        env: "local",
+        tenant: "tenant-local",
+        workerId: "worker/path",
+        kind: "status-changed",
+      }),
+    /invalid worker activity subject input/u,
+  );
+});
+
+test("control plane store publishes worker activity to the event bus and reads bus projection", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "yukh-worker-activity-bus-"));
+  const store = new ControlPlanePlanPreviewStore(workspace, {
+    workerActivityAdapter: async ({ sequence }) => activity(sequence),
+    workerActivityBus: new (class implements WorkerActivityEventBus {
+      readonly events: WorkerActivityEvent[] = [];
+
+      async publish(event: WorkerActivityEvent) {
+        this.events.unshift(event);
+        return {
+          stream: WORKER_ACTIVITY_STREAM,
+          sequence: this.events.length,
+          duplicate: false,
+        } as const;
+      }
+
+      async recent(limit: number) {
+        return this.events.slice(0, limit);
+      }
+
+      async close() {}
+    })(),
+  });
+  await mkdir(join(workspace, ".yukh", "control-plane"), { recursive: true });
+  await writeFile(
+    join(workspace, ".yukh", "control-plane", "plan-previews.json"),
+    JSON.stringify({
+      schema: 1,
+      previews: [],
+      provider_runner_attachments: [
+        {
+          schema: 1,
+          provider_runner_attachment_id: "provider-runner-attachment:demo",
+          provider_worker_process_id: "provider-worker-process:demo",
+          worker_launch_receipt_id: "worker-launch-receipt:demo",
+          worker_launch_candidate_id: "worker-launch-candidate:demo",
+          provider: "Copilot SDK workers",
+          runtime: "copilot",
+          team_id: "team-11111111-1111-4111-8111-111111111111",
+          agent_id: "worker-22222222-2222-4222-8222-222222222222",
+          pid: 12345,
+          log_path: "/tmp/preview-adapter-only.log",
+          token_budget: 66_000,
+          provider_process_start: "attached",
+          worker_launch: "running",
+          coordination_write: "not_performed",
+          projects_write: "not_performed",
+          created_at: "2026-08-19T12:00:00.000Z",
+          next_required_action: "observe_worker_completion",
+        },
+      ],
+    }),
+  );
+
+  const recorded = await store.recordWorkerActivity();
+  assert.equal(recorded.type, "worker.activity.v1");
+  const status = await store.workerActivities();
+  assert.equal(status.source, "worker.activity.v1-jetstream");
+  assert.equal(status.activities.length, 1);
+  assert.equal(status.activities[0]?.id, recorded.id);
+});


### PR DESCRIPTION
## Summary
- add a runtime-events worker.activity.v1 JetStream adapter for YKR_WORKER_EVENTS_V1
- let the Control Plane publish/read worker activity from JetStream when YUKH_WORKER_ACTIVITY_JETSTREAM=1
- keep the local preview adapter as fallback and document the env wiring

## Validation
- npm run format:check
- npm run typecheck
- npm run build
- npm run test:contracts
- node --import tsx --test test/runtime/worker-activity-events.test.ts test/runtime/control-plane-preview.test.ts
- npm test (outside sandbox; 327 pass)