### PR TITLE
Emit worker activity from team runtime

### DIFF
--- a/apps/team-worker/src/activity.ts
+++ b/apps/team-worker/src/activity.ts
@@ -1,0 +1,174 @@
+import { randomUUID } from "node:crypto";
+import type {
+  AgentState,
+  AgentUsage,
+  AgentRecord,
+} from "../../../packages/team-control/src/store.js";
+import {
+  WORKER_ACTIVITY_SCHEMA,
+  WorkerActivityJetStreamBus,
+  workerActivitySubject,
+  type WorkerActivityEvent,
+  type WorkerActivityEventBus,
+} from "../../../packages/runtime-events/src/worker-activity.js";
+
+const DEFAULT_ENV = "local";
+const DEFAULT_TENANT = "tenant-local";
+const PRODUCER_ID = "team-worker-runtime";
+
+export interface WorkerActivityEmitter {
+  running(): Promise<void>;
+  tokens(usage: AgentUsage): Promise<void>;
+  terminal(
+    state: Extract<AgentState, "completed" | "failed" | "stopped">,
+    summary?: string,
+  ): Promise<void>;
+  close(): Promise<void>;
+}
+
+export function createNoopWorkerActivityEmitter(): WorkerActivityEmitter {
+  return {
+    async running() {
+      return;
+    },
+    async tokens() {
+      return;
+    },
+    async terminal() {
+      return;
+    },
+    async close() {
+      return;
+    },
+  };
+}
+
+export async function createConfiguredWorkerActivityEmitter(
+  agent: AgentRecord,
+  env: NodeJS.ProcessEnv,
+): Promise<WorkerActivityEmitter> {
+  if (env.YUKH_WORKER_ACTIVITY_JETSTREAM !== "1") return createNoopWorkerActivityEmitter();
+  try {
+    const bus = await WorkerActivityJetStreamBus.connect({
+      servers: env.YUKH_NATS_URL ?? "nats://127.0.0.1:4222",
+      createStream: env.YUKH_WORKER_ACTIVITY_CREATE_STREAM !== "0",
+    });
+    return createWorkerActivityEmitter(agent, bus, {
+      env: runtimeEnvironment(env.YUKH_RUNTIME_ENV),
+      tenant: env.YUKH_TENANT ?? DEFAULT_TENANT,
+    });
+  } catch (error) {
+    process.stderr.write(`yukh-team-worker: worker activity bus unavailable: ${message(error)}\n`);
+    return createNoopWorkerActivityEmitter();
+  }
+}
+
+export function createWorkerActivityEmitter(
+  agent: AgentRecord,
+  bus: WorkerActivityEventBus,
+  options: { readonly env?: "local" | "dev" | "staging" | "prod"; readonly tenant?: string } = {},
+): WorkerActivityEmitter {
+  let sequence = 0;
+  const publish = async (
+    activityKind: WorkerActivityEvent["data"]["activity_kind"],
+    data: Partial<WorkerActivityEvent["data"]>,
+  ): Promise<void> => {
+    const event = workerActivityEvent(agent, {
+      env: options.env ?? DEFAULT_ENV,
+      tenant: options.tenant ?? DEFAULT_TENANT,
+      sequence: ++sequence,
+      activityKind,
+      data,
+    });
+    try {
+      await bus.publish(event);
+    } catch (error) {
+      process.stderr.write(
+        `yukh-team-worker: worker activity publish skipped: ${message(error)}\n`,
+      );
+    }
+  };
+  return {
+    async running() {
+      await publish("status-changed", {
+        worker_state: "running",
+        summary: "Worker entered running state.",
+      });
+    },
+    async tokens(usage) {
+      await publish("tokens-observed", {
+        worker_state: "running",
+        summary: "Observed bounded token usage.",
+        tokens: {
+          observed: usage.total_tokens,
+          budget: agent.token_budget,
+          budget_outcome: usage.budget_outcome,
+        },
+      });
+    },
+    async terminal(state, summary) {
+      await publish("status-changed", {
+        worker_state: state,
+        summary: boundedSummary(summary ?? `Worker ${state}.`),
+      });
+    },
+    async close() {
+      try {
+        await bus.close();
+      } catch {
+        // Observability must not change worker outcome.
+      }
+    },
+  };
+}
+
+export function workerActivityEvent(
+  agent: AgentRecord,
+  input: {
+    readonly env: "local" | "dev" | "staging" | "prod";
+    readonly tenant: string;
+    readonly sequence: number;
+    readonly activityKind: WorkerActivityEvent["data"]["activity_kind"];
+    readonly data: Partial<WorkerActivityEvent["data"]>;
+  },
+): WorkerActivityEvent {
+  const now = new Date().toISOString();
+  return {
+    specversion: "1.0",
+    id: randomUUID(),
+    source: `yukh://runtime/local-preview/worker/${agent.agent_id}`,
+    type: "worker.activity.v1",
+    subject: workerActivitySubject({
+      env: input.env,
+      tenant: input.tenant,
+      workerId: agent.agent_id,
+      kind: input.activityKind,
+    }),
+    time: now,
+    datacontenttype: "application/json",
+    dataschema: WORKER_ACTIVITY_SCHEMA,
+    correlationid: agent.team_id,
+    causationid: agent.agent_id,
+    data: {
+      aggregate_type: "WorkerSession",
+      aggregate_id: agent.agent_id,
+      producer_id: PRODUCER_ID,
+      sequence: input.sequence,
+      activity_kind: input.activityKind,
+      observed_at: now,
+      ...input.data,
+    },
+  };
+}
+
+function runtimeEnvironment(value: string | undefined): "local" | "dev" | "staging" | "prod" {
+  return value === "dev" || value === "staging" || value === "prod" ? value : "local";
+}
+
+function boundedSummary(value: string): string {
+  return value.length <= 2_048 ? value : `${value.slice(0, 2_045)}...`;
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : "unknown";
+}

