### PR TITLE
Add preview runtime diagnostic check

### DIFF
--- a/.github/scripts/check-preview-runtime.sh
+++ b/.github/scripts/check-preview-runtime.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runtime="${YUKH_PREVIEW_RUNTIME:-$HOME/.yukh/local-preview}"
+coordination_root="${YUKH_COORDINATION_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)/yukh-coordination}"
+launcher="${YUKH_COORDINATION_LAUNCHER:-$coordination_root/.github/scripts/yukh-local-agent.py}"
+
+ok=1
+
+report() {
+  printf '%s\n' "$*"
+}
+
+problem() {
+  ok=0
+  report "problem: $*"
+}
+
+report "yukh-preview-runtime-check"
+report "runtime: $runtime"
+report "launcher: $launcher"
+
+[[ -d "$runtime" ]] || problem "runtime directory missing"
+if [[ -d "$runtime" ]]; then
+  mode="$(stat -c '%a' "$runtime" 2>/dev/null || stat -f '%Lp' "$runtime" 2>/dev/null || true)"
+  report "runtime_mode: ${mode:-unknown}"
+  [[ "$mode" == "700" ]] || problem "runtime directory must be mode 0700 for local custody"
+fi
+
+for file in bin/yukh-coordination server.crt supervisor.token agent-a.root agent-b.root; do
+  [[ -f "$runtime/$file" ]] || problem "missing $runtime/$file"
+done
+
+if [[ -f "$runtime/server.crt" ]]; then
+  if openssl x509 -checkend 21600 -noout -in "$runtime/server.crt" >/dev/null 2>&1; then
+    report "tls: ok"
+  else
+    problem "preview TLS certificate is expired or expires within 6 hours"
+  fi
+fi
+
+if command -v docker >/dev/null 2>&1; then
+  if docker ps >/dev/null 2>&1; then
+    report "docker: ok"
+  elif command -v sudo >/dev/null 2>&1 && sudo -n docker ps >/dev/null 2>&1; then
+    report "docker: sudo-required"
+  else
+    problem "docker daemon unavailable to current user"
+  fi
+else
+  problem "docker command missing"
+fi
+
+if [[ -x "$launcher" && -d "$runtime" ]]; then
+  if YUKH_PREVIEW_RUNTIME="$runtime" "$launcher" agent-a events replay >/dev/null 2>&1; then
+    report "coordination_replay: ok"
+  else
+    report "coordination_replay: unavailable"
+    report "hint: run agent bootstrap/join after the coordinator is reachable; if replay returns YKC-TRANSCRIPT-001, start with a join event instead of deleting state."
+  fi
+else
+  problem "coordination launcher unavailable"
+fi
+
+if [[ "$ok" == 1 ]]; then
+  report "status: ok"
+else
+  report "status: attention-required"
+  exit 2
+fi

--- a/docs/guides/codex-copilot-coordination-preview.md
+++ b/docs/guides/codex-copilot-coordination-preview.md
@@ -27,6 +27,19 @@ error means stop and fix the checkout before continuing.
 
 This command is the gate before starting a Yukh-managed implementation worker.
 
+Before launching real workers, check the local Coordination preview runtime:
+
+```sh
+YUKH_PREVIEW_RUNTIME=/path/to/local-preview \
+YUKH_COORDINATION_LAUNCHER=/path/to/yukh-coordination/.github/scripts/yukh-local-agent.py \
+.github/scripts/check-preview-runtime.sh
+```
+
+The check is diagnostic only: it does not start containers, stop containers or
+delete JetStream volumes. Fix `attention-required` results before approving a
+worker, especially expired TLS, runtime directories not using mode `0700`, and
+Docker setups that require `sudo` or an unsandboxed terminal.
+
 For a small documentation change, start with the `micro-doc-edit` preset instead
 of the generic implementation profile:
 

--- a/test/supply-chain/qualification-scripts.test.mjs
+++ b/test/supply-chain/qualification-scripts.test.mjs
@@ -37,3 +37,17 @@ test("Control Plane live activity qualification uses JetStream and fake provider
   assert.doesNotMatch(source, /tail -f/u);
   assert.doesNotMatch(source, /YUKH_CODEX_EXECUTABLE:-\\$\\(command -v codex\\)/u);
 });
+
+test("preview runtime check is diagnostic and non-destructive", async () => {
+  const path = ".github/scripts/check-preview-runtime.sh";
+  await access(new URL(`../../${path}`, import.meta.url), constants.X_OK);
+  const source = await read(path);
+
+  assert.match(source, /runtime directory must be mode 0700/);
+  assert.match(source, /openssl x509 -checkend 21600/);
+  assert.match(source, /docker: sudo-required/);
+  assert.match(source, /coordination_replay: unavailable/);
+  assert.match(source, /YKC-TRANSCRIPT-001/);
+  assert.doesNotMatch(source, /down --volumes/u);
+  assert.doesNotMatch(source, /rm -rf/u);
+});


### PR DESCRIPTION
## Summary
- add a non-destructive preview runtime diagnostic script for Coordination/NATS worker runs
- document the check before approving real workers
- add supply-chain coverage that the script checks TLS/runtime mode/Docker and avoids destructive reset commands

## Validation
- .github/scripts/check-preview-runtime.sh || true
- node --test test/supply-chain/qualification-scripts.test.mjs
- npm run format:check
- npm run typecheck
- npm run build
- git diff --check

## Runtime note
On this VPS the diagnostic correctly reports attention-required for Docker access from the sandboxed user and unavailable replay, without deleting JetStream or local agent state.