### PR TITLE
Gate launch readiness on preview runtime

### DIFF
--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -27,7 +27,11 @@ import {
 } from "./plan-preview-store.js";
 import { createTeamStatus } from "./team-status.js";
 import { createTopologyStatus } from "./topology-status.js";
-import { createPreviewRuntimeCheck, type PreviewRuntimeCheck } from "./preview-runtime-status.js";
+import {
+  createPreviewRuntimeCheck,
+  type PreviewRuntimeCheck,
+  type PreviewRuntimeStatusResponse,
+} from "./preview-runtime-status.js";
 
 type ControlPlaneOptions = {
   readonly host: string;
@@ -139,6 +143,20 @@ export const discoverConfiguredProviderModels: ControlPlaneProviderModelDiscover
 
 function runtimeForProvider(provider: string): "codex" | "copilot" {
   return provider === "Copilot SDK workers" ? "copilot" : "codex";
+}
+
+function redactPreviewRuntimeForLaunchReadiness(status: PreviewRuntimeStatusResponse): {
+  readonly status: PreviewRuntimeStatusResponse["status"];
+  readonly checked_at: string;
+  readonly warnings_count: number;
+  readonly problems_count: number;
+} {
+  return {
+    status: status.status,
+    checked_at: status.checked_at,
+    warnings_count: status.warnings.length,
+    problems_count: status.problems.length,
+  };
 }
 
 function createConfiguredProviderRunner(
@@ -313,7 +331,27 @@ export function createControlPlaneServer(
         "cache-control": "no-store",
         "content-type": "application/json; charset=utf-8",
       });
-      response.end(JSON.stringify(options.planPreviewStore.launchReadiness()));
+      const readiness = options.planPreviewStore.launchReadiness();
+      const runtimeStatus = previewRuntimeCheck();
+      const runtimeReasons =
+        runtimeStatus.status === "attention-required"
+          ? [
+              {
+                code: "preview_runtime_attention_required",
+                message:
+                  "The preview runtime gate is attention-required; fix runtime problems before recording a launch intent.",
+              },
+            ]
+          : [];
+      response.end(
+        JSON.stringify({
+          ...readiness,
+          outcome:
+            readiness.outcome === "ready" && runtimeReasons.length === 0 ? "ready" : "blocked",
+          reasons: [...readiness.reasons, ...runtimeReasons],
+          preview_runtime: redactPreviewRuntimeForLaunchReadiness(runtimeStatus),
+        }),
+      );
       return;
     }
 
