### PR TITLE
Guard Python app-server implementation preflight

### DIFF
--- a/apps/team-preflight/src/approved-run.ts
+++ b/apps/team-preflight/src/approved-run.ts
@@ -5,7 +5,7 @@ import { TeamSupervisor } from "../../../packages/team-control/src/supervisor.js
 import type { AgentRecord } from "../../../packages/team-control/src/store.js";
 import { inheritedWorkerActivityEnvironment } from "../../../packages/team-control/src/profile-environment.js";
 import { preflightApprovalDigest, type EngagePreflightOutput } from "./preflight.js";
-import { assertRuntimeTokenFloor } from "./runtime-floor.js";
+import { assertRuntimeTokenFloor, codexWorkerProvider } from "./runtime-floor.js";
 
 export interface ApprovedRunArguments {
   readonly preflightPath: string;
@@ -38,13 +38,18 @@ async function awaitAgent(
 
 function loadPreflight(path: string): EngagePreflightOutput {
   const value = JSON.parse(readFileSync(path, "utf8")) as EngagePreflightOutput;
+  const launchableByFloor =
+    value.runtime_token_floor === undefined ||
+    value.planned_worker.token_budget >= value.runtime_token_floor.minimum_token_budget;
+  const blockedByReadOnlyProvider =
+    value.planned_worker.runtime === "codex" &&
+    value.policy.work_profile === "implementation" &&
+    codexWorkerProvider() === "python-app-server";
   if (
     value.schema !== 1 ||
     value.status !== "ok" ||
     value.command !== "team preflight-engage" ||
-    value.provider_launchable !==
-      (value.runtime_token_floor === undefined ||
-        value.planned_worker.token_budget >= value.runtime_token_floor.minimum_token_budget) ||
+    value.provider_launchable !== (launchableByFloor && !blockedByReadOnlyProvider) ||
     value.provider_runtime_launched !== false ||
     value.provider_tokens_observed !== 0
   )
@@ -89,6 +94,7 @@ export async function runApprovedPreflight(args: ApprovedRunArguments) {
   if (microWorkerRequiresExplicitAllow(worker) && args.allowMicroLaunch !== true)
     throw new Error("micro_worker_launch_requires_explicit_allow");
   assertRuntimeTokenFloor(worker);
+  if (!preflight.provider_launchable) throw new Error("preflight_provider_not_launchable");
 
   const entrypoints = teamRuntimeEntrypoints();
   const supervisor = new TeamSupervisor({

--- a/apps/team-preflight/src/preflight.ts
+++ b/apps/team-preflight/src/preflight.ts
@@ -6,7 +6,7 @@ import { roleProfilePolicy } from "../../team-control/src/server.js";
 import { TeamStore } from "../../../packages/team-control/src/store.js";
 import type { AgentRuntime } from "../../../packages/team-control/src/store.js";
 import type { TeamWorkProfile } from "../../team-control/src/server.js";
-import { runtimeTokenFloor, type RuntimeTokenFloor } from "./runtime-floor.js";
+import { codexWorkerProvider, runtimeTokenFloor, type RuntimeTokenFloor } from "./runtime-floor.js";
 
 export interface EngagePreflightArguments {
   readonly workspace?: string;
@@ -56,6 +56,17 @@ function workerInstructions(workProfile: TeamWorkProfile): string {
   if (workProfile === "readonly")
     return "Run at most one compact read-only probe. Do not mutate files, install dependencies, start services, call the network, or list dependency/build/runtime trees. Keep command output and final summary short.";
   return "Execute only the approved task, stay within the approved runtime bounds, keep output concise, and report any missing context instead of guessing.";
+}
+
+function implementationBlockedByReadOnlyProvider(input: {
+  readonly runtime: AgentRuntime;
+  readonly workProfile: TeamWorkProfile;
+}): boolean {
+  return (
+    input.runtime === "codex" &&
+    input.workProfile === "implementation" &&
+    codexWorkerProvider() === "python-app-server"
+  );
 }
 
 export function approvalDigest(input: {
@@ -171,7 +182,12 @@ export function runEngagePreflight(args: EngagePreflightArguments): EngagePrefli
   });
   const floor = runtimeTokenFloor(worker);
   const budget = store.status(managed.team.team_id).tokens;
-  const providerLaunchable = !floor || worker.token_budget >= floor.minimum_token_budget;
+  const blockedByReadOnlyProvider = implementationBlockedByReadOnlyProvider({
+    runtime: worker.runtime,
+    workProfile: args.workProfile,
+  });
+  const providerLaunchable =
+    !blockedByReadOnlyProvider && (!floor || worker.token_budget >= floor.minimum_token_budget);
   const output = {
     schema: 1 as const,
     status: "ok" as const,
@@ -189,7 +205,9 @@ export function runEngagePreflight(args: EngagePreflightArguments): EngagePrefli
     budget,
     next_real_action: providerLaunchable
       ? "Run a managed manager or agent.engage from Team Control only after approving this policy and budget."
-      : "Do not launch this worker with the current CLI runtime budget. Use an SDK/lean worker runtime or raise the worker budget to the measured runtime floor.",
+      : blockedByReadOnlyProvider
+        ? "Do not launch implementation work with the current Python app-server runtime: it is intentionally read-only. Use a write-capable approved runner, or switch this task to review/readonly."
+        : "Do not launch this worker with the current CLI runtime budget. Use an SDK/lean worker runtime or raise the worker budget to the measured runtime floor.",
   };
   return { ...output, approval_digest: preflightApprovalDigest(output) };
 }

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -777,6 +777,87 @@ test("Codex Python app-server opt-in uses the qualified lower token floor", asyn
   }
 });
 
+test("Codex Python app-server does not launch implementation workers while read-only", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-codex-python-readonly-")));
+  const previous = process.env.YUKH_CODEX_WORKER_PROVIDER;
+  try {
+    process.env.YUKH_CODEX_WORKER_PROVIDER = "python-app-server";
+    const output = runEngagePreflight({
+      workspace: root,
+      goal: "Edit one named file and run one focused test",
+      role: "backend-developer",
+      workProfile: "implementation",
+      preferredRuntime: "codex",
+      teamBudget: 90_000,
+      managerBudget: 20_000,
+      workerBudget: 45_000,
+      workerMaxCommands: 1,
+      workerTimeoutMs: 180_000,
+      codexModels: ["default"],
+      copilotModels: ["default"],
+      codexSkills: ["api-design", "testing"],
+      copilotSkills: ["frontend"],
+    });
+    assert.equal(output.runtime_token_floor?.provider, "python-app-server");
+    assert.equal(output.runtime_token_floor?.minimum_token_budget, 18_000);
+    assert.equal(output.provider_launchable, false);
+    assert.equal(output.provider_runtime_launched, false);
+    assert.match(output.next_real_action, /read-only/u);
+    assert.match(output.next_real_action, /write-capable approved runner/u);
+  } finally {
+    if (previous === undefined) delete process.env.YUKH_CODEX_WORKER_PROVIDER;
+    else process.env.YUKH_CODEX_WORKER_PROVIDER = previous;
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("approved preflight refuses read-only Python app-server implementation launch", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-python-readonly-launch-")));
+  const previous = process.env.YUKH_CODEX_WORKER_PROVIDER;
+  try {
+    process.env.YUKH_CODEX_WORKER_PROVIDER = "python-app-server";
+    const preflightPath = join(root, "preflight.json");
+    const preflight = runEngagePreflight({
+      workspace: root,
+      goal: "Edit one named file and run one focused test",
+      role: "backend-developer",
+      workProfile: "implementation",
+      preferredRuntime: "codex",
+      teamBudget: 90_000,
+      managerBudget: 20_000,
+      workerBudget: 45_000,
+      workerMaxCommands: 1,
+      workerTimeoutMs: 180_000,
+      codexModels: ["default"],
+      copilotModels: ["default"],
+      codexSkills: ["api-design", "testing"],
+      copilotSkills: ["frontend"],
+    });
+    await writeFile(preflightPath, `${JSON.stringify(preflight)}\n`, { mode: 0o600 });
+    await assert.rejects(
+      () =>
+        runApprovedPreflight({
+          preflightPath,
+          approvedDigest: preflight.approval_digest,
+          launcher: process.execPath,
+          codex: process.execPath,
+          copilot: process.execPath,
+          allowMicroLaunch: true,
+          waitMs: 0,
+        }),
+      /preflight_provider_not_launchable/u,
+    );
+    const store = new TeamStore(root);
+    const worker = store.agent(preflight.team.team_id, preflight.planned_worker.agent_id);
+    assert.equal(worker.state, "defined");
+    assert.equal(store.status(preflight.team.team_id).tokens.observed, 0);
+  } finally {
+    if (previous === undefined) delete process.env.YUKH_CODEX_WORKER_PROVIDER;
+    else process.env.YUKH_CODEX_WORKER_PROVIDER = previous;
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("runtime model discovery parses CLI catalogs and keeps explicit env authoritative", () => {
   assert.deepEqual(
     parseCodexModelCatalog(


### PR DESCRIPTION
## Summary
- mark Codex Python app-server implementation preflights as not provider-launchable while the runtime is read-only
- make run-approved respect provider_launchable=false before launching a provider
- add regression coverage for preflight and approved-run guards

## Validation
- node --import tsx --test test/runtime/team-control.test.ts --test-name-pattern 'Python app-server|read-only|runtime floor|micro documentation|micro code|approved preflight blocks measured|approved preflight refuses'
- npm run typecheck
- npm run build
- npm run format:check