### PR TITLE
Add Codex Python workspace-write worker provider

### DIFF
--- a/apps/team-preflight/src/approved-run.ts
+++ b/apps/team-preflight/src/approved-run.ts
@@ -38,13 +38,14 @@ async function awaitAgent(
 
 function loadPreflight(path: string): EngagePreflightOutput {
   const value = JSON.parse(readFileSync(path, "utf8")) as EngagePreflightOutput;
+  const provider = codexWorkerProvider();
   const launchableByFloor =
     value.runtime_token_floor === undefined ||
     value.planned_worker.token_budget >= value.runtime_token_floor.minimum_token_budget;
   const blockedByReadOnlyProvider =
     value.planned_worker.runtime === "codex" &&
     value.policy.work_profile === "implementation" &&
-    codexWorkerProvider() === "python-app-server";
+    provider === "python-app-server";
   if (
     value.schema !== 1 ||
     value.status !== "ok" ||
@@ -63,8 +64,11 @@ function profileEnvironment(args: ApprovedRunArguments): Readonly<Record<string,
   if (args.copilotModels) env.YUKH_COPILOT_MODELS = args.copilotModels;
   if (args.codexSkills) env.YUKH_CODEX_SKILLS = args.codexSkills;
   if (args.copilotSkills) env.YUKH_COPILOT_SKILLS = args.copilotSkills;
-  if (process.env.YUKH_CODEX_WORKER_PROVIDER === "python-app-server")
-    env.YUKH_CODEX_WORKER_PROVIDER = "python-app-server";
+  if (
+    process.env.YUKH_CODEX_WORKER_PROVIDER === "python-app-server" ||
+    process.env.YUKH_CODEX_WORKER_PROVIDER === "python-app-server-workspace-write"
+  )
+    env.YUKH_CODEX_WORKER_PROVIDER = process.env.YUKH_CODEX_WORKER_PROVIDER;
   if (process.env.YUKH_CODEX_PYTHON_EXECUTABLE)
     env.YUKH_CODEX_PYTHON_EXECUTABLE = process.env.YUKH_CODEX_PYTHON_EXECUTABLE;
   if (process.env.YUKH_COPILOT_WORKER_PROVIDER === "sdk") env.YUKH_COPILOT_WORKER_PROVIDER = "sdk";

--- a/apps/team-preflight/src/plan-execute.ts
+++ b/apps/team-preflight/src/plan-execute.ts
@@ -39,8 +39,11 @@ function profileEnvironment(args: ApprovedPlanRunArguments): Readonly<Record<str
   if (args.copilotModels) env.YUKH_COPILOT_MODELS = args.copilotModels;
   if (args.codexSkills) env.YUKH_CODEX_SKILLS = args.codexSkills;
   if (args.copilotSkills) env.YUKH_COPILOT_SKILLS = args.copilotSkills;
-  if (process.env.YUKH_CODEX_WORKER_PROVIDER === "python-app-server")
-    env.YUKH_CODEX_WORKER_PROVIDER = "python-app-server";
+  if (
+    process.env.YUKH_CODEX_WORKER_PROVIDER === "python-app-server" ||
+    process.env.YUKH_CODEX_WORKER_PROVIDER === "python-app-server-workspace-write"
+  )
+    env.YUKH_CODEX_WORKER_PROVIDER = process.env.YUKH_CODEX_WORKER_PROVIDER;
   if (process.env.YUKH_CODEX_PYTHON_EXECUTABLE)
     env.YUKH_CODEX_PYTHON_EXECUTABLE = process.env.YUKH_CODEX_PYTHON_EXECUTABLE;
   if (process.env.YUKH_COPILOT_WORKER_PROVIDER === "sdk") env.YUKH_COPILOT_WORKER_PROVIDER = "sdk";

--- a/apps/team-preflight/src/runtime-floor.ts
+++ b/apps/team-preflight/src/runtime-floor.ts
@@ -4,22 +4,25 @@ export interface RuntimeTokenFloor {
   readonly schema: 1;
   readonly applies: true;
   readonly runtime: "codex";
-  readonly provider: "cli" | "python-app-server";
+  readonly provider: CodexWorkerProvider;
   readonly minimum_token_budget: number;
   readonly measured_total_tokens: number;
   readonly measured_cached_input_tokens: number;
   readonly reason: string;
 }
 
-export function codexWorkerProvider(): "cli" | "python-app-server" {
-  return process.env.YUKH_CODEX_WORKER_PROVIDER === "python-app-server"
-    ? "python-app-server"
+export type CodexWorkerProvider = "cli" | "python-app-server" | "python-app-server-workspace-write";
+
+export function codexWorkerProvider(): CodexWorkerProvider {
+  const provider = process.env.YUKH_CODEX_WORKER_PROVIDER;
+  return provider === "python-app-server" || provider === "python-app-server-workspace-write"
+    ? provider
     : "cli";
 }
 
 export function runtimeTokenFloor(
   worker: AgentRecord,
-  provider: "cli" | "python-app-server" = codexWorkerProvider(),
+  provider: CodexWorkerProvider = codexWorkerProvider(),
 ): RuntimeTokenFloor | undefined {
   if (
     worker.runtime !== "codex" ||
@@ -33,7 +36,7 @@ export function runtimeTokenFloor(
     applies: true,
     runtime: "codex",
     provider,
-    ...(provider === "python-app-server"
+    ...(provider === "python-app-server" || provider === "python-app-server-workspace-write"
       ? {
           minimum_token_budget: 18_000,
           measured_total_tokens: 10_830,
@@ -53,7 +56,7 @@ export function runtimeTokenFloor(
 
 export function assertRuntimeTokenFloor(
   worker: AgentRecord,
-  provider: "cli" | "python-app-server" = codexWorkerProvider(),
+  provider: CodexWorkerProvider = codexWorkerProvider(),
 ): void {
   const floor = runtimeTokenFloor(worker, provider);
   if (floor && worker.token_budget < floor.minimum_token_budget)

--- a/apps/team-worker/src/codex-python-runner.ts
+++ b/apps/team-worker/src/codex-python-runner.ts
@@ -13,6 +13,7 @@ export interface CodexPythonWorkerRunOptions {
   readonly prompt: string;
   readonly agent: AgentRecord;
   readonly timeoutMs: number;
+  readonly sandbox?: "read_only" | "workspace_write";
   readonly workerSource?: string;
 }
 
@@ -23,6 +24,7 @@ export async function runCodexPythonWorker({
   prompt,
   agent,
   timeoutMs,
+  sandbox = "read_only",
   workerSource,
 }: CodexPythonWorkerRunOptions): Promise<WorkerRunOutcome> {
   const output = new RuntimeOutput("codex");
@@ -44,6 +46,7 @@ export async function runCodexPythonWorker({
         YUKH_CODEX_EXECUTABLE: executable,
         YUKH_CODEX_PYTHON_PROMPT_PATH: promptPath,
         YUKH_CODEX_PYTHON_MODEL: agent.profile?.model ?? "default",
+        YUKH_CODEX_PYTHON_SANDBOX: sandbox,
       },
     });
     if (!child.stdout || !child.stderr) throw new Error("agent_output_unavailable");
@@ -138,6 +141,7 @@ codex_bin = os.environ["YUKH_CODEX_EXECUTABLE"]
 workspace = os.getcwd()
 prompt = Path(os.environ["YUKH_CODEX_PYTHON_PROMPT_PATH"]).read_text()
 model = os.environ.get("YUKH_CODEX_PYTHON_MODEL", "default")
+sandbox_name = os.environ.get("YUKH_CODEX_PYTHON_SANDBOX", "read_only")
 
 config = CodexConfig(
     codex_bin=codex_bin,
@@ -165,15 +169,35 @@ def breakdown(value):
     }
 
 
+def enum_value(enum, *candidates):
+    for candidate in candidates:
+        if hasattr(enum, candidate):
+            return getattr(enum, candidate)
+    for candidate in candidates:
+        try:
+            return enum(candidate)
+        except Exception:
+            pass
+    raise RuntimeError(f"unsupported enum value: {candidates[0]}")
+
+
+if sandbox_name == "workspace_write":
+    sandbox = enum_value(Sandbox, "workspace_write", "workspace-write")
+elif sandbox_name == "read_only":
+    sandbox = enum_value(Sandbox, "read_only", "read-only")
+else:
+    raise RuntimeError("unsupported Codex Python sandbox")
+
+
 with Codex(config) as codex:
     thread = codex.thread_start(
         cwd=workspace,
-        sandbox=Sandbox.read_only,
+        sandbox=sandbox,
         approval_mode=ApprovalMode.deny_all,
         ephemeral=True,
     )
     run_options = {
-        "sandbox": Sandbox.read_only,
+        "sandbox": sandbox,
         "approval_mode": ApprovalMode.deny_all,
         "effort": "low",
         "summary": "none",

--- a/apps/team-worker/src/main.ts
+++ b/apps/team-worker/src/main.ts
@@ -138,7 +138,12 @@ const useCopilotSdk =
 const useCodexPython =
   agent.runtime === "codex" &&
   modelToolMode === "none" &&
-  process.env.YUKH_CODEX_WORKER_PROVIDER === "python-app-server";
+  (process.env.YUKH_CODEX_WORKER_PROVIDER === "python-app-server" ||
+    process.env.YUKH_CODEX_WORKER_PROVIDER === "python-app-server-workspace-write");
+const codexPythonSandbox =
+  process.env.YUKH_CODEX_WORKER_PROVIDER === "python-app-server-workspace-write"
+    ? "workspace_write"
+    : "read_only";
 const args =
   agent.runtime === "codex"
     ? [
@@ -293,6 +298,7 @@ const outcome = !joined
         prompt,
         agent,
         timeoutMs: agent.timeout_ms ?? 300_000,
+        sandbox: codexPythonSandbox,
       })
     : useCopilotSdk
       ? await runCopilotSdkWorker({

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -124,10 +124,18 @@ into the lower-overhead Python app-server provider only after installing
 env = { YUKH_CODEX_WORKER_PROVIDER = "python-app-server", YUKH_CODEX_PYTHON_EXECUTABLE = "/absolute/path/to/python3" }
 ```
 
-This provider is used only when the worker runs with `tool_mode: none`; workers
-that need Coordination or team-control tools stay on the CLI path. The preflight
-token floor remains 120k for the CLI and becomes 18k for the opt-in Python
-app-server path.
+`python-app-server` is read-only and is suitable for review/verification. For an
+approved micro implementation worker, use the explicit workspace-write variant:
+
+```toml
+env = { YUKH_CODEX_WORKER_PROVIDER = "python-app-server-workspace-write", YUKH_CODEX_PYTHON_EXECUTABLE = "/absolute/path/to/python3" }
+```
+
+Both Python providers are used only when the worker runs with `tool_mode: none`;
+workers that need Coordination or team-control tools stay on the CLI path. The
+preflight token floor remains 120k for the CLI and becomes 18k for the opt-in
+Python app-server path. Treat the workspace-write floor as a launch guard until
+the first real edit cycle records fresh usage.
 
 Start work with `manager.start`, not `team.create`. It creates the team and a
 depth-zero manager runtime together, reserves the manager budget and returns a

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -915,3 +915,10 @@ execution behind `YUKH_CODEX_WORKER_PROVIDER=python-app-server`. The default
 Codex CLI path remains unchanged. The Python provider is limited to tool-free
 workers, runs with read-only sandbox and deny-all approvals, records usage as
 `codex-python-app-server-v1` and fails closed if token accounting is absent.
+
+The provider guard keeps that read-only path from launching implementation work.
+Implementation workers require the separate
+`YUKH_CODEX_WORKER_PROVIDER=python-app-server-workspace-write` opt-in, still
+with deny-all approvals and `tool_mode: none`. The workspace-write path is a
+bounded implementation runner, not a fallback for workers that need Coordination
+or team-control tools.

--- a/test/runtime/team-control.test.ts
+++ b/test/runtime/team-control.test.ts
@@ -811,6 +811,38 @@ test("Codex Python app-server does not launch implementation workers while read-
   }
 });
 
+test("Codex Python workspace-write app-server can preflight implementation workers", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-codex-python-write-")));
+  const previous = process.env.YUKH_CODEX_WORKER_PROVIDER;
+  try {
+    process.env.YUKH_CODEX_WORKER_PROVIDER = "python-app-server-workspace-write";
+    const output = runEngagePreflight({
+      workspace: root,
+      goal: "Edit one named file and run one focused test",
+      role: "backend-developer",
+      workProfile: "implementation",
+      preferredRuntime: "codex",
+      teamBudget: 90_000,
+      managerBudget: 20_000,
+      workerBudget: 45_000,
+      workerMaxCommands: 1,
+      workerTimeoutMs: 180_000,
+      codexModels: ["default"],
+      copilotModels: ["default"],
+      codexSkills: ["api-design", "testing"],
+      copilotSkills: ["frontend"],
+    });
+    assert.equal(output.runtime_token_floor?.provider, "python-app-server-workspace-write");
+    assert.equal(output.runtime_token_floor?.minimum_token_budget, 18_000);
+    assert.equal(output.provider_launchable, true);
+    assert.match(output.next_real_action, /Run a managed manager or agent\.engage/u);
+  } finally {
+    if (previous === undefined) delete process.env.YUKH_CODEX_WORKER_PROVIDER;
+    else process.env.YUKH_CODEX_WORKER_PROVIDER = previous;
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("approved preflight refuses read-only Python app-server implementation launch", async () => {
   const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-python-readonly-launch-")));
   const previous = process.env.YUKH_CODEX_WORKER_PROVIDER;
@@ -1926,6 +1958,56 @@ test("codex python app-server worker captures final response and token accountin
       total_tokens: 115,
       budget_outcome: "within",
     });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("codex python app-server worker forwards workspace-write sandbox explicitly", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "yukh-codex-python-sandbox-")));
+  try {
+    const store = new TeamStore(root);
+    const team = store.create("Codex Python sandbox probe", "codex");
+    const agent = store.spawn(team.team_id, {
+      runtime: "codex",
+      role: "python-developer",
+      task: "Edit one file",
+      profile: {
+        schema: 1,
+        mission: "Implement",
+        model: "codex-test-model",
+        skills: [],
+        instructions: "Be brief",
+      },
+      model_tool_mode: "none",
+      token_budget: 1_000,
+    });
+    const outcome = await runCodexPythonWorker({
+      executable: "/bin/codex",
+      python: process.env.PYTHON ?? "python3",
+      workspace: root,
+      prompt: "Do the task",
+      agent,
+      timeoutMs: 1_000,
+      sandbox: "workspace_write",
+      workerSource: [
+        "import json",
+        "import os",
+        "print(json.dumps({",
+        "  'schema': 1,",
+        "  'status': 'completed',",
+        "  'final_response': os.environ['YUKH_CODEX_PYTHON_SANDBOX'],",
+        "  'usage_last': {",
+        "    'input_tokens': 1,",
+        "    'cached_input_tokens': 0,",
+        "    'output_tokens': 1,",
+        "    'reasoning_output_tokens': 0,",
+        "  },",
+        "}))",
+      ].join("\n"),
+    });
+    assert.equal(outcome.exitCode, 0);
+    assert.equal(outcome.output.summary(), "workspace_write");
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- add explicit Codex Python app-server provider value for workspace-write implementation workers
- keep python-app-server read-only and preserve the implementation guard from PR #293
- pass the selected sandbox into the Python app-server wrapper with deny-all approvals
- document read-only vs workspace-write provider use

## Validation
- node --import tsx --test test/runtime/team-control.test.ts --test-name-pattern 'Python app-server|workspace-write|read-only|runtime floor|approved preflight refuses|codex python app-server worker'
- node --test test/supply-chain/qualification-scripts.test.mjs
- npm run typecheck
- npm run build
- npm run format:check

Note: I accidentally ran the broad npm test target once; it passed contracts/supply-chain and 21 runtime files, but 6 existing preview/runtime environment tests failed outside this change scope.