### PR TITLE
Document Codex workspace-write micro-edit qualification

### DIFF
--- a/.context/sessions/SESSION-2026-08-19-12-codex-python-workspace-write-micro-edit.md
+++ b/.context/sessions/SESSION-2026-08-19-12-codex-python-workspace-write-micro-edit.md
@@ -1,0 +1,8 @@
+# Session note: Codex Python workspace-write micro-edit
+
+- Date: 2026-08-19
+- Worker: worker-67445c67-8038-47bc-aad1-c0d34b00db81
+- Scope: first Codex Python workspace-write micro-edit qualification attempt.
+- Result: session note created as the scoped workspace-write change.
+- Context pack: not supplied.
+- Validation: `git diff --check` requested after this edit.


### PR DESCRIPTION
## Summary
- add the session note generated by the first successful Codex Python workspace-write micro-edit worker
- preserve the worker id, scope and validation result for auditability

## Validation
- git diff --check
- worker terminal state: completed/succeeded
- worker usage: 12,598 / 18,000 tokens, within budget

## Notes
This PR intentionally contains only the generated session note. Runtime artifacts under .yukh are not tracked.