### PR TITLE
Add real project readiness gates

### DIFF
--- a/.yukh/project.yaml
+++ b/.yukh/project.yaml
@@ -74,3 +74,26 @@ safety:
   overwrite_human_values: false
   fail_on_unknown_values: true
   comment_on_validation_error: true
+
+real_use:
+  first_micro_task:
+    max_team_token_budget: 120000
+    max_worker_count: 2
+    allowed_runtimes:
+      - codex
+    required_gates:
+      - project_policy
+      - preview_runtime
+      - provider_adapter
+      - launch_readiness
+      - worker_activity
+  branch_policy:
+    strategy: feature_branch_pr
+    base: main
+    commit_author: producing_agent
+    require_human_merge_approval: true
+  definition_of_done:
+    - tests_passed
+    - diff_reviewed
+    - activity_recorded
+    - token_usage_recorded

--- a/apps/control-plane-preview/src/main.ts
+++ b/apps/control-plane-preview/src/main.ts
@@ -32,6 +32,7 @@ import {
   type PreviewRuntimeCheck,
   type PreviewRuntimeStatusResponse,
 } from "./preview-runtime-status.js";
+import { createRealProjectReadiness } from "./real-project-readiness.js";
 
 type ControlPlaneOptions = {
   readonly host: string;
@@ -68,6 +69,7 @@ const API_WORKER_LAUNCH_RECEIPTS_PATH = "/api/manager-plan/worker-launch-receipt
 const API_PROVIDER_WORKER_PROCESSES_PATH = "/api/manager-plan/provider-worker-processes";
 const API_PROVIDER_RUNNER_ATTACHMENTS_PATH = "/api/manager-plan/provider-runner-attachments";
 const API_WORKER_ACTIVITIES_PATH = "/api/manager-plan/worker-activities";
+const API_REAL_PROJECT_READINESS_PATH = "/api/manager-plan/real-project-readiness";
 
 export function parseArguments(argv: readonly string[]): ControlPlaneOptions {
   const options = { host: "127.0.0.1", port: 7345 } as {
@@ -576,6 +578,35 @@ export function createControlPlaneServer(
         "content-type": "application/json; charset=utf-8",
       });
       response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+      return;
+    }
+
+    if (
+      request.url &&
+      new URL(request.url, "http://127.0.0.1").pathname === API_REAL_PROJECT_READINESS_PATH
+    ) {
+      if (request.method !== "GET") {
+        response.writeHead(405, {
+          allow: "GET",
+          "cache-control": "no-store",
+          "content-type": "application/json; charset=utf-8",
+        });
+        response.end(JSON.stringify({ schema: 1, status: "error", code: "method_not_allowed" }));
+        return;
+      }
+      response.writeHead(200, {
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(
+        JSON.stringify(
+          await createRealProjectReadiness({
+            repoRoot: process.cwd(),
+            previewRuntime: previewRuntimeCheck(),
+            ...(options.planPreviewStore ? { planPreviewStore: options.planPreviewStore } : {}),
+          }),
+        ),
+      );
       return;
     }
 

--- a/apps/control-plane-preview/src/real-project-readiness.ts
+++ b/apps/control-plane-preview/src/real-project-readiness.ts
@@ -3,6 +3,14 @@ import { join } from "node:path";
 import type { ControlPlanePlanPreviewStore } from "./plan-preview-store.js";
 import type { PreviewRuntimeStatusResponse } from "./preview-runtime-status.js";
 
+export type RealProjectReadinessPlanReader = Pick<
+  ControlPlanePlanPreviewStore,
+  | "providerAdapters"
+  | "providerCapabilityInventories"
+  | "providerRunnerAttachments"
+  | "workerActivities"
+>;
+
 export type RealProjectReadinessStatus = {
   readonly schema: "yukh-control-plane-real-project-readiness-v1";
   readonly source: "control-plane-preview";
@@ -74,7 +82,7 @@ export async function createRealProjectReadiness(
   input: {
     readonly repoRoot: string;
     readonly previewRuntime: PreviewRuntimeStatusResponse;
-    readonly planPreviewStore?: ControlPlanePlanPreviewStore;
+    readonly planPreviewStore?: RealProjectReadinessPlanReader;
   },
   now = new Date(),
 ): Promise<RealProjectReadinessStatus> {

--- a/apps/control-plane-preview/src/real-project-readiness.ts
+++ b/apps/control-plane-preview/src/real-project-readiness.ts
@@ -1,0 +1,142 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ControlPlanePlanPreviewStore } from "./plan-preview-store.js";
+import type { PreviewRuntimeStatusResponse } from "./preview-runtime-status.js";
+
+export type RealProjectReadinessStatus = {
+  readonly schema: "yukh-control-plane-real-project-readiness-v1";
+  readonly source: "control-plane-preview";
+  readonly generated_at: string;
+  readonly outcome: "ready-for-micro-task" | "blocked";
+  readonly gates: readonly {
+    readonly gate: string;
+    readonly status: "pass" | "warning" | "blocked";
+    readonly detail: string;
+  }[];
+  readonly next_required_action: string;
+};
+
+function projectPolicyGate(repoRoot: string): RealProjectReadinessStatus["gates"][number] {
+  const path = join(repoRoot, ".yukh", "project.yaml");
+  if (!existsSync(path)) {
+    return {
+      gate: "project_policy",
+      status: "blocked",
+      detail: ".yukh/project.yaml is missing.",
+    };
+  }
+  const source = readFileSync(path, "utf8");
+  const requiredMarkers = [
+    "version: 1",
+    "repository: yukh-mcp",
+    "marker: yukh",
+    "overwrite_human_values: false",
+  ];
+  const missing = requiredMarkers.filter((marker) => !source.includes(marker));
+  return missing.length === 0
+    ? {
+        gate: "project_policy",
+        status: "pass",
+        detail: "Project policy is present and keeps human values protected.",
+      }
+    : {
+        gate: "project_policy",
+        status: "blocked",
+        detail: `Project policy is present but missing ${missing.join(", ")}.`,
+      };
+}
+
+function runtimeGate(
+  runtime: PreviewRuntimeStatusResponse,
+): RealProjectReadinessStatus["gates"][number] {
+  if (runtime.status === "attention-required") {
+    return {
+      gate: "preview_runtime",
+      status: "blocked",
+      detail: `Preview runtime needs attention: ${runtime.problems.length} problems.`,
+    };
+  }
+  if (runtime.status === "ok-with-warnings") {
+    return {
+      gate: "preview_runtime",
+      status: "warning",
+      detail: `Preview runtime is usable with ${runtime.warnings.length} warnings.`,
+    };
+  }
+  return {
+    gate: "preview_runtime",
+    status: "pass",
+    detail: "Preview runtime is ready.",
+  };
+}
+
+export async function createRealProjectReadiness(
+  input: {
+    readonly repoRoot: string;
+    readonly previewRuntime: PreviewRuntimeStatusResponse;
+    readonly planPreviewStore?: ControlPlanePlanPreviewStore;
+  },
+  now = new Date(),
+): Promise<RealProjectReadinessStatus> {
+  const gates: RealProjectReadinessStatus["gates"][number][] = [
+    projectPolicyGate(input.repoRoot),
+    runtimeGate(input.previewRuntime),
+  ];
+
+  if (!input.planPreviewStore) {
+    gates.push({
+      gate: "control_plane_workspace",
+      status: "blocked",
+      detail: "Control Plane workspace is not configured.",
+    });
+  } else {
+    const adapters = input.planPreviewStore.providerAdapters().adapters;
+    const inventories = input.planPreviewStore.providerCapabilityInventories().inventories;
+    const attachments = input.planPreviewStore.providerRunnerAttachments().attachments;
+    const activities = await input.planPreviewStore.workerActivities();
+    gates.push({
+      gate: "provider_adapter",
+      status: adapters.length > 0 ? "pass" : "blocked",
+      detail:
+        adapters.length > 0
+          ? `${adapters.length} provider adapter configured.`
+          : "Configure at least one provider adapter before real project use.",
+    });
+    gates.push({
+      gate: "provider_capabilities",
+      status: inventories.length > 0 ? "pass" : "warning",
+      detail:
+        inventories.length > 0
+          ? `${inventories.length} provider capability inventory recorded.`
+          : "No provider capability inventory recorded yet; guided run can create it.",
+    });
+    gates.push({
+      gate: "runner_attachment",
+      status: attachments.length > 0 ? "pass" : "warning",
+      detail:
+        attachments.length > 0
+          ? `${attachments.length} provider runner attachment observed.`
+          : "No provider runner attachment observed yet; first guided run will qualify this.",
+    });
+    gates.push({
+      gate: "worker_activity",
+      status: activities.activities.length > 0 ? "pass" : "warning",
+      detail:
+        activities.activities.length > 0
+          ? `${activities.activities.length} worker.activity.v1 events available from ${activities.source}.`
+          : "No worker activity observed yet; first guided run should record a snapshot.",
+    });
+  }
+
+  const blocked = gates.some((gate) => gate.status === "blocked");
+  return {
+    schema: "yukh-control-plane-real-project-readiness-v1",
+    source: "control-plane-preview",
+    generated_at: now.toISOString(),
+    outcome: blocked ? "blocked" : "ready-for-micro-task",
+    gates,
+    next_required_action: blocked
+      ? (gates.find((gate) => gate.status === "blocked")?.detail ?? "Resolve blocked gates.")
+      : "Run one bounded real micro-task through the guided Control Plane flow.",
+  };
+}

--- a/apps/control-plane-preview/static/index.html
+++ b/apps/control-plane-preview/static/index.html
@@ -277,6 +277,17 @@
                 <h3>New team</h3>
               </div>
             </div>
+            <section class="real-readiness" aria-label="Real project readiness">
+              <div class="subsection-title">
+                <h4>Real project readiness</h4>
+                <button type="button" class="secondary small-button" id="real-readiness-refresh">
+                  Refresh
+                </button>
+              </div>
+              <div id="real-readiness-panel" aria-live="polite">
+                <p class="muted">Checking project policy, runtime, provider and activity gates.</p>
+              </div>
+            </section>
             <form class="start-form provider-adapter-form" id="provider-adapter-form">
               <label
                 >Provider adapter<select id="adapter-provider">

--- a/apps/control-plane-preview/static/mock-data.js
+++ b/apps/control-plane-preview/static/mock-data.js
@@ -1057,6 +1057,64 @@ const loadWorkerActivities = async () => {
   }
 };
 
+const loadRealProjectReadiness = async () => {
+  try {
+    const response = await fetch("./api/manager-plan/real-project-readiness", {
+      cache: "no-store",
+    });
+    if (!response.ok) return null;
+    const status = await response.json();
+    if (status?.schema !== "yukh-control-plane-real-project-readiness-v1") return null;
+    return status;
+  } catch {
+    return null;
+  }
+};
+
+const renderRealProjectReadiness = (status) => {
+  if (!status) {
+    byId("real-readiness-panel").innerHTML =
+      '<p class="muted">Real project readiness is unavailable from this Control Plane server.</p>';
+    return;
+  }
+  const dot = status.outcome === "ready-for-micro-task" ? "ok" : "warn";
+  byId("real-readiness-panel").innerHTML = `
+    <article class="real-readiness-summary">
+      <span class="status-pill small"><span class="dot ${dot}"></span>${escapeHtml(status.outcome)}</span>
+      <p class="muted">${escapeHtml(status.next_required_action)}</p>
+    </article>
+    <div class="real-readiness-gates">
+      ${status.gates
+        .map(
+          (gate) => `
+            <article class="${escapeHtml(gate.status)}">
+              <span>${escapeHtml(gate.gate)}</span>
+              <strong>${escapeHtml(gate.status)}</strong>
+              <p class="muted">${escapeHtml(gate.detail)}</p>
+            </article>
+          `,
+        )
+        .join("")}
+    </div>
+  `;
+};
+
+const refreshRealProjectReadiness = async (button = null) => {
+  button?.setAttribute("disabled", "true");
+  if (button) button.textContent = "Checking…";
+  renderRealProjectReadiness(await loadRealProjectReadiness());
+  if (button) {
+    button.removeAttribute("disabled");
+    button.textContent = "Refresh";
+  }
+};
+
+await refreshRealProjectReadiness();
+
+byId("real-readiness-refresh").addEventListener("click", (event) => {
+  void refreshRealProjectReadiness(event.target.closest("button"));
+});
+
 const renderProviderAdapter = (adapter) => {
   if (!adapter) return "";
   return `
@@ -1523,6 +1581,7 @@ const startGuidedTeamRun = async (button) => {
   if (activity) {
     anchor = appendGuidedRunStep(anchor, renderWorkerActivity(activity));
   }
+  await refreshRealProjectReadiness();
   button.textContent = "Guided run started";
 };
 
@@ -1867,6 +1926,7 @@ byId("plan-preview").addEventListener("click", async (event) => {
   button
     .closest(".provider-worker-process")
     ?.insertAdjacentHTML("afterend", renderProviderRunnerAttachment(attachment));
+  await refreshRealProjectReadiness();
 });
 
 byId("plan-preview").addEventListener("click", async (event) => {
@@ -1884,6 +1944,7 @@ byId("plan-preview").addEventListener("click", async (event) => {
   button
     .closest(".provider-runner-attachment")
     ?.insertAdjacentHTML("beforeend", renderWorkerActivityFeed(status));
+  await refreshRealProjectReadiness();
 });
 
 byId("plan-preview").addEventListener("click", async (event) => {
@@ -1901,6 +1962,7 @@ byId("plan-preview").addEventListener("click", async (event) => {
   button
     .closest(".provider-runner-attachment")
     ?.insertAdjacentHTML("afterend", renderWorkerActivity(activity));
+  await refreshRealProjectReadiness();
 });
 
 byId("manager-plan-form").addEventListener("submit", (event) => {
@@ -1928,6 +1990,7 @@ byId("provider-adapter-form").addEventListener("submit", async (event) => {
   byId("provider-adapter-status").innerHTML = adapter
     ? renderProviderAdapter(adapter)
     : '<div class="provider-adapter"><span>Provider adapter rejected</span><p class="muted">Check provider, adapter kind, absolute CLI path and model list.</p></div>';
+  await refreshRealProjectReadiness();
 });
 
 byId("provider-adapter-status").addEventListener("click", async (event) => {
@@ -1944,6 +2007,7 @@ byId("provider-adapter-status").addEventListener("click", async (event) => {
   button
     .closest(".provider-adapter")
     ?.insertAdjacentHTML("afterend", renderProviderCapabilityInventory(inventory));
+  await refreshRealProjectReadiness();
 });
 
 const persistedPlan = await loadPersistedPlanPreview();

--- a/apps/control-plane-preview/static/styles.css
+++ b/apps/control-plane-preview/static/styles.css
@@ -1044,6 +1044,54 @@ nav a:hover {
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+.real-readiness {
+  border-bottom: 1px solid var(--line);
+  display: grid;
+  gap: 12px;
+  margin-bottom: 18px;
+  padding-bottom: 18px;
+}
+.real-readiness-summary {
+  background: rgba(125, 211, 252, 0.08);
+  border: 1px solid rgba(125, 211, 252, 0.26);
+  border-radius: 16px;
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  padding: 12px;
+}
+.real-readiness-gates {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+.real-readiness-gates article {
+  background: rgba(255, 255, 255, 0.035);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  padding: 10px;
+}
+.real-readiness-gates article.pass {
+  border-color: rgba(119, 240, 178, 0.36);
+}
+.real-readiness-gates article.warning {
+  border-color: rgba(255, 209, 102, 0.36);
+}
+.real-readiness-gates article.blocked {
+  border-color: rgba(251, 113, 133, 0.42);
+}
+.real-readiness-gates span {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 .provider-capability-inventory {
   background: rgba(119, 240, 178, 0.08);
   border: 1px solid rgba(119, 240, 178, 0.28);

--- a/apps/control-plane-readiness/src/main.ts
+++ b/apps/control-plane-readiness/src/main.ts
@@ -1,0 +1,155 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  createRealProjectReadiness,
+  type RealProjectReadinessPlanReader,
+  type RealProjectReadinessStatus,
+} from "../../control-plane-preview/src/real-project-readiness.js";
+import {
+  createPreviewRuntimeCheck,
+  type PreviewRuntimeCheck,
+} from "../../control-plane-preview/src/preview-runtime-status.js";
+import type {
+  ControlPlaneProviderAdapterStatus,
+  ControlPlaneProviderCapabilityInventoryStatus,
+  ControlPlaneProviderRunnerAttachmentStatus,
+  ControlPlaneWorkerActivityStatus,
+} from "../../control-plane-preview/src/plan-preview-store.js";
+
+type ReadinessCliOptions = {
+  readonly repoRoot: string;
+  readonly workspace?: string;
+  readonly format: "json" | "text";
+};
+
+type PlanPreviewDocument = {
+  readonly schema?: number;
+  readonly provider_adapters?: readonly { readonly schema?: number }[];
+  readonly provider_capability_inventories?: readonly { readonly schema?: number }[];
+  readonly provider_runner_attachments?: readonly { readonly schema?: number }[];
+  readonly worker_activities?: readonly { readonly type?: string }[];
+};
+
+export function parseArguments(argv: readonly string[]): ReadinessCliOptions {
+  const options: { repoRoot: string; workspace?: string; format: "json" | "text" } = {
+    repoRoot: process.cwd(),
+    format: "text",
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--workspace") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("missing --workspace value");
+      options.workspace = value;
+      index += 1;
+    } else if (argument === "--repo-root") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("missing --repo-root value");
+      options.repoRoot = value;
+      index += 1;
+    } else if (argument === "--format") {
+      const value = argv[index + 1];
+      if (value !== "json" && value !== "text") throw new Error("invalid --format value");
+      options.format = value;
+      index += 1;
+    } else {
+      throw new Error(`invalid readiness argument: ${argument}`);
+    }
+  }
+  return options;
+}
+
+function readDocument(workspace: string): PlanPreviewDocument {
+  const path = join(workspace, ".yukh", "control-plane", "plan-previews.json");
+  if (!existsSync(path)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as PlanPreviewDocument;
+    return parsed.schema === 1 ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function createReadOnlyPlanReader(workspace: string): RealProjectReadinessPlanReader {
+  const read = () => readDocument(workspace);
+  return {
+    providerAdapters(): ControlPlaneProviderAdapterStatus {
+      return {
+        schema: "yukh-control-plane-provider-adapters-v1",
+        source: "local-control-plane-store",
+        adapters: (read().provider_adapters ?? []).filter((item) => item.schema === 1) as never,
+      };
+    },
+    providerCapabilityInventories(): ControlPlaneProviderCapabilityInventoryStatus {
+      return {
+        schema: "yukh-control-plane-provider-capability-inventories-v1",
+        source: "local-control-plane-store",
+        inventories: (read().provider_capability_inventories ?? []).filter(
+          (item) => item.schema === 1,
+        ) as never,
+      };
+    },
+    providerRunnerAttachments(): ControlPlaneProviderRunnerAttachmentStatus {
+      return {
+        schema: "yukh-control-plane-provider-runner-attachments-v1",
+        source: "local-control-plane-store",
+        attachments: (read().provider_runner_attachments ?? []).filter(
+          (item) => item.schema === 1,
+        ) as never,
+      };
+    },
+    async workerActivities(): Promise<ControlPlaneWorkerActivityStatus> {
+      return {
+        schema: "yukh-control-plane-worker-activities-v1",
+        source: "worker.activity.v1-preview-adapter",
+        activities: (read().worker_activities ?? []).filter(
+          (item) => item.type === "worker.activity.v1",
+        ) as never,
+      };
+    },
+  };
+}
+
+export async function createReadinessReport(
+  options: ReadinessCliOptions,
+  previewRuntimeCheck: PreviewRuntimeCheck = createPreviewRuntimeCheck({
+    repoRoot: options.repoRoot,
+  }),
+): Promise<RealProjectReadinessStatus> {
+  return createRealProjectReadiness({
+    repoRoot: options.repoRoot,
+    previewRuntime: previewRuntimeCheck(),
+    ...(options.workspace ? { planPreviewStore: createReadOnlyPlanReader(options.workspace) } : {}),
+  });
+}
+
+export function renderReadinessText(status: RealProjectReadinessStatus): string {
+  const gates = status.gates
+    .map((gate) => `- ${gate.gate}: ${gate.status} — ${gate.detail}`)
+    .join("\n");
+  return [
+    `Yukh real project readiness: ${status.outcome}`,
+    gates,
+    `Next: ${status.next_required_action}`,
+  ].join("\n");
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+  try {
+    const options = parseArguments(argv);
+    const status = await createReadinessReport(options);
+    process.stdout.write(
+      options.format === "json"
+        ? `${JSON.stringify(status)}\n`
+        : `${renderReadinessText(status)}\n`,
+    );
+    if (status.outcome === "blocked") process.exitCode = 1;
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : "readiness failed"}\n`);
+    process.exitCode = 2;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  void main();
+}

--- a/bin/yukh.mjs
+++ b/bin/yukh.mjs
@@ -21,6 +21,10 @@ if (process.argv[2] === "conversation" && process.argv[3] === "watch") {
   process.argv.splice(2, 2);
   const { main } = await import("../dist/apps/control-plane-preview/src/main.js");
   main(process.argv.slice(2));
+} else if (process.argv[2] === "control" && process.argv[3] === "readiness") {
+  process.argv.splice(2, 2);
+  const { main } = await import("../dist/apps/control-plane-readiness/src/main.js");
+  main(process.argv.slice(2));
 } else if (process.argv[2] === "team" && process.argv[3] === "preflight-engage") {
   process.argv.splice(2, 2);
   await import("../dist/apps/team-preflight/src/main.js");
@@ -45,7 +49,7 @@ if (process.argv[2] === "conversation" && process.argv[3] === "watch") {
       "       yukh team start --goal text [--workspace path] [--mode plan-first|delegate] [--runtime codex|copilot] [--team-budget N] [--manager-budget N] [--format json|text]\n" +
       "       yukh team start-from-handoff --handoff file [--workspace path] [--goal text] [--dry-run true] [--allow-dynamic-workers true] [--format json|text]\n" +
       "       yukh team run-plan-approved --team team-... --plan plan-... --approved-digest sha-256:... [--format json|text]\n" +
-      "       yukh team status --team team-... [--workspace path] [--format json|text]\n       yukh team stop --team team-... [--workspace path] [--format json|text]\n       yukh control start [--host 127.0.0.1] [--port 7345]\n",
+      "       yukh team status --team team-... [--workspace path] [--format json|text]\n       yukh team stop --team team-... [--workspace path] [--format json|text]\n       yukh control start [--host 127.0.0.1] [--port 7345]\n       yukh control readiness [--workspace path] [--repo-root path] [--format json|text]\n",
   );
   process.exitCode = 2;
 }

--- a/test/runtime/control-plane-preview.test.ts
+++ b/test/runtime/control-plane-preview.test.ts
@@ -165,6 +165,97 @@ test("control plane preview exposes read-only preview runtime gate", async () =>
   }
 });
 
