### PR TITLE
Add Control Plane preview runtime gate

### DIFF
--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -27,6 +27,7 @@ import {
 } from "./plan-preview-store.js";
 import { createTeamStatus } from "./team-status.js";
 import { createTopologyStatus } from "./topology-status.js";
+import { createPreviewRuntimeCheck, type PreviewRuntimeCheck } from "./preview-runtime-status.js";
 
 type ControlPlaneOptions = {
   readonly host: string;
@@ -42,6 +43,7 @@ const CONTENT_TYPES = new Map([
 ]);
 
 const API_TOPOLOGY_STATUS_PATH = "/api/topology/status";
+const API_PREVIEW_RUNTIME_STATUS_PATH = "/api/topology/preview-runtime";
 const API_TEAM_STATUS_PATH = "/api/teams/status";
 const API_PLAN_PREVIEWS_PATH = "/api/manager-plan/previews";
 const API_LAUNCH_READINESS_PATH = "/api/manager-plan/launch-readiness";
@@ -281,8 +283,10 @@ export function createControlPlaneServer(
   options: {
     readonly teamStore?: Pick<TeamStore, "teams">;
     readonly planPreviewStore?: ControlPlanePlanPreviewStore;
+    readonly previewRuntimeCheck?: PreviewRuntimeCheck;
   } = {},
 ): Server {
+  const previewRuntimeCheck = options.previewRuntimeCheck ?? createPreviewRuntimeCheck();
   return createServer(async (request, response) => {
     if (
       request.url &&
@@ -1220,6 +1224,27 @@ export function createControlPlaneServer(
         "content-type": "application/json; charset=utf-8",
       });
       response.end(JSON.stringify(createTopologyStatus()));
+      return;
+    }
+
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_PREVIEW_RUNTIME_STATUS_PATH
+    ) {
+      if (request.method !== "GET") {
+        response.writeHead(405, {
+          allow: "GET",
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+        return;
+      }
+      response.writeHead(200, {
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(JSON.stringify(previewRuntimeCheck()));
       return;
     }
 

--- a/apps/control-plane-preview/src/preview-runtime-status.ts
+++ b/apps/control-plane-preview/src/preview-runtime-status.ts
@@ -1,0 +1,124 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+export type PreviewRuntimeStatus = "ok" | "ok-with-warnings" | "attention-required";
+
+export type PreviewRuntimeCheck = () => PreviewRuntimeStatusResponse;
+
+export type PreviewRuntimeStatusResponse = {
+  readonly schema: "yukh-control-plane-preview-runtime-status-v1";
+  readonly source: "preview-runtime-check";
+  readonly checked_at: string;
+  readonly side_effects: "none";
+  readonly status: PreviewRuntimeStatus;
+  readonly runtime?: string;
+  readonly launcher?: string;
+  readonly checks: Record<string, string>;
+  readonly warnings: readonly string[];
+  readonly problems: readonly string[];
+};
+
+const STATUS_VALUES = new Set(["ok", "ok-with-warnings", "attention-required"]);
+
+function emptyStatus(
+  status: PreviewRuntimeStatus,
+  checkedAt: string,
+): PreviewRuntimeStatusResponse {
+  return {
+    schema: "yukh-control-plane-preview-runtime-status-v1",
+    source: "preview-runtime-check",
+    checked_at: checkedAt,
+    side_effects: "none",
+    status,
+    checks: {},
+    warnings: [],
+    problems: [],
+  };
+}
+
+export function parsePreviewRuntimeCheckOutput(
+  output: string,
+  checkedAt = new Date().toISOString(),
+): PreviewRuntimeStatusResponse {
+  const checks: Record<string, string> = {};
+  const warnings: string[] = [];
+  const problems: string[] = [];
+  let status: PreviewRuntimeStatus = "attention-required";
+  let runtime: string | undefined;
+  let launcher: string | undefined;
+
+  for (const rawLine of output.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const separator = line.indexOf(":");
+    if (separator < 1) continue;
+    const key = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1).trim();
+    if (key === "status" && STATUS_VALUES.has(value)) {
+      status = value as PreviewRuntimeStatus;
+    } else if (key === "warning") {
+      warnings.push(value);
+    } else if (key === "problem") {
+      problems.push(value);
+    } else if (key === "runtime") {
+      runtime = value;
+    } else if (key === "launcher") {
+      launcher = value;
+    } else {
+      checks[key] = value;
+    }
+  }
+
+  return {
+    ...emptyStatus(status, checkedAt),
+    ...(runtime ? { runtime } : {}),
+    ...(launcher ? { launcher } : {}),
+    checks,
+    warnings,
+    problems,
+  };
+}
+
+export function createPreviewRuntimeCheck(
+  options: { readonly repoRoot?: string; readonly timeoutMs?: number } = {},
+): PreviewRuntimeCheck {
+  const repoRoot = options.repoRoot ?? process.cwd();
+  const timeoutMs = options.timeoutMs ?? 5_000;
+  const script = join(repoRoot, ".github", "scripts", "check-preview-runtime.sh");
+
+  return () => {
+    const checkedAt = new Date().toISOString();
+    if (!existsSync(script)) {
+      return {
+        ...emptyStatus("attention-required", checkedAt),
+        problems: ["preview runtime check script unavailable"],
+      };
+    }
+
+    const result = spawnSync(script, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: process.env,
+      timeout: timeoutMs,
+    });
+    const stdout = result.stdout ?? "";
+    const stderr = result.stderr ?? "";
+    const parsed = parsePreviewRuntimeCheckOutput(stdout, checkedAt);
+    if (result.error) {
+      return {
+        ...parsed,
+        status: "attention-required",
+        problems: [...parsed.problems, result.error.message],
+      };
+    }
+    if (result.status !== 0 && parsed.problems.length === 0) {
+      return {
+        ...parsed,
+        status: "attention-required",
+        problems: [...parsed.problems, stderr.trim() || "preview runtime check failed"],
+      };
+    }
+    return parsed;
+  };
+}

--- a/apps/control-plane-preview/static/index.html
+++ b/apps/control-plane-preview/static/index.html
@@ -69,6 +69,21 @@
           </article>
         </section>
 
+        <section class="card preview-runtime-card" aria-label="Preview runtime gate">
+          <div class="section-title">
+            <div>
+              <p class="eyebrow">Preview runtime gate</p>
+              <h3>Can this host launch Yukh work safely?</h3>
+            </div>
+            <span id="preview-runtime-status" class="status-pill small">
+              <span class="dot warn"></span>checking
+            </span>
+          </div>
+          <div id="preview-runtime-panel" class="preview-runtime-panel">
+            <p class="muted">Checking Docker, TLS, launcher and Coordination replay readiness.</p>
+          </div>
+        </section>
+
         <section class="card command-center-card" id="managers">
           <div class="section-title">
             <div>

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -175,6 +175,17 @@ const loadTopology = async () => {
     return data.topology;
   }
 };
+const loadPreviewRuntimeStatus = async () => {
+  try {
+    const response = await fetch("./api/topology/preview-runtime", { cache: "no-store" });
+    if (!response.ok) return null;
+    const status = await response.json();
+    if (status?.schema !== "yukh-control-plane-preview-runtime-status-v1") return null;
+    return status;
+  } catch {
+    return null;
+  }
+};
 const loadTeams = async () => {
   try {
     const response = await fetch("./api/teams/status", { cache: "no-store" });
@@ -264,6 +275,79 @@ byId("metric-agents").textContent = String(agents.length);
 byId("metric-budget").textContent =
   allocated > 0 ? `${Math.round((used / allocated) * 100)}% used` : "no budget";
 byId("metric-providers").textContent = "CLI + SDK";
+
+const renderPreviewRuntimeStatus = (runtimeStatus) => {
+  const status = runtimeStatus?.status ?? "attention-required";
+  const statusDot = status === "ok" ? "ok" : "warn";
+  byId("preview-runtime-status").innerHTML =
+    `<span class="dot ${statusDot}"></span>${escapeHtml(status)}`;
+
+  if (!runtimeStatus) {
+    byId("preview-runtime-panel").innerHTML = `
+      <article class="preview-runtime-summary attention-required">
+        <strong>Runtime status unavailable</strong>
+        <p class="muted">The Control Plane could not read the preview runtime check endpoint.</p>
+      </article>
+    `;
+    return;
+  }
+
+  const checks = Object.entries(runtimeStatus.checks ?? {});
+  const warnings = runtimeStatus.warnings ?? [];
+  const problems = runtimeStatus.problems ?? [];
+  const launchMessage =
+    status === "ok"
+      ? "Safe to continue with a plan-first run."
+      : status === "ok-with-warnings"
+        ? "Usable, but review warnings before launching expensive workers."
+        : "Fix the listed problems before relying on worker launch.";
+
+  byId("preview-runtime-panel").innerHTML = `
+    <article class="preview-runtime-summary ${escapeHtml(status)}">
+      <div>
+        <strong>${escapeHtml(launchMessage)}</strong>
+        <p class="muted">Checked at ${escapeHtml(runtimeStatus.checked_at)} · side effects: ${escapeHtml(runtimeStatus.side_effects)}</p>
+      </div>
+      <dl>
+        <div><dt>Runtime</dt><dd>${escapeHtml(runtimeStatus.runtime ?? "not reported")}</dd></div>
+        <div><dt>Launcher</dt><dd>${escapeHtml(runtimeStatus.launcher ?? "not reported")}</dd></div>
+      </dl>
+    </article>
+    <div class="preview-runtime-grid">
+      <section>
+        <h4>Checks</h4>
+        ${
+          checks.length === 0
+            ? '<p class="muted">No check detail reported.</p>'
+            : checks
+                .map(
+                  ([key, value]) =>
+                    `<p><span>${escapeHtml(key)}</span><strong>${escapeHtml(value)}</strong></p>`,
+                )
+                .join("")
+        }
+      </section>
+      <section>
+        <h4>Warnings</h4>
+        ${
+          warnings.length === 0
+            ? '<p class="muted">No warnings.</p>'
+            : warnings.map((warning) => `<p class="muted">${escapeHtml(warning)}</p>`).join("")
+        }
+      </section>
+      <section>
+        <h4>Problems</h4>
+        ${
+          problems.length === 0
+            ? '<p class="muted">No blocking problems.</p>'
+            : problems.map((problem) => `<p class="muted">${escapeHtml(problem)}</p>`).join("")
+        }
+      </section>
+    </div>
+  `;
+};
+
+renderPreviewRuntimeStatus(await loadPreviewRuntimeStatus());
 
 byId("manager-count").textContent = `${activeTeams.length} active`;
 byId("manager-list").innerHTML = teams

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -321,6 +321,58 @@ nav a:hover {
   display: grid;
   gap: 14px;
 }
+.preview-runtime-panel {
+  display: grid;
+  gap: 12px;
+}
+.preview-runtime-summary {
+  background: linear-gradient(135deg, rgba(119, 240, 178, 0.09), transparent 48%), #0d121c;
+  border: 1px solid rgba(119, 240, 178, 0.22);
+  border-radius: 18px;
+  display: grid;
+  gap: 14px;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 0.45fr);
+  padding: 14px;
+}
+.preview-runtime-summary.ok-with-warnings,
+.preview-runtime-summary.attention-required {
+  background: linear-gradient(135deg, rgba(255, 209, 102, 0.11), transparent 48%), #0d121c;
+  border-color: rgba(255, 209, 102, 0.28);
+}
+.preview-runtime-summary dl,
+.preview-runtime-grid {
+  display: grid;
+  gap: 10px;
+}
+.preview-runtime-summary dl {
+  margin: 0;
+}
+.preview-runtime-summary dt,
+.preview-runtime-grid span {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.preview-runtime-summary dd {
+  margin: 2px 0 0;
+}
+.preview-runtime-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+.preview-runtime-grid section {
+  background: var(--panel-2);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+}
+.preview-runtime-grid p {
+  display: grid;
+  gap: 3px;
+}
 .team-detail {
   display: grid;
   gap: 16px;
@@ -1113,6 +1165,8 @@ textarea {
   .detail-grid,
   .worker-table article,
   .command-center,
+  .preview-runtime-summary,
+  .preview-runtime-grid,
   .preview-grid,
   .metrics {
     grid-template-columns: 1fr;

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -7,6 +7,7 @@ import {
   createControlPlaneServer,
   parseArguments,
 } from "../../apps/control-plane-preview/src/main.js";
+import { parsePreviewRuntimeCheckOutput } from "../../apps/control-plane-preview/src/preview-runtime-status.js";
 import { ControlPlanePlanPreviewStore } from "../../apps/control-plane-preview/src/plan-preview-store.js";
 import { TeamStore } from "../../packages/team-control/src/store.js";
 
@@ -107,6 +108,83 @@ test("control plane preview exposes closed read-only topology status", async () 
       server.close((error) => (error ? reject(error) : resolve()));
     });
   }
+});
+
+test("control plane preview exposes read-only preview runtime gate", async () => {
+  const root = await mkdtemp(join(tmpdir(), "yukh-control-plane-preview-runtime-api-"));
+  await writeFile(join(root, "index.html"), "<h1>Control</h1>");
+  await writeFile(join(root, "styles.css"), "body{}");
+  await writeFile(join(root, "mock-data.js"), "export {};");
+
+  const server = createControlPlaneServer(root, {
+    previewRuntimeCheck: () => ({
+      schema: "yukh-control-plane-preview-runtime-status-v1",
+      source: "preview-runtime-check",
+      checked_at: "2026-08-19T12:00:00.000Z",
+      side_effects: "none",
+      status: "ok-with-warnings",
+      runtime: "/tmp/yukh-preview",
+      launcher: ".github/scripts/yukh-local-agent.py",
+      checks: { docker: "sudo-required", tls: "ok", coordination_replay: "unavailable" },
+      warnings: ["coordination replay unavailable for a fresh profile"],
+      problems: [],
+    }),
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  try {
+    const address = server.address();
+    if (typeof address !== "object" || address === null) {
+      throw new TypeError("expected TCP server address");
+    }
+    const base = `http://127.0.0.1:${address.port}`;
+
+    const response = await fetch(`${base}/api/topology/preview-runtime`);
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("cache-control"), "no-store");
+    const body = await response.json();
+    assert.equal(body.schema, "yukh-control-plane-preview-runtime-status-v1");
+    assert.equal(body.status, "ok-with-warnings");
+    assert.equal(body.side_effects, "none");
+    assert.equal(body.checks.docker, "sudo-required");
+    assert.deepEqual(body.problems, []);
+    assert.doesNotMatch(JSON.stringify(body), /token|secret|private|credential/iu);
+
+    const mutation = await fetch(`${base}/api/topology/preview-runtime`, { method: "POST" });
+    assert.equal(mutation.status, 405);
+    assert.equal(mutation.headers.get("allow"), "GET");
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("control plane preview parses runtime diagnostic output", () => {
+  const parsed = parsePreviewRuntimeCheckOutput(
+    [
+      "runtime: /tmp/yukh-preview",
+      "launcher: .github/scripts/yukh-local-agent.py",
+      "docker: sudo-required",
+      "tls: ok",
+      "warning: coordination replay unavailable for a fresh profile",
+      "status: ok-with-warnings",
+    ].join("\n"),
+    "2026-08-19T12:00:00.000Z",
+  );
+
+  assert.equal(parsed.schema, "yukh-control-plane-preview-runtime-status-v1");
+  assert.equal(parsed.status, "ok-with-warnings");
+  assert.equal(parsed.runtime, "/tmp/yukh-preview");
+  assert.equal(parsed.launcher, ".github/scripts/yukh-local-agent.py");
+  assert.equal(parsed.side_effects, "none");
+  assert.equal(parsed.checks.docker, "sudo-required");
+  assert.deepEqual(parsed.warnings, ["coordination replay unavailable for a fresh profile"]);
 });
 
 test("control plane preview exposes redacted live team status", async () => {
@@ -1462,6 +1540,8 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(html, /Communication/u);
   assert.match(html, /Team detail/u);
   assert.match(html, /Plan, workers, tokens and next action/u);
+  assert.match(html, /Preview runtime gate/u);
+  assert.match(html, /Can this host launch Yukh work safely/u);
   assert.match(html, /manager-plan-form/u);
   assert.match(html, /provider-adapter-form/u);
   assert.match(html, /plan-preview/u);
@@ -1472,7 +1552,11 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(html, /Manager detail/u);
   assert.match(html, /Current orchestration/u);
   assert.match(data, /api\/topology\/status/u);
+  assert.match(data, /api\/topology\/preview-runtime/u);
   assert.match(data, /api\/teams\/status/u);
+  assert.match(data, /yukh-control-plane-preview-runtime-status-v1/u);
+  assert.match(data, /renderPreviewRuntimeStatus/u);
+  assert.match(data, /Fix the listed problems before relying on worker launch/u);
   assert.match(data, /missing_required_actions/u);
   assert.match(data, /task-board/u);
   assert.match(data, /conversation-feed/u);
@@ -1553,6 +1637,7 @@ test("control plane preview explains runtime topology without Mermaid", async ()
 
   const styles = await readFile("apps/control-plane-preview/static/styles.css", "utf8");
   assert.match(styles, /\.worker-activity/u);
+  assert.match(styles, /\.preview-runtime-panel/u);
 });
 
 test("control plane preview has bounded text containers for operator UI", async () => {
@@ -1592,6 +1677,8 @@ test("control plane preview has bounded text containers for operator UI", async 
   assert.match(css, /\.provider-worker-process/u);
   assert.match(css, /\.provider-runner-attachment/u);
   assert.match(css, /\.worker-activity/u);
+  assert.match(css, /\.preview-runtime-summary/u);
+  assert.match(css, /\.preview-runtime-grid/u);
   assert.match(css, /\.preflight-grid/u);
   assert.match(css, /@media \(max-width: 640px\)/u);
 });


### PR DESCRIPTION
## Summary
- add a read-only preview runtime status endpoint for Control Plane
- surface ok / ok-with-warnings / attention-required in the dashboard before worker launch
- cover endpoint parsing, static UI wiring, bounded layout, typecheck, format and build

## Tests
- node --import tsx --test test/runtime/control-plane-preview.test.ts --test-name-pattern 'preview runtime|runtime topology|bounded text|topology status'
- npm run typecheck
- npm run format:check
- npm run build