--- a/apps/team-worker/src/main.ts
+++ b/apps/team-worker/src/main.ts
@@ -6,6 +6,7 @@ import { RuntimeOutput } from "../../../packages/team-control/src/runtime-output
 import { buildWorkerPrompt } from "./prompt.js";
 import { runCodexPythonWorker } from "./codex-python-runner.js";
 import { runCopilotSdkWorker } from "./copilot-sdk-runner.js";
+import { createConfiguredWorkerActivityEmitter } from "./activity.js";
 
 const required = (name: string): string => {
   const value = process.env[name];
@@ -19,6 +20,7 @@ if (!teamID || !agentID) throw new TypeError("invalid team worker arguments");
 const workspace = required("YUKH_TEAM_WORKSPACE");
 const store = new TeamStore(workspace);
 const agent = store.agent(teamID, agentID);
+const activity = await createConfiguredWorkerActivityEmitter(agent, process.env);
 
 const node = process.execPath;
 const launcher = required("YUKH_COORDINATION_LAUNCHER");
@@ -274,9 +276,11 @@ const joined =
 if (!joined) {
   process.stderr.write("yukh-team-worker: coordination bootstrap or join failed\n");
   store.transition(teamID, agentID, "failed");
+  await activity.terminal("failed", "Coordination bootstrap or join failed.");
   process.exitCode = 1;
 } else {
   store.transition(teamID, agentID, "running");
+  await activity.running();
 }
 
 const outcome = !joined
@@ -368,6 +372,7 @@ let wrapperExitCode = outcome.stopped ? 0 : outcome.exitCode;
 if (joined && "output" in outcome) {
   if (outcome.stopped) {
     store.transition(teamID, agentID, "stopped");
+    await activity.terminal("stopped", "Worker stopped by team request.");
   } else {
     const summary = outcome.output.summary();
     const usage = outcome.output.usage(agent.token_budget);
@@ -418,8 +423,16 @@ if (joined && "output" in outcome) {
                           summary,
                           ...(proposedPlan ? { plan_id: proposedPlan.plan_id } : {}),
                         };
-    store.finish(teamID, agentID, completion, usage);
+    const terminal = store.finish(teamID, agentID, completion, usage);
+    if (usage) await activity.tokens(usage);
+    if (
+      terminal.state === "completed" ||
+      terminal.state === "failed" ||
+      terminal.state === "stopped"
+    )
+      await activity.terminal(terminal.state, completion.summary);
     if (completion.outcome !== "succeeded") wrapperExitCode = 1;
   }
 }
+await activity.close();
 process.exitCode = wrapperExitCode;

--- a/test/runtime/worker-activity-events.test.ts
+++ b/test/runtime/worker-activity-events.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { createWorkerActivityEmitter } from "../../apps/team-worker/src/activity.js";
 import { ControlPlanePlanPreviewStore } from "../../apps/control-plane-preview/src/plan-preview-store.js";
 import {
   encodeWorkerActivityEvent,
@@ -13,7 +14,9 @@ import {
   workerActivitySubject,
   type WorkerActivityEvent,
   type WorkerActivityEventBus,
+  type WorkerActivityPublishReceipt,
 } from "../../packages/runtime-events/src/worker-activity.js";
+import type { AgentRecord } from "../../packages/team-control/src/store.js";
 
 const activity = (sequence = 1): WorkerActivityEvent => ({
   specversion: "1.0",
@@ -48,6 +51,23 @@ const activity = (sequence = 1): WorkerActivityEvent => ({
   },
 });
 
+const agent = (): AgentRecord => ({
+  schema: 1,
+  agent_id: "worker-22222222-2222-4222-8222-222222222222",
+  kind: "worker",
+  coordination_agent: "agent-worker-22222222-2222-4222-8222-222222222222",
+  coordination_participant: "agent:worker-22222222-2222-4222-8222-222222222222",
+  team_id: "team-11111111-1111-4111-8111-111111111111",
+  runtime: "codex",
+  role: "backend-developer",
+  task: "Implement a bounded worker activity probe.",
+  depth: 1,
+  can_spawn: false,
+  token_budget: 20_000,
+  required_actions: [],
+  state: "running",
+});
+
 test("worker activity subject and payload stay within the JetStream policy", () => {
   const event = activity();
   assert.equal(
@@ -68,6 +88,80 @@ test("worker activity subject and payload stay within the JetStream policy", () 
       }),
     /invalid worker activity subject input/u,
   );
+});
+
+test("team worker activity emitter publishes running, token and terminal events", async () => {
+  const events: WorkerActivityEvent[] = [];
+  const emitter = createWorkerActivityEmitter(
+    agent(),
+    new (class implements WorkerActivityEventBus {
+      async publish(event: WorkerActivityEvent): Promise<WorkerActivityPublishReceipt> {
+        validateWorkerActivityEvent(event);
+        events.push(event);
+        return { stream: WORKER_ACTIVITY_STREAM, sequence: events.length, duplicate: false };
+      }
+
+      async recent() {
+        return events;
+      }
+
+      async close() {
+        return;
+      }
+    })(),
+  );
+
+  await emitter.running();
+  await emitter.tokens({
+    schema: 1,
+    source: "codex-python-app-server-v1",
+    input_tokens: 1_200,
+    cached_input_tokens: 900,
+    output_tokens: 300,
+    reasoning_output_tokens: 100,
+    total_tokens: 1_500,
+    budget_outcome: "within",
+  });
+  await emitter.terminal("completed", "Worker completed with a short public summary.");
+  await emitter.close();
+
+  assert.deepEqual(
+    events.map((event) => [event.data.sequence, event.data.activity_kind, event.data.worker_state]),
+    [
+      [1, "status-changed", "running"],
+      [2, "tokens-observed", "running"],
+      [3, "status-changed", "completed"],
+    ],
+  );
+  assert.equal(events[1]?.data.tokens?.observed, 1_500);
+  assert.equal(events[1]?.data.tokens?.budget, 20_000);
+  assert.equal(events[0]?.data.producer_id, "team-worker-runtime");
+  assert.doesNotMatch(JSON.stringify(events), /Implement a bounded worker activity probe/u);
+});
+
+test("team worker activity emitter treats bus publish failures as observability-only", async () => {
+  const emitter = createWorkerActivityEmitter(
+    agent(),
+    new (class implements WorkerActivityEventBus {
+      async publish(): Promise<never> {
+        throw new Error("nats_down");
+      }
+
+      async recent() {
+        return [];
+      }
+
+      async close() {
+        return;
+      }
+    })(),
+  );
+
+  await assert.doesNotReject(async () => {
+    await emitter.running();
+    await emitter.terminal("failed", "Worker failed.");
+    await emitter.close();
+  });
 });
 
 test("control plane store publishes worker activity to the event bus and reads bus projection", async () => {


### PR DESCRIPTION
## Summary

- emit `worker.activity.v1` directly from the team worker runtime
- publish running, token-observed and terminal status events when JetStream activity is enabled
- keep activity observability-only: publish failures are logged and never change worker outcome

## Validation

- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `node --import tsx --test test/runtime/worker-activity-events.test.ts`
- `node --import tsx --test test/runtime/team-control.test.ts`
