### PR TITLE
Improve Python worker observability

### DIFF
--- a/apps/team-worker/src/codex-python-runner.ts
+++ b/apps/team-worker/src/codex-python-runner.ts
@@ -49,7 +49,11 @@ export async function runCodexPythonWorker({
     if (!child.stdout || !child.stderr) throw new Error("agent_output_unavailable");
     child.stderr.pipe(process.stderr);
     const chunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
     child.stdout.on("data", (chunk: Buffer) => chunks.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => {
+      if (Buffer.concat(stderrChunks).byteLength < 8_192) stderrChunks.push(chunk);
+    });
     let stdoutEnded = false;
     let closed = false;
     let childExitCode = 1;
@@ -73,8 +77,13 @@ export async function runCodexPythonWorker({
       try {
         const result = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
           readonly final_response?: unknown;
+          readonly error_code?: unknown;
+          readonly error_message?: unknown;
           readonly usage_last?: unknown;
         };
+        if (result.error_code === "provider_usage_limited") {
+          output.setSummary(publicProviderSummary(result.error_message));
+        }
         if (typeof result.final_response === "string") output.setSummary(result.final_response);
         if (record(result.usage_last))
           output.addUsage("codex-python-app-server-v1", {
@@ -88,10 +97,22 @@ export async function runCodexPythonWorker({
         process.stderr.write(
           `yukh-team-worker: codex python runner emitted invalid output bytes=${Buffer.concat(chunks).length}\n`,
         );
+        const message = Buffer.concat(stderrChunks).toString("utf8");
+        if (providerUsageLimited(message)) output.setSummary(publicProviderSummary(message));
       } finally {
         rmSync(temporary, { recursive: true, force: true });
       }
-      resolve({ exitCode: childExitCode, stopped: false, ...(bound ? { bound } : {}), output });
+      const providerFailure =
+        childExitCode !== 0 && providerUsageLimited(output.summary())
+          ? { providerFailure: "provider_usage_limited" as const }
+          : {};
+      resolve({
+        exitCode: childExitCode,
+        stopped: false,
+        ...(bound ? { bound } : {}),
+        ...providerFailure,
+        output,
+      });
     };
     child.stdout.once("end", () => {
       stdoutEnded = true;
@@ -159,7 +180,27 @@ with Codex(config) as codex:
     }
     if model != "default":
         run_options["model"] = model
-    result = thread.run(prompt, **run_options)
+    try:
+        result = thread.run(prompt, **run_options)
+    except Exception as error:
+        message = str(error)
+        code = (
+            "provider_usage_limited"
+            if "usage limit" in message.lower() or "you've hit your usage limit" in message.lower()
+            else "provider_run_failed"
+        )
+        print(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "status": "error",
+                    "error_code": code,
+                    "error_message": message[:512],
+                },
+                sort_keys=True,
+            )
+        )
+        raise SystemExit(1)
     print(
         json.dumps(
             {
@@ -183,4 +224,16 @@ function record(value: unknown): value is Record<string, unknown> {
 
 function safeInteger(value: unknown): number {
   return Number.isSafeInteger(value) && Number(value) >= 0 ? Number(value) : 0;
+}
+
+function providerUsageLimited(value: string): boolean {
+  return /usage limit|you've hit your usage limit/iu.test(value);
+}
+
+function publicProviderSummary(value: unknown): string {
+  const message = typeof value === "string" ? value : "";
+  const retry = message.match(/try again at ([^.]+)\./iu)?.[1];
+  return retry
+    ? `Provider usage limit reached; retry after ${retry}.`
+    : "Provider usage limit reached.";
 }

--- a/apps/team-worker/src/copilot-sdk-runner.ts
+++ b/apps/team-worker/src/copilot-sdk-runner.ts
@@ -38,6 +38,7 @@ export interface WorkerRunOutcome {
   readonly exitCode: number;
   readonly stopped: boolean;
   readonly bound?: "commands" | "deadline";
+  readonly providerFailure?: "provider_usage_limited";
   readonly output: RuntimeOutput;
 }
 

--- a/apps/team-worker/src/main.ts
+++ b/apps/team-worker/src/main.ts
@@ -397,32 +397,34 @@ if (joined && "output" in outcome) {
         ? { schema: 1 as const, outcome: "command_budget_exceeded" as const, summary }
         : outcome.bound === "deadline"
           ? { schema: 1 as const, outcome: "runtime_deadline_exceeded" as const, summary }
-          : outcome.exitCode !== 0
-            ? { schema: 1 as const, outcome: "agent_exit_nonzero" as const, summary }
-            : !usage
-              ? { schema: 1 as const, outcome: "token_accounting_unavailable" as const, summary }
-              : usage.budget_outcome === "exceeded"
-                ? { schema: 1 as const, outcome: "token_budget_exceeded" as const, summary }
-                : missingActions.length > 0
-                  ? {
-                      schema: 1 as const,
-                      outcome: "required_action_missing" as const,
-                      summary: `Missing required action receipts: ${missingActions.join(", ")}`,
-                    }
-                  : !summary
-                    ? { schema: 1 as const, outcome: "completion_missing" as const, summary: "" }
-                    : planInvalid
-                      ? {
-                          schema: 1 as const,
-                          outcome: "team_plan_invalid" as const,
-                          summary: "Structured team plan validation failed",
-                        }
-                      : {
-                          schema: 1 as const,
-                          outcome: "succeeded" as const,
-                          summary,
-                          ...(proposedPlan ? { plan_id: proposedPlan.plan_id } : {}),
-                        };
+          : "providerFailure" in outcome && outcome.providerFailure === "provider_usage_limited"
+            ? { schema: 1 as const, outcome: "provider_usage_limited" as const, summary }
+            : outcome.exitCode !== 0
+              ? { schema: 1 as const, outcome: "agent_exit_nonzero" as const, summary }
+              : !usage
+                ? { schema: 1 as const, outcome: "token_accounting_unavailable" as const, summary }
+                : usage.budget_outcome === "exceeded"
+                  ? { schema: 1 as const, outcome: "token_budget_exceeded" as const, summary }
+                  : missingActions.length > 0
+                    ? {
+                        schema: 1 as const,
+                        outcome: "required_action_missing" as const,
+                        summary: `Missing required action receipts: ${missingActions.join(", ")}`,
+                      }
+                    : !summary
+                      ? { schema: 1 as const, outcome: "completion_missing" as const, summary: "" }
+                      : planInvalid
+                        ? {
+                            schema: 1 as const,
+                            outcome: "team_plan_invalid" as const,
+                            summary: "Structured team plan validation failed",
+                          }
+                        : {
+                            schema: 1 as const,
+                            outcome: "succeeded" as const,
+                            summary,
+                            ...(proposedPlan ? { plan_id: proposedPlan.plan_id } : {}),
+                          };
     const terminal = store.finish(teamID, agentID, completion, usage);
     if (usage) await activity.tokens(usage);
     if (
@@ -431,6 +433,27 @@ if (joined && "output" in outcome) {
       terminal.state === "stopped"
     )
       await activity.terminal(terminal.state, completion.summary);
+    process.stdout.write(
+      `${JSON.stringify({
+        schema: 1,
+        event: "worker_result",
+        team_id: teamID,
+        agent_id: agentID,
+        state: terminal.state,
+        completion_outcome: completion.outcome,
+        summary_bytes: Buffer.byteLength(completion.summary, "utf8"),
+        ...(usage
+          ? {
+              usage: {
+                source: usage.source,
+                total_tokens: usage.total_tokens,
+                budget: agent.token_budget,
+                budget_outcome: usage.budget_outcome,
+              },
+            }
+          : {}),
+      })}\n`,
+    );
     if (completion.outcome !== "succeeded") wrapperExitCode = 1;
   }
 }

--- a/packages/conversation-coordinator/src/coordinator.ts
+++ b/packages/conversation-coordinator/src/coordinator.ts
@@ -39,6 +39,7 @@ export interface CoordinatorEvent {
     | "agent_spawn_failed"
     | "agent_timed_out"
     | "agent_exit_nonzero"
+    | "provider_usage_limited"
     | "agent_coordination_failed"
     | "agent_error";
   readonly coordination_action?: "bootstrap" | "join" | "replay";
@@ -136,6 +137,7 @@ export class ConversationCoordinator {
         "agent_spawn_failed",
         "agent_timed_out",
         "agent_exit_nonzero",
+        "provider_usage_limited",
         "agent_coordination_failed",
       ];
       const failure =

--- a/packages/conversation-watch/src/watch.ts
+++ b/packages/conversation-watch/src/watch.ts
@@ -155,6 +155,7 @@ export function lifecycleRecords(raw: string, after: number): LifecycleRecord[] 
           "agent_spawn_failed",
           "agent_timed_out",
           "agent_exit_nonzero",
+          "provider_usage_limited",
           "agent_coordination_failed",
           "agent_error",
         ].includes(record.failure_code)) ||

--- a/packages/team-control/src/store.ts
+++ b/packages/team-control/src/store.ts
@@ -37,6 +37,7 @@ export interface AgentCompletion {
     | "team_plan_invalid"
     | "command_budget_exceeded"
     | "runtime_deadline_exceeded"
+    | "provider_usage_limited"
     | "required_action_missing"
     | "token_accounting_unavailable"
     | "token_budget_exceeded";
@@ -771,6 +772,7 @@ export class TeamStore {
         "team_plan_invalid",
         "command_budget_exceeded",
         "runtime_deadline_exceeded",
+        "provider_usage_limited",
         "required_action_missing",
         "token_accounting_unavailable",
         "token_budget_exceeded",

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -1850,6 +1850,54 @@ test("codex python app-server worker captures final response and token accountin
   }
 });
 
+test("codex python app-server worker classifies usage limits", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-codex-python-limit-")));
+  try {
+    const store = new TeamStore(root);
+    const team = store.create("Codex Python limit probe", "codex");
+    const agent = store.spawn(team.team_id, {
+      runtime: "codex",
+      role: "python-reviewer",
+      task: "Summarize only",
+      profile: {
+        schema: 1,
+        mission: "Review",
+        model: "codex-test-model",
+        skills: [],
+        instructions: "Be brief",
+      },
+      model_tool_mode: "none",
+      token_budget: 1_000,
+    });
+    const outcome = await runCodexPythonWorker({
+      executable: "/bin/codex",
+      python: process.env.PYTHON ?? "python3",
+      workspace: root,
+      prompt: "Do the task",
+      agent,
+      timeoutMs: 1_000,
+      workerSource: [
+        "import json",
+        "print(json.dumps({",
+        "  'schema': 1,",
+        "  'status': 'error',",
+        "  'error_code': 'provider_usage_limited',",
+        "  'error_message': \"You've hit your usage limit for GPT-Test. Switch model, or try again at Aug 23rd, 2026 1:14 AM.\",",
+        "}))",
+        "raise SystemExit(1)",
+      ].join("\n"),
+    });
+    assert.equal(outcome.exitCode, 1);
+    assert.equal(outcome.providerFailure, "provider_usage_limited");
+    assert.equal(
+      outcome.output.summary(),
+      "Provider usage limit reached; retry after Aug 23rd, 2026 1:14 AM.",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("legacy teams stay readable but cannot bypass explicit token allocation", async () => {
   const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-team-legacy-budget-")));
   try {


### PR DESCRIPTION
## Summary

Improves observability for Python app-server workers.

## Changes

- emits a compact `worker_result` JSONL record to the worker log for terminal outcomes;
- classifies Codex provider usage-limit failures as `provider_usage_limited` instead of opaque `agent_exit_nonzero`;
- keeps the terminal log public-safe: no prompt, no raw summary, no credentials;
- updates coordinator/watch allowlists and team completion validation;
- adds coverage for Codex Python usage-limit classification.

## Validation

- `node --import tsx --test test/runtime/team-control.test.ts --test-name-pattern 'codex python app-server worker|approved preflight launches exactly|blocks micro|runtime floor'`
- `node --import tsx --test test/runtime/conversation-watch.test.ts test/runtime/conversation-coordinator.test.ts`
- `npm run typecheck`
- `npm run build`
- Real bounded worker run with `gpt-5.6-terra`: completed, 12,641 observed tokens / 18,000 budget, worker log contains `worker_result`.