+test("control plane preview exposes real project readiness gates", async () => {
+  const root = await mkdtemp(join(tmpdir(), "yukh-control-plane-real-readiness-api-"));
+  await writeFile(join(root, "index.html"), "<h1>Control</h1>");
+  await writeFile(join(root, "styles.css"), "body{}");
+  await writeFile(join(root, "mock-data.js"), "export {};");
+
+  const workspace = await mkdtemp(join(tmpdir(), "yukh-control-plane-real-readiness-workspace-"));
+  const planPreviewStore = new ControlPlanePlanPreviewStore(workspace);
+  const server = createControlPlaneServer(root, {
+    planPreviewStore,
+    previewRuntimeCheck: () => ({
+      schema: "yukh-control-plane-preview-runtime-status-v1",
+      source: "preview-runtime-check",
+      checked_at: "2026-08-19T12:00:00.000Z",
+      side_effects: "none",
+      status: "ok",
+      runtime: "/tmp/yukh-preview",
+      launcher: ".github/scripts/yukh-local-agent.py",
+      checks: { docker: "ok", tls: "ok", coordination_replay: "ok" },
+      warnings: [],
+      problems: [],
+    }),
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  try {
+    const address = server.address();
+    if (typeof address !== "object" || address === null) {
+      throw new TypeError("expected TCP server address");
+    }
+    const base = `http://127.0.0.1:${address.port}`;
+
+    const blocked = await fetch(`${base}/api/manager-plan/real-project-readiness`);
+    assert.equal(blocked.status, 200);
+    assert.equal(blocked.headers.get("cache-control"), "no-store");
+    const blockedBody = await blocked.json();
+    assert.equal(blockedBody.schema, "yukh-control-plane-real-project-readiness-v1");
+    assert.equal(blockedBody.outcome, "blocked");
+    assert.equal(
+      blockedBody.gates.find((gate: { gate: string }) => gate.gate === "project_policy")?.status,
+      "pass",
+    );
+    assert.equal(
+      blockedBody.gates.find((gate: { gate: string }) => gate.gate === "provider_adapter")?.status,
+      "blocked",
+    );
+    assert.doesNotMatch(JSON.stringify(blockedBody), /token|secret|credential|private/iu);
+
+    const adapter = await fetch(`${base}/api/manager-plan/provider-adapters`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        provider: "Codex SDK, planned",
+        adapter_kind: "sdk",
+        models: ["codex-sdk-default"],
+        max_run_token_budget: 120_000,
+      }),
+    });
+    assert.equal(adapter.status, 201);
+
+    const ready = await fetch(`${base}/api/manager-plan/real-project-readiness`);
+    assert.equal(ready.status, 200);
+    const readyBody = await ready.json();
+    assert.equal(readyBody.outcome, "ready-for-micro-task");
+    assert.equal(
+      readyBody.gates.find((gate: { gate: string }) => gate.gate === "provider_adapter")?.status,
+      "pass",
+    );
+    assert.equal(
+      readyBody.gates.find((gate: { gate: string }) => gate.gate === "worker_activity")?.status,
+      "warning",
+    );
+    assert.match(readyBody.next_required_action, /Run one bounded real micro-task/u);
+
+    const mutation = await fetch(`${base}/api/manager-plan/real-project-readiness`, {
+      method: "POST",
+    });
+    assert.equal(mutation.status, 405);
+    assert.equal(mutation.headers.get("allow"), "GET");
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
 test("control plane preview parses runtime diagnostic output", () => {
   const parsed = parsePreviewRuntimeCheckOutput(
     [
@@ -1632,6 +1723,7 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(html, /Plan, workers, tokens and next action/u);
   assert.match(html, /Preview runtime gate/u);
   assert.match(html, /Can this host launch Yukh work safely/u);
+  assert.match(html, /Real project readiness/u);
   assert.match(html, /manager-plan-form/u);
   assert.match(html, /provider-adapter-form/u);
   assert.match(html, /plan-preview/u);
@@ -1680,6 +1772,10 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   assert.match(data, /api\/manager-plan\/provider-worker-processes/u);
   assert.match(data, /api\/manager-plan\/provider-runner-attachments/u);
   assert.match(data, /api\/manager-plan\/worker-activities/u);
+  assert.match(data, /api\/manager-plan\/real-project-readiness/u);
+  assert.match(data, /yukh-control-plane-real-project-readiness-v1/u);
+  assert.match(data, /renderRealProjectReadiness/u);
+  assert.match(data, /ready-for-micro-task/u);
   assert.match(data, /Launch readiness/u);
   assert.match(data, /Launch intent recorded/u);
   assert.match(data, /Manager run planned/u);
@@ -1744,6 +1840,7 @@ test("control plane preview explains runtime topology without Mermaid", async ()
   const styles = await readFile("apps/control-plane-preview/static/styles.css", "utf8");
   assert.match(styles, /\.worker-activity/u);
   assert.match(styles, /\.preview-runtime-panel/u);
+  assert.match(styles, /\.real-readiness/u);
 });
 
 test("control plane preview has bounded text containers for operator UI", async () => {
@@ -1784,6 +1881,8 @@ test("control plane preview has bounded text containers for operator UI", async 
   assert.match(css, /\.provider-worker-process/u);
   assert.match(css, /\.provider-runner-attachment/u);
   assert.match(css, /\.worker-activity/u);
+  assert.match(css, /\.real-readiness-summary/u);
+  assert.match(css, /\.real-readiness-gates/u);
   assert.match(css, /\.preview-runtime-summary/u);
   assert.match(css, /\.preview-runtime-grid/u);
   assert.match(css, /\.preflight-grid/u);

--- a/test/runtime/control-plane-readiness-cli.test.ts
+++ b/test/runtime/control-plane-readiness-cli.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  createReadinessReport,
+  parseArguments,
+  renderReadinessText,
+} from "../../apps/control-plane-readiness/src/main.js";
+
+const okRuntime = () =>
+  ({
+    schema: "yukh-control-plane-preview-runtime-status-v1",
+    source: "preview-runtime-check",
+    checked_at: "2026-08-20T00:00:00.000Z",
+    side_effects: "none",
+    status: "ok",
+    runtime: "/tmp/yukh-preview",
+    launcher: ".github/scripts/yukh-local-agent.py",
+    checks: { docker: "ok", tls: "ok", coordination_replay: "ok" },
+    warnings: [],
+    problems: [],
+  }) as const;
+
+test("control readiness CLI parses bounded arguments", () => {
+  assert.equal(parseArguments(["--format", "json"]).format, "json");
+  assert.deepEqual(parseArguments(["--workspace", "/tmp/work", "--repo-root", "/tmp/repo"]), {
+    workspace: "/tmp/work",
+    repoRoot: "/tmp/repo",
+    format: "text",
+  });
+  assert.throws(() => parseArguments(["--format", "yaml"]), /invalid --format value/u);
+  assert.throws(() => parseArguments(["--workspace"]), /missing --workspace value/u);
+  assert.throws(() => parseArguments(["--unknown"]), /invalid readiness argument/u);
+});
+
+test("control readiness CLI reads workspace state without creating preview files", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "yukh-readiness-empty-workspace-"));
+  const report = await createReadinessReport(
+    { repoRoot: process.cwd(), workspace, format: "text" },
+    okRuntime,
+  );
+
+  assert.equal(report.outcome, "blocked");
+  assert.equal(report.gates.find((gate) => gate.gate === "provider_adapter")?.status, "blocked");
+  assert.equal(existsSync(join(workspace, ".yukh")), false);
+});
+
+test("control readiness CLI reports ready when provider adapter exists", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "yukh-readiness-ready-workspace-"));
+  await mkdir(join(workspace, ".yukh", "control-plane"), { recursive: true });
+  await writeFile(
+    join(workspace, ".yukh", "control-plane", "plan-previews.json"),
+    JSON.stringify({
+      schema: 1,
+      previews: [],
+      provider_adapters: [
+        {
+          schema: 1,
+          provider_adapter_id: "provider-adapter-preview",
+          provider: "Codex SDK, planned",
+          adapter_kind: "sdk",
+          models: ["codex-sdk-default"],
+          max_run_token_budget: 120000,
+          command_policy: "bounded_control_plane_only",
+          configured_at: "2026-08-20T00:00:00.000Z",
+        },
+      ],
+    }),
+  );
+
+  const report = await createReadinessReport(
+    { repoRoot: process.cwd(), workspace, format: "text" },
+    okRuntime,
+  );
+
+  assert.equal(report.outcome, "ready-for-micro-task");
+  assert.equal(report.gates.find((gate) => gate.gate === "provider_adapter")?.status, "pass");
+  assert.equal(report.gates.find((gate) => gate.gate === "worker_activity")?.status, "warning");
+  assert.match(renderReadinessText(report), /Yukh real project readiness: ready-for-micro-task/u);
+  assert.doesNotMatch(JSON.stringify(report), /GH_TOKEN|secret|credential|private/iu);
+});

--- a/test/supply-chain/workflows.test.mjs
+++ b/test/supply-chain/workflows.test.mjs
@@ -116,6 +116,13 @@ test("Yukh Projects shadow policy is versioned with its workflow", () => {
   assert.doesNotMatch(source, /^  area:\n    project_field: Component$/mu);
   assert.match(source, /^  status:\n    project_field: Status\n    derived: true$/mu);
   assert.match(source, /^  overwrite_human_values: false$/mu);
+  assert.match(source, /^real_use:\n  first_micro_task:$/mu);
+  assert.match(source, /^    max_team_token_budget: 120000$/mu);
+  assert.match(source, /^    max_worker_count: 2$/mu);
+  assert.match(source, /^    strategy: feature_branch_pr$/mu);
+  assert.match(source, /^    require_human_merge_approval: true$/mu);
+  assert.match(source, /^    - token_usage_recorded$/mu);
+  assert.doesNotMatch(source, /GH_TOKEN|github-token|https?:\/\//iu);
 });
 
 test("Yukh Projects controlled-apply contract remains inert", () => {


### PR DESCRIPTION
## Summary
- add a read-only real project readiness endpoint for Control Plane preview
- surface project/runtime/provider/activity gates in the UI
- codify first real micro-task policy, token budget and DoD in .yukh/project.yaml
- add yukh control readiness for scriptable readiness checks without opening the UI

## Tests
- npm run typecheck
- npm run format:check
- node --import tsx --test test/runtime/control-plane-preview.test.ts --test-name-pattern 'real project readiness|preview runtime|launch readiness|runtime topology|bounded text'
- node --import tsx --test test/runtime/control-plane-readiness-cli.test.ts
- node --test test/supply-chain/workflows.test.mjs test/supply-chain/project-area-contract.test.mjs
- npm run build
- git diff --check