### PR TITLE
Wire live worker activity into control plane

### DIFF
--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -10,6 +10,7 @@ import {
 import { TeamStore } from "../../../packages/team-control/src/store.js";
 import { teamRuntimeEntrypoints } from "../../../packages/team-control/src/entrypoints.js";
 import { TeamSupervisor } from "../../../packages/team-control/src/supervisor.js";
+import { inheritedWorkerActivityEnvironment } from "../../../packages/team-control/src/profile-environment.js";
 import {
   WorkerActivityJetStreamBus,
   WORKER_ACTIVITY_SCHEMA,
@@ -169,6 +170,7 @@ function createConfiguredProviderRunner(
       ...(process.env.YUKH_CODEX_PYTHON_EXECUTABLE
         ? { YUKH_CODEX_PYTHON_EXECUTABLE: process.env.YUKH_CODEX_PYTHON_EXECUTABLE }
         : {}),
+      ...inheritedWorkerActivityEnvironment(),
     },
   });
 

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -905,6 +905,16 @@ const recordWorkerActivity = async () => {
   }
 };
 
+const loadWorkerActivities = async () => {
+  try {
+    const response = await fetch("./api/manager-plan/worker-activities", { cache: "no-store" });
+    if (!response.ok) return null;
+    return await response.json();
+  } catch {
+    return null;
+  }
+};
+
 const renderProviderAdapter = (adapter) => {
   if (!adapter) return "";
   return `
@@ -1161,8 +1171,9 @@ const renderProviderRunnerAttachment = (attachment) => {
         <article><span>Launch</span><strong>${escapeHtml(attachment.worker_launch)}</strong></article>
       </div>
       <p class="muted">Log: ${escapeHtml(attachment.log_path)}</p>
-      <p class="muted">Tokens reserved: ${attachment.token_budget.toLocaleString()} · next: read worker.activity.v1.</p>
-      <button type="button" class="secondary worker-activity-button">Read worker activity</button>
+      <p class="muted">Tokens reserved: ${attachment.token_budget.toLocaleString()} · next: watch worker.activity.v1 from the runtime stream.</p>
+      <button type="button" class="secondary worker-activity-refresh-button">Refresh worker activity</button>
+      <button type="button" class="secondary worker-activity-button">Record preview snapshot</button>
     </div>
   `;
 };