@@ -339,6 +377,22 @@ export function createControlPlaneServer(
       }
       if (request.method === "POST") {
         try {
+          const runtimeStatus = previewRuntimeCheck();
+          if (runtimeStatus.status === "attention-required") {
+            response.writeHead(409, {
+              "cache-control": "no-store",
+              "content-type": "application/json; charset=utf-8",
+            });
+            response.end(
+              JSON.stringify({
+                schema: 1,
+                status: "error",
+                code: "preview_runtime_attention_required",
+                preview_runtime: redactPreviewRuntimeForLaunchReadiness(runtimeStatus),
+              }),
+            );
+            return;
+          }
           const record = options.planPreviewStore.createLaunchIntent();
           response.writeHead(201, {
             "cache-control": "no-store",

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -1299,6 +1299,9 @@ const renderWorkerActivityFeed = (status) => {
 
 const readinessPanel = (readiness) => {
   if (!readiness) return "";
+  const runtime = readiness.preview_runtime;
+  const runtimeBlocksLaunch = runtime?.status === "attention-required";
+  const canRecordLaunchIntent = readiness.outcome === "ready" && !runtimeBlocksLaunch;
   return `
     <div class="readiness-panel ${readiness.outcome}">
       <div>
@@ -1306,14 +1309,21 @@ const readinessPanel = (readiness) => {
         <strong>${escapeHtml(readiness.outcome)}</strong>
       </div>
       ${
+        runtime
+          ? `<p class="muted">Preview runtime gate: ${escapeHtml(runtime.status)} · ${runtime.problems_count.toLocaleString()} problems · ${runtime.warnings_count.toLocaleString()} warnings.</p>`
+          : '<p class="muted">Preview runtime gate not reported by this server.</p>'
+      }
+      ${
         readiness.reasons.length === 0
           ? '<p class="muted">Ready for the next explicit launch step. This panel still launches nothing.</p>'
           : `<ul>${readiness.reasons.map((reason) => `<li>${escapeHtml(reason.message)}</li>`).join("")}</ul>`
       }
       ${
-        readiness.outcome === "ready"
+        canRecordLaunchIntent
           ? '<button type="button" class="secondary launch-intent-button">Record launch intent</button>'
-          : ""
+          : runtimeBlocksLaunch
+            ? '<button type="button" class="secondary" disabled>Runtime attention required</button>'
+            : ""
       }
     </div>
   `;

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -187,6 +187,82 @@ test("control plane preview parses runtime diagnostic output", () => {
   assert.deepEqual(parsed.warnings, ["coordination replay unavailable for a fresh profile"]);
 });
 
+test("control plane launch readiness blocks launch intents when preview runtime needs attention", async () => {
+  const root = await mkdtemp(join(tmpdir(), "yukh-control-plane-preview-runtime-gated-api-"));
+  await writeFile(join(root, "index.html"), "<h1>Control</h1>");
+  await writeFile(join(root, "styles.css"), "body{}");
+  await writeFile(join(root, "mock-data.js"), "export {};");
+
+  const workspace = await mkdtemp(join(tmpdir(), "yukh-control-plane-runtime-gated-workspace-"));
+  const planPreviewStore = new ControlPlanePlanPreviewStore(workspace);
+  const server = createControlPlaneServer(root, {
+    planPreviewStore,
+    previewRuntimeCheck: () => ({
+      schema: "yukh-control-plane-preview-runtime-status-v1",
+      source: "preview-runtime-check",
+      checked_at: "2026-08-19T12:00:00.000Z",
+      side_effects: "none",
+      status: "attention-required",
+      runtime: "/tmp/yukh-preview",
+      launcher: ".github/scripts/yukh-local-agent.py",
+      checks: { docker: "unavailable", tls: "ok" },
+      warnings: [],
+      problems: ["docker daemon unavailable to current user"],
+    }),
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  try {
+    const address = server.address();
+    if (typeof address !== "object" || address === null) {
+      throw new TypeError("expected TCP server address");
+    }
+    const base = `http://127.0.0.1:${address.port}`;
+
+    const approved = await fetch(`${base}/api/manager-plan/previews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        goal: "Approved but runtime-gated launch",
+        mode: "plan-first",
+        provider: "Codex manager CLI",
+        token_budget: 80_000,
+        state: "approved-preview",
+      }),
+    });
+    assert.equal(approved.status, 201);
+
+    const readiness = await fetch(`${base}/api/manager-plan/launch-readiness`);
+    assert.equal(readiness.status, 200);
+    const readinessBody = await readiness.json();
+    assert.equal(readinessBody.outcome, "blocked");
+    assert.equal(readinessBody.preview_runtime.status, "attention-required");
+    assert.equal(readinessBody.preview_runtime.problems_count, 1);
+    assert.ok(
+      readinessBody.reasons.some(
+        (reason: { code: string }) => reason.code === "preview_runtime_attention_required",
+      ),
+    );
+    assert.doesNotMatch(JSON.stringify(readinessBody), /docker daemon unavailable/iu);
+
+    const intent = await fetch(`${base}/api/manager-plan/launch-intents`, { method: "POST" });
+    assert.equal(intent.status, 409);
+    const intentBody = await intent.json();
+    assert.equal(intentBody.code, "preview_runtime_attention_required");
+    assert.equal(intentBody.preview_runtime.status, "attention-required");
+    assert.equal(intentBody.preview_runtime.problems_count, 1);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
 test("control plane preview exposes redacted live team status", async () => {
   const root = await mkdtemp(join(tmpdir(), "yukh-control-plane-preview-team-"));
   await writeFile(join(root, "index.html"), "<h1>Control</h1>");
@@ -338,7 +414,21 @@ test("control plane preview persists local manager plan previews without leaking
       };
     },
   });
-  const server = createControlPlaneServer(root, { planPreviewStore });
+  const server = createControlPlaneServer(root, {
+    planPreviewStore,
+    previewRuntimeCheck: () => ({
+      schema: "yukh-control-plane-preview-runtime-status-v1",
+      source: "preview-runtime-check",
+      checked_at: "2026-08-19T12:00:00.000Z",
+      side_effects: "none",
+      status: "ok",
+      runtime: "/tmp/yukh-preview",
+      launcher: ".github/scripts/yukh-local-agent.py",
+      checks: { docker: "ok", tls: "ok", coordination_replay: "ok" },
+      warnings: [],
+      problems: [],
+    }),
+  });
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
     server.listen(0, "127.0.0.1", () => {
@@ -1557,6 +1647,9 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /yukh-control-plane-preview-runtime-status-v1/u);
   assert.match(data, /renderPreviewRuntimeStatus/u);
   assert.match(data, /Fix the listed problems before relying on worker launch/u);
+  assert.match(data, /Preview runtime gate:/u);
+  assert.match(data, /Runtime attention required/u);
+  assert.match(data, /canRecordLaunchIntent/u);
   assert.match(data, /missing_required_actions/u);
   assert.match(data, /task-board/u);
   assert.match(data, /conversation-feed/u);


### PR DESCRIPTION
## Summary
- add preview runtime gate data to launch readiness
- block launch-intent creation when the preview runtime is attention-required
- show runtime gate status inside the launch readiness UI so operators understand why launch is blocked

## Tests
- node --import tsx --test test/runtime/control-plane-preview.test.ts --test-name-pattern 'preview runtime|launch readiness|runtime topology|bounded text|topology status'
- npm run typecheck
- npm run format:check
- npm run build