### PR TITLE
Default worker activity preview to JetStream port

### DIFF
--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -13,6 +13,7 @@ import { TeamSupervisor } from "../../../packages/team-control/src/supervisor.js
 import { inheritedWorkerActivityEnvironment } from "../../../packages/team-control/src/profile-environment.js";
 import {
   WorkerActivityJetStreamBus,
+  WORKER_ACTIVITY_PREVIEW_NATS_URL,
   WORKER_ACTIVITY_SCHEMA,
   workerActivitySubject,
 } from "../../../packages/runtime-events/src/worker-activity.js";
@@ -262,7 +263,7 @@ async function createConfiguredWorkerActivityBus(): Promise<
   if (process.env.YUKH_WORKER_ACTIVITY_JETSTREAM !== "1") return undefined;
   try {
     return await WorkerActivityJetStreamBus.connect({
-      servers: process.env.YUKH_NATS_URL ?? "nats://127.0.0.1:4222",
+      servers: process.env.YUKH_NATS_URL ?? WORKER_ACTIVITY_PREVIEW_NATS_URL,
       createStream: process.env.YUKH_WORKER_ACTIVITY_CREATE_STREAM !== "0",
     });
   } catch (error) {

--- a/apps/team-worker/src/activity.ts
+++ b/apps/team-worker/src/activity.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../../packages/team-control/src/store.js";
 import {
   WORKER_ACTIVITY_SCHEMA,
+  WORKER_ACTIVITY_PREVIEW_NATS_URL,
   WorkerActivityJetStreamBus,
   workerActivitySubject,
   type WorkerActivityEvent,
@@ -50,7 +51,7 @@ export async function createConfiguredWorkerActivityEmitter(
   if (env.YUKH_WORKER_ACTIVITY_JETSTREAM !== "1") return createNoopWorkerActivityEmitter();
   try {
     const bus = await WorkerActivityJetStreamBus.connect({
-      servers: env.YUKH_NATS_URL ?? "nats://127.0.0.1:4222",
+      servers: env.YUKH_NATS_URL ?? WORKER_ACTIVITY_PREVIEW_NATS_URL,
       createStream: env.YUKH_WORKER_ACTIVITY_CREATE_STREAM !== "0",
     });
     return createWorkerActivityEmitter(agent, bus, {

--- a/docs/architecture/event-subject-policy.md
+++ b/docs/architecture/event-subject-policy.md
@@ -83,7 +83,7 @@ adapter when explicitly enabled:
 
 ```text
 YUKH_WORKER_ACTIVITY_JETSTREAM=1
-YUKH_NATS_URL=nats://127.0.0.1:4222
+YUKH_NATS_URL=nats://127.0.0.1:14222
 YUKH_WORKER_ACTIVITY_CREATE_STREAM=1
 ```
 
@@ -91,6 +91,10 @@ If the adapter is not enabled, the preview UI keeps using the local preview
 adapter and labels the source accordingly. Enabling JetStream creates or uses
 `YKR_WORKER_EVENTS_V1` with subject `yukh.*.*.runtime.worker.*.*.v1`; events
 are published with `msgID = event.id` for idempotent delivery.
+
+The local Coordination preview exposes JetStream for Control Plane runtime
+activity on `127.0.0.1:14222`, leaving `127.0.0.1:4222` free for any existing
+host NATS server.
 
 ## Resource and resilience policy
 

--- a/packages/runtime-events/src/worker-activity.ts
+++ b/packages/runtime-events/src/worker-activity.ts
@@ -1,5 +1,6 @@
 export const WORKER_ACTIVITY_STREAM = "YKR_WORKER_EVENTS_V1";
 export const WORKER_ACTIVITY_SUBJECT = "yukh.*.*.runtime.worker.*.*.v1";
+export const WORKER_ACTIVITY_PREVIEW_NATS_URL = "nats://127.0.0.1:14222";
 export const WORKER_ACTIVITY_SCHEMA =
   "https://yukh.example/schemas/runtime/v1/worker-activity.schema.json";
 export const WORKER_ACTIVITY_MAX_PAYLOAD_BYTES = 8_192;

--- a/test/runtime/worker-activity-events.test.ts
+++ b/test/runtime/worker-activity-events.test.ts
@@ -169,7 +169,7 @@ test("worker activity environment inheritance forwards only runtime activity set
   assert.deepEqual(
     inheritedWorkerActivityEnvironment({
       YUKH_WORKER_ACTIVITY_JETSTREAM: "1",
-      YUKH_NATS_URL: "nats://127.0.0.1:4222",
+      YUKH_NATS_URL: "nats://127.0.0.1:14222",
       YUKH_WORKER_ACTIVITY_CREATE_STREAM: "0",
       YUKH_RUNTIME_ENV: "local",
       YUKH_TENANT: "tenant-local",
@@ -178,7 +178,7 @@ test("worker activity environment inheritance forwards only runtime activity set
     }),
     {
       YUKH_WORKER_ACTIVITY_JETSTREAM: "1",
-      YUKH_NATS_URL: "nats://127.0.0.1:4222",
+      YUKH_NATS_URL: "nats://127.0.0.1:14222",
       YUKH_WORKER_ACTIVITY_CREATE_STREAM: "0",
       YUKH_RUNTIME_ENV: "local",
       YUKH_TENANT: "tenant-local",


### PR DESCRIPTION
## Summary

- centralize the worker activity preview NATS URL as `nats://127.0.0.1:14222`
- use that default from Control Plane and team-worker activity adapters
- update the event/subject policy to document the non-conflicting preview JetStream port

## Validation

- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `node --import tsx --test test/runtime/worker-activity-events.test.ts`