@@ -1180,6 +1191,24 @@ const renderWorkerActivity = (activity) => {
         <article><span>Tokens</span><strong>${activity.data.tokens ? `${activity.data.tokens.observed.toLocaleString()}/${activity.data.tokens.budget.toLocaleString()}` : "pending"}</strong></article>
       </div>
       <p class="muted">${escapeHtml(activity.data.summary ?? "Activity snapshot from the preview adapter.")}</p>
+    </div>
+  `;
+};
+
+const renderWorkerActivityFeed = (status) => {
+  if (!status) return "";
+  const live = status.source === "worker.activity.v1-jetstream";
+  const activities = status.activities ?? [];
+  return `
+    <div class="worker-activity-feed">
+      <span>${live ? "JetStream live activity" : "Preview activity fallback"}</span>
+      <strong>${activities.length.toLocaleString()} event${activities.length === 1 ? "" : "s"}</strong>
+      <p class="muted">${escapeHtml(status.source)} · Control Plane reads worker.activity.v1; local file paths are not the runtime contract.</p>
+      ${
+        activities.length === 0
+          ? '<p class="muted">No worker activity observed yet. Start/attach a worker with activity env enabled, then refresh.</p>'
+          : activities.map((activity) => renderWorkerActivity(activity)).join("")
+      }
     </div>
   `;
 };
@@ -1541,6 +1570,23 @@ byId("plan-preview").addEventListener("click", async (event) => {
   button
     .closest(".provider-worker-process")
     ?.insertAdjacentHTML("afterend", renderProviderRunnerAttachment(attachment));
+});
+
+byId("plan-preview").addEventListener("click", async (event) => {
+  const button = event.target.closest(".worker-activity-refresh-button");
+  if (!button) return;
+  button.setAttribute("disabled", "true");
+  const status = await loadWorkerActivities();
+  button.removeAttribute("disabled");
+  if (!status) {
+    button.textContent = "Worker activity unavailable";
+    return;
+  }
+  button.textContent = "Refresh worker activity";
+  button.closest(".provider-runner-attachment")?.querySelector(".worker-activity-feed")?.remove();
+  button
+    .closest(".provider-runner-attachment")
+    ?.insertAdjacentHTML("beforeend", renderWorkerActivityFeed(status));
 });
 
 byId("plan-preview").addEventListener("click", async (event) => {

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -1059,8 +1059,19 @@ nav a:hover {
   display: grid;
   gap: 10px;
   padding: 12px;
+  overflow-wrap: anywhere;
 }
-.worker-activity span {
+.worker-activity-feed {
+  background: rgba(80, 115, 251, 0.1);
+  border: 1px solid rgba(80, 115, 251, 0.28);
+  border-radius: 16px;
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  overflow-wrap: anywhere;
+}
+.worker-activity span,
+.worker-activity-feed > span {
   color: var(--warn);
   font-size: 11px;
   font-weight: 800;

--- a/apps/team-control/src/main.ts
+++ b/apps/team-control/src/main.ts
@@ -7,6 +7,7 @@ import {
 import { teamRuntimeEntrypoints } from "../../../packages/team-control/src/entrypoints.js";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
 import { TeamSupervisor } from "../../../packages/team-control/src/supervisor.js";
+import { inheritedWorkerActivityEnvironment } from "../../../packages/team-control/src/profile-environment.js";
 import { createTeamControlServer } from "./server.js";
 
 const workspace = process.env.YUKH_TEAM_WORKSPACE;
@@ -43,6 +44,7 @@ const profileEnvironment = {
       .filter((name) => process.env[name] !== undefined)
       .map((name) => [name, process.env[name]!] as const),
   ),
+  ...inheritedWorkerActivityEnvironment(),
 };
 const entrypoints = teamRuntimeEntrypoints();
 const supervisor = new TeamSupervisor({

--- a/apps/team-preflight/src/approved-run.ts
+++ b/apps/team-preflight/src/approved-run.ts
@@ -3,6 +3,7 @@ import { teamRuntimeEntrypoints } from "../../../packages/team-control/src/entry
 import { TeamStore } from "../../../packages/team-control/src/store.js";
 import { TeamSupervisor } from "../../../packages/team-control/src/supervisor.js";
 import type { AgentRecord } from "../../../packages/team-control/src/store.js";
+import { inheritedWorkerActivityEnvironment } from "../../../packages/team-control/src/profile-environment.js";
 import { preflightApprovalDigest, type EngagePreflightOutput } from "./preflight.js";
 import { assertRuntimeTokenFloor } from "./runtime-floor.js";
 
@@ -63,6 +64,7 @@ function profileEnvironment(args: ApprovedRunArguments): Readonly<Record<string,
     env.YUKH_CODEX_PYTHON_EXECUTABLE = process.env.YUKH_CODEX_PYTHON_EXECUTABLE;
   if (process.env.YUKH_COPILOT_WORKER_PROVIDER === "sdk") env.YUKH_COPILOT_WORKER_PROVIDER = "sdk";
   if (process.env.YUKH_PREVIEW_RUNTIME) env.YUKH_PREVIEW_RUNTIME = process.env.YUKH_PREVIEW_RUNTIME;
+  Object.assign(env, inheritedWorkerActivityEnvironment());
   return env;
 }
 

--- a/apps/team-preflight/src/plan-execute.ts
+++ b/apps/team-preflight/src/plan-execute.ts
@@ -8,6 +8,7 @@ import type { TeamControlOptions } from "../../team-control/src/server.js";
 import { teamRuntimeEntrypoints } from "../../../packages/team-control/src/entrypoints.js";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
 import { TeamSupervisor } from "../../../packages/team-control/src/supervisor.js";
+import { inheritedWorkerActivityEnvironment } from "../../../packages/team-control/src/profile-environment.js";
 
 export interface ApprovedPlanRunArguments {
   readonly workspace: string;
@@ -44,6 +45,7 @@ function profileEnvironment(args: ApprovedPlanRunArguments): Readonly<Record<str
     env.YUKH_CODEX_PYTHON_EXECUTABLE = process.env.YUKH_CODEX_PYTHON_EXECUTABLE;
   if (process.env.YUKH_COPILOT_WORKER_PROVIDER === "sdk") env.YUKH_COPILOT_WORKER_PROVIDER = "sdk";
   if (process.env.YUKH_PREVIEW_RUNTIME) env.YUKH_PREVIEW_RUNTIME = process.env.YUKH_PREVIEW_RUNTIME;
+  Object.assign(env, inheritedWorkerActivityEnvironment());
   return env;
 }
 

--- a/apps/team-start/src/main.ts
+++ b/apps/team-start/src/main.ts
@@ -13,6 +13,7 @@ import type {
 import { teamRuntimeEntrypoints } from "../../../packages/team-control/src/entrypoints.js";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
 import { TeamSupervisor } from "../../../packages/team-control/src/supervisor.js";
+import { inheritedWorkerActivityEnvironment } from "../../../packages/team-control/src/profile-environment.js";
 import { formatTeamStatus } from "../../team-preflight/src/format.js";
 
 export interface Arguments {
@@ -208,6 +209,7 @@ export function startManager(args: Arguments) {
     ...(process.env.YUKH_PREVIEW_RUNTIME
       ? { YUKH_PREVIEW_RUNTIME: process.env.YUKH_PREVIEW_RUNTIME }
       : {}),
+    ...inheritedWorkerActivityEnvironment(),
   };
   const supervisor = new TeamSupervisor({
     node: process.execPath,

--- a/packages/team-control/src/profile-environment.ts
+++ b/packages/team-control/src/profile-environment.ts
@@ -1,0 +1,17 @@
+const WORKER_ACTIVITY_ENVIRONMENT = [
+  "YUKH_WORKER_ACTIVITY_JETSTREAM",
+  "YUKH_NATS_URL",
+  "YUKH_WORKER_ACTIVITY_CREATE_STREAM",
+  "YUKH_RUNTIME_ENV",
+  "YUKH_TENANT",
+] as const;
+
+export function inheritedWorkerActivityEnvironment(
+  env: NodeJS.ProcessEnv = process.env,
+): Readonly<Record<string, string>> {
+  return Object.fromEntries(
+    WORKER_ACTIVITY_ENVIRONMENT.filter((name) => env[name] !== undefined).map(
+      (name) => [name, env[name]!] as const,
+    ),
+  );
+}

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -1518,7 +1518,10 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /Provider runner attached/u);
   assert.match(data, /provider-runner-attachment-button/u);
   assert.match(data, /worker\.activity\.v1/u);
+  assert.match(data, /worker-activity-refresh-button/u);
   assert.match(data, /worker-activity-button/u);
+  assert.match(data, /JetStream live activity/u);
+  assert.match(data, /Preview activity fallback/u);
   assert.match(data, /provider_process/u);
   assert.match(data, /worker_delegation/u);
   assert.match(data, /worker_launch/u);

--- a/test/runtime/worker-activity-events.test.ts
+++ b/test/runtime/worker-activity-events.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import test from "node:test";
 import { createWorkerActivityEmitter } from "../../apps/team-worker/src/activity.js";
 import { ControlPlanePlanPreviewStore } from "../../apps/control-plane-preview/src/plan-preview-store.js";
+import { inheritedWorkerActivityEnvironment } from "../../packages/team-control/src/profile-environment.js";
 import {
   encodeWorkerActivityEvent,
   validateWorkerActivityEvent,
@@ -162,6 +163,27 @@ test("team worker activity emitter treats bus publish failures as observability-
     await emitter.terminal("failed", "Worker failed.");
     await emitter.close();
   });
+});
+
+test("worker activity environment inheritance forwards only runtime activity settings", () => {
+  assert.deepEqual(
+    inheritedWorkerActivityEnvironment({
+      YUKH_WORKER_ACTIVITY_JETSTREAM: "1",
+      YUKH_NATS_URL: "nats://127.0.0.1:4222",
+      YUKH_WORKER_ACTIVITY_CREATE_STREAM: "0",
+      YUKH_RUNTIME_ENV: "local",
+      YUKH_TENANT: "tenant-local",
+      YUKH_CODEX_EXECUTABLE: "/usr/bin/codex",
+      SECRET_TOKEN: "must-not-pass",
+    }),
+    {
+      YUKH_WORKER_ACTIVITY_JETSTREAM: "1",
+      YUKH_NATS_URL: "nats://127.0.0.1:4222",
+      YUKH_WORKER_ACTIVITY_CREATE_STREAM: "0",
+      YUKH_RUNTIME_ENV: "local",
+      YUKH_TENANT: "tenant-local",
+    },
+  );
 });
 
 test("control plane store publishes worker activity to the event bus and reads bus projection", async () => {


### PR DESCRIPTION
## Summary

- pass worker activity JetStream env from Control Plane, team-start, team-control MCP and approved preflight runners into launched workers
- add a focused helper that forwards only bounded runtime activity settings, not credentials or provider config
- update Control Plane UI to refresh/read worker.activity.v1 from the runtime feed and label preview snapshots as fallback

## Validation

- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `node --import tsx --test test/runtime/worker-activity-events.test.ts test/runtime/team-control.test.ts`
- `node --import tsx test/runtime/control-plane-preview.test.ts` outside sandbox because it binds 127.0.0.1
