### PR TITLE
Clarify preview runtime warning status

### DIFF
--- a/.github/scripts/check-preview-runtime.sh
+++ b/.github/scripts/check-preview-runtime.sh
@@ -5,15 +5,21 @@ runtime="${YUKH_PREVIEW_RUNTIME:-$HOME/.yukh/local-preview}"
 coordination_root="${YUKH_COORDINATION_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)/yukh-coordination}"
 launcher="${YUKH_COORDINATION_LAUNCHER:-$coordination_root/.github/scripts/yukh-local-agent.py}"
 
-ok=1
+problems=0
+warnings=0
 
 report() {
   printf '%s\n' "$*"
 }
 
 problem() {
-  ok=0
+  problems=$((problems + 1))
   report "problem: $*"
+}
+
+warning() {
+  warnings=$((warnings + 1))
+  report "warning: $*"
 }
 
 report "yukh-preview-runtime-check"
@@ -55,16 +61,18 @@ if [[ -x "$launcher" && -d "$runtime" ]]; then
   if YUKH_PREVIEW_RUNTIME="$runtime" "$launcher" agent-a events replay >/dev/null 2>&1; then
     report "coordination_replay: ok"
   else
-    report "coordination_replay: unavailable"
+    warning "coordination_replay: unavailable"
     report "hint: run agent bootstrap/join after the coordinator is reachable; if replay returns YKC-TRANSCRIPT-001, start with a join event instead of deleting state."
   fi
 else
   problem "coordination launcher unavailable"
 fi
 
-if [[ "$ok" == 1 ]]; then
-  report "status: ok"
-else
+if (( problems > 0 )); then
   report "status: attention-required"
   exit 2
+elif (( warnings > 0 )); then
+  report "status: ok-with-warnings"
+else
+  report "status: ok"
 fi

--- a/test/supply-chain/qualification-scripts.test.mjs
+++ b/test/supply-chain/qualification-scripts.test.mjs
@@ -46,6 +46,10 @@ test("preview runtime check is diagnostic and non-destructive", async () => {
   assert.match(source, /runtime directory must be mode 0700/);
   assert.match(source, /openssl x509 -checkend 21600/);
   assert.match(source, /docker: sudo-required/);
+  assert.match(source, /warnings=0/);
+  assert.match(source, /warning "coordination_replay: unavailable"/);
+  assert.match(source, /status: ok-with-warnings/);
+  assert.match(source, /status: attention-required/);
   assert.match(source, /coordination_replay: unavailable/);
   assert.match(source, /YKC-TRANSCRIPT-001/);
   assert.doesNotMatch(source, /down --volumes/u);


### PR DESCRIPTION
## Summary
- separate preview runtime diagnostic problems from warnings
- report coordination replay unavailability as a warning
- emit status ok-with-warnings when only warnings remain
- keep attention-required reserved for real problems

## Worker run
- provider: python-app-server-workspace-write
- model: gpt-5.6-terra
- worker: worker-8c82a2d8-3090-409e-a40d-fd1e17f59c2f
- outcome: succeeded
- usage: 14,836 / 24,000 tokens, within budget

## Validation
- node --test test/supply-chain/qualification-scripts.test.mjs
- git diff --check
- .github/scripts/check-preview-runtime.sh || true
- npm run format:check
- npm run typecheck
- npm run build