### PR TITLE
Add local suite compose preview

### DIFF
--- a/.context/rfcs/RFC-0026-local-suite-compose-preview.md
+++ b/.context/rfcs/RFC-0026-local-suite-compose-preview.md
@@ -1,0 +1,77 @@
+# RFC-0026 — Local suite Compose preview
+
+- Status: Accepted
+- Authors: Nomed with Codex implementation support
+- Created: 2026-08-20
+- Accepted: 2026-08-20
+- Decider: project owner
+- Governing issue: pending
+- Depends on: RFC-0017, RFC-0020, RFC-0025
+
+## Decision
+
+Add a local Docker Compose profile that starts the services an operator needs to
+open the Control Plane and inspect the local Yukh runtime from a browser:
+
+- NATS JetStream;
+- Yukh Coordination preview coordinator;
+- inert Yukh MCP gateway;
+- Yukh Control Plane preview UI.
+
+The profile is a local preview topology. It is not a production deployment and
+does not broaden gateway authority.
+
+## Boundaries
+
+The Compose profile may create local Docker volumes for:
+
+- preview Coordination runtime material;
+- JetStream data;
+- Control Plane workspace state.
+
+The profile must not bake credentials into images or repository files. Runtime
+TLS, supervisor token and receipt signing material are generated inside a local
+Compose volume by a one-shot init service.
+
+The Control Plane runtime check is container-native. It verifies the Compose
+runtime from inside the Compose network and must not require Docker access from
+inside the Control Plane container.
+
+## Worker execution
+
+The Compose profile starts runtime and UI only. Real Codex/Copilot worker
+execution remains a separate provider-runner concern. The next accepted
+increment must choose one of:
+
+- SDK-based workers running inside containers with explicit credential delivery;
+- an explicit host runner bridge with bounded authority and observable events.
+
+Until that increment exists, the Compose profile can show readiness, plans,
+receipts and worker activity events, but it must not claim to provide complete
+autonomous code patch delivery.
+
+## Security impact
+
+New exposed local ports bind to `127.0.0.1` only. The gateway remains inert.
+Coordination remains local-preview scoped. JetStream is a local shared runtime
+for preview streams and projections.
+
+Residual risks are local resource use, stale Docker volumes and confusion
+between “runtime/UI is up” and “workers can produce patches.” The UI and docs
+must state that real worker execution is still pending.
+
+## Qualification
+
+- Compose config renders successfully.
+- Control Plane image contains the compose runtime check and project policy.
+- Static tests assert local-only ports and the worker execution limitation.
+- Existing typecheck, runtime, supply-chain and build tests remain green.
+
+## Rollback
+
+Remove `compose.suite.yaml`, the compose runtime check script and this RFC. Stop
+and remove local state with:
+
+```bash
+docker compose -f compose.suite.yaml down --volumes --remove-orphans
+```

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,9 @@
 .git
 .github
+!.github
+!.github/scripts
+.github/scripts/*
+!.github/scripts/check-compose-runtime.mjs
 .context
 coverage
 dist

--- a/.github/scripts/check-compose-runtime.mjs
+++ b/.github/scripts/check-compose-runtime.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import { connect } from "node:net";
+import { URL } from "node:url";
+
+const runtime = process.env.YUKH_PREVIEW_RUNTIME ?? "/run/yukh";
+const natsUrl = process.env.YUKH_NATS_URL ?? "nats://nats:4222";
+const supervisorUrl =
+  process.env.YUKH_COORDINATION_SUPERVISOR_URL ??
+  "https://coordinator:7444/local-preview/v1/config";
+const problems = [];
+const warnings = [];
+const checks = new Map();
+
+const report = (line) => {
+  process.stdout.write(`${line}\n`);
+};
+const problem = (message) => {
+  problems.push(message);
+  report(`problem: ${message}`);
+};
+const warning = (message) => {
+  warnings.push(message);
+  report(`warning: ${message}`);
+};
+
+const tcpReachable = async (url) =>
+  new Promise((resolve) => {
+    const parsed = new URL(url);
+    const socket = connect(
+      {
+        host: parsed.hostname,
+        port: Number.parseInt(parsed.port || "4222", 10),
+        timeout: 2000,
+      },
+      () => {
+        socket.destroy();
+        resolve(true);
+      },
+    );
+    socket.once("error", () => resolve(false));
+    socket.once("timeout", () => {
+      socket.destroy();
+      resolve(false);
+    });
+  });
+
+report("yukh-preview-runtime-check");
+report(`runtime: ${runtime}`);
+report("launcher: compose-local-suite");
+checks.set("runtime_mode", "compose-volume");
+
+for (const file of [
+  "coordinator.json",
+  "server.crt",
+  "server.key",
+  "supervisor.token",
+  "receipt-signing.key",
+]) {
+  try {
+    await readFile(`${runtime}/${file}`);
+    checks.set(file, "present");
+  } catch {
+    problem(`missing ${runtime}/${file}`);
+  }
+}
+
+checks.set("nats_url", natsUrl);
+if (await tcpReachable(natsUrl)) {
+  checks.set("nats", "ok");
+} else {
+  problem(`NATS unavailable at ${natsUrl}`);
+}
+
+checks.set("coordination_supervisor_url", supervisorUrl);
+const parsedSupervisor = new URL(supervisorUrl);
+const supervisorTcpUrl = `tcp://${parsedSupervisor.hostname}:${parsedSupervisor.port || "7444"}`;
+if (await tcpReachable(supervisorTcpUrl)) {
+  checks.set("coordination_supervisor_tcp", "ok");
+} else {
+  warning(`Coordination supervisor TCP endpoint unavailable at ${supervisorTcpUrl}`);
+}
+
+for (const [key, value] of checks) report(`${key}: ${value}`);
+
+if (problems.length > 0) {
+  report("status: attention-required");
+  process.exit(2);
+}
+if (warnings.length > 0) {
+  report("status: ok-with-warnings");
+} else {
+  report("status: ok");
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ WORKDIR /app
 COPY --from=build --chown=node:node /workspace/package.json /workspace/package-lock.json ./
 COPY --from=build --chown=node:node /workspace/node_modules ./node_modules
 COPY --from=build --chown=node:node /workspace/dist ./dist
+COPY --chown=node:node --chmod=0755 .github/scripts/check-compose-runtime.mjs ./.github/scripts/check-compose-runtime.mjs
+COPY --chown=node:node .yukh/project.yaml ./.yukh/project.yaml
 USER node
 EXPOSE 3000
 CMD ["node", "dist/apps/gateway/src/main.js"]

--- a/apps/control-plane-preview/src/preview-runtime-status.ts
+++ b/apps/control-plane-preview/src/preview-runtime-status.ts
@@ -85,7 +85,9 @@ export function createPreviewRuntimeCheck(
 ): PreviewRuntimeCheck {
   const repoRoot = options.repoRoot ?? process.cwd();
   const timeoutMs = options.timeoutMs ?? 5_000;
-  const script = join(repoRoot, ".github", "scripts", "check-preview-runtime.sh");
+  const script =
+    process.env.YUKH_PREVIEW_RUNTIME_CHECK_SCRIPT ??
+    join(repoRoot, ".github", "scripts", "check-preview-runtime.sh");
 
   return () => {
     const checkedAt = new Date().toISOString();

--- a/compose.suite.yaml
+++ b/compose.suite.yaml
@@ -1,0 +1,143 @@
+name: yukh-local-suite
+
+services:
+  preview-init:
+    image: alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
+    command:
+      - /bin/sh
+      - -euc
+      - |
+        apk add --no-cache openssl >/dev/null
+        install -d -m 0700 /run/yukh
+        [ -f /run/yukh/server.key ] || openssl req -x509 -newkey rsa:3072 -sha256 -nodes -days 2 \
+          -keyout /run/yukh/server.key \
+          -out /run/yukh/server.crt \
+          -subj "/CN=localhost" \
+          -addext "subjectAltName=DNS:localhost,DNS:coordinator,IP:127.0.0.1" >/dev/null 2>&1
+        [ -f /run/yukh/supervisor.token ] || openssl rand -base64 32 > /run/yukh/supervisor.token
+        [ -f /run/yukh/receipt-signing.key ] || openssl rand 32 > /run/yukh/receipt-signing.key
+        cat > /run/yukh/coordinator.json <<'JSON'
+        {"profile":"yukh-coordination/local-preview-runtime-v1","public_base_uri":"https://127.0.0.1:7443","public_bind":"0.0.0.0:7443","supervisor_bind":"0.0.0.0:7444","nats_url":"nats://nats:4222","tls_certificate":"/run/yukh/server.crt","tls_private_key":"/run/yukh/server.key","supervisor_token":"/run/yukh/supervisor.token","receipt_signing_key":"/run/yukh/receipt-signing.key"}
+        JSON
+        chmod 0600 /run/yukh/*
+    volumes:
+      - preview-runtime:/run/yukh
+    restart: "no"
+
+  nats:
+    image: nats:2.12.0-alpine@sha256:5ef5cab0ec8057c0b2017e0579f1de7ff01c9ef6d506b07cfef1e63037854776
+    command: ["--jetstream", "--store_dir", "/data", "--name", "yukh-local-suite"]
+    ports:
+      - "127.0.0.1:14222:4222"
+    volumes:
+      - jetstream:/data
+    healthcheck:
+      test: ["CMD", "/bin/sh", "-c", "kill -0 1"]
+      interval: 2s
+      timeout: 1s
+      retries: 15
+    restart: "no"
+
+  coordinator:
+    build:
+      context: ${YUKH_COORDINATION_REPO:-../yukh-coordination}
+      dockerfile: .github/preview/Dockerfile.coordinator
+    command: ["/run/yukh/coordinator.json"]
+    depends_on:
+      preview-init:
+        condition: service_completed_successfully
+      nats:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:7443:7443"
+      - "127.0.0.1:7444:7444"
+    volumes:
+      - preview-runtime:/run/yukh:ro
+    read_only: true
+    tmpfs:
+      - /tmp:size=16m,mode=0700
+    security_opt:
+      - no-new-privileges:true
+    cap_drop: [ALL]
+    restart: "no"
+
+  gateway:
+    build:
+      context: .
+    environment:
+      YUKH_HOST: 0.0.0.0
+      YUKH_ALLOWED_HOSTS: localhost,127.0.0.1
+    ports:
+      - "127.0.0.1:3000:3000"
+    read_only: true
+    tmpfs:
+      - /tmp:size=16m,mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 128
+    mem_limit: 256m
+    cpus: 1.0
+    restart: "no"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:3000/readyz').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+
+  control-plane:
+    build:
+      context: .
+    command:
+      [
+        "node",
+        "dist/apps/control-plane-preview/src/main.js",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "7345",
+        "--workspace",
+        "/workspace",
+      ]
+    depends_on:
+      coordinator:
+        condition: service_started
+      nats:
+        condition: service_healthy
+    environment:
+      YUKH_CONVERSATION_WORKSPACE: /workspace
+      YUKH_PREVIEW_RUNTIME: /run/yukh
+      YUKH_PREVIEW_RUNTIME_CHECK_SCRIPT: /app/.github/scripts/check-compose-runtime.mjs
+      YUKH_COORDINATION_SUPERVISOR_URL: https://coordinator:7444/local-preview/v1/config
+      YUKH_NATS_URL: nats://nats:4222
+      YUKH_WORKER_ACTIVITY_JETSTREAM: "1"
+      YUKH_WORKER_ACTIVITY_CREATE_STREAM: "1"
+    ports:
+      - "127.0.0.1:7345:7345"
+    volumes:
+      - control-plane-workspace:/workspace
+      - preview-runtime:/run/yukh:ro
+    read_only: true
+    tmpfs:
+      - /tmp:size=16m,mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 128
+    mem_limit: 384m
+    cpus: 1.0
+    restart: "no"
+
+volumes:
+  control-plane-workspace:
+  jetstream:
+  preview-runtime:

--- a/docs/how-to/run-local-suite-compose.md
+++ b/docs/how-to/run-local-suite-compose.md
@@ -1,0 +1,74 @@
+# Run the local suite with Docker Compose
+
+This profile starts the local Yukh runtime needed to inspect and operate the
+Control Plane from a browser:
+
+- NATS JetStream;
+- Yukh Coordination preview coordinator;
+- inert Yukh MCP gateway;
+- Yukh Control Plane UI.
+
+It is intended for local evaluation. It does not yet containerize Codex or
+Copilot worker execution.
+
+## Prerequisites
+
+- Docker Desktop or a compatible Docker engine.
+- A sibling checkout of `nomed/yukh-coordination`, or set
+  `YUKH_COORDINATION_REPO` to its path.
+
+Expected workspace layout:
+
+```text
+yukh-workspace/
+  yukh-mcp/
+  yukh-coordination/
+```
+
+## Start
+
+From `yukh-mcp`:
+
+```bash
+docker compose -f compose.suite.yaml up -d --build
+```
+
+Open:
+
+```text
+http://127.0.0.1:7345
+```
+
+Useful endpoints:
+
+```text
+Control Plane UI: http://127.0.0.1:7345
+Gateway readyz:   http://127.0.0.1:3000/readyz
+NATS client:      127.0.0.1:14222
+Coordination:     127.0.0.1:7443
+Supervisor:       127.0.0.1:7444
+```
+
+## Check status
+
+```bash
+docker compose -f compose.suite.yaml ps
+```
+
+The Control Plane “Real project readiness” panel should report runtime and
+JetStream gates from inside the Compose network.
+
+## Stop and clean local state
+
+```bash
+docker compose -f compose.suite.yaml down --volumes --remove-orphans
+```
+
+This removes the local preview runtime volume, JetStream data and Control Plane
+workspace state created by this Compose project.
+
+## Current limit
+
+This Compose profile starts the suite runtime and UI. Real Codex/Copilot worker
+execution still needs the next provider-runner increment: either SDK-based
+workers inside containers or an explicit host runner bridge.

--- a/test/runtime/local-suite-compose.test.mjs
+++ b/test/runtime/local-suite-compose.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const compose = readFileSync(new URL("../../compose.suite.yaml", import.meta.url), "utf8");
+const dockerfile = readFileSync(new URL("../../Dockerfile", import.meta.url), "utf8");
+const check = readFileSync(
+  new URL("../../.github/scripts/check-compose-runtime.mjs", import.meta.url),
+  "utf8",
+);
+const previewRuntimeStatus = readFileSync(
+  new URL("../../apps/control-plane-preview/src/preview-runtime-status.ts", import.meta.url),
+  "utf8",
+);
+const guide = readFileSync(
+  new URL("../../docs/how-to/run-local-suite-compose.md", import.meta.url),
+  "utf8",
+);
+const rfc = readFileSync(
+  new URL("../../.context/rfcs/RFC-0026-local-suite-compose-preview.md", import.meta.url),
+  "utf8",
+);
+
+test("local suite compose starts runtime, gateway and Control Plane UI", () => {
+  for (const service of ["preview-init", "nats", "coordinator", "gateway", "control-plane"]) {
+    assert.match(compose, new RegExp(`^  ${service}:$`, "mu"));
+  }
+  assert.match(compose, /--jetstream/u);
+  assert.match(compose, /YUKH_WORKER_ACTIVITY_JETSTREAM: "1"/u);
+  assert.match(compose, /YUKH_PREVIEW_RUNTIME_CHECK_SCRIPT/u);
+  assert.match(compose, /dist\/apps\/control-plane-preview\/src\/main\.js/u);
+});
+
+test("local suite compose binds local ports only", () => {
+  for (const port of ["14222:4222", "7443:7443", "7444:7444", "3000:3000", "7345:7345"]) {
+    assert.equal(compose.includes(`"127.0.0.1:${port}"`), true, port);
+  }
+  assert.doesNotMatch(compose, /"0\.0\.0\.0:[0-9]+:/u);
+});
+
+test("Control Plane image carries compose runtime check and project policy", () => {
+  assert.match(dockerfile, /--chmod=0755 .*check-compose-runtime\.mjs/u);
+  assert.match(dockerfile, /\.yukh\/project\.yaml/u);
+  assert.match(check, /YUKH_COORDINATION_SUPERVISOR_URL/u);
+  assert.match(check, /NATS unavailable/u);
+  assert.match(check, /status: ok/u);
+  assert.match(previewRuntimeStatus, /YUKH_PREVIEW_RUNTIME_CHECK_SCRIPT/u);
+  assert.doesNotMatch(
+    check,
+    /docker ps|DOCKER_HOST|rejectUnauthorized|authorization|supervisor\.token.*console/u,
+  );
+});
+
+test("local suite docs and RFC state the current worker execution limit", () => {
+  assert.match(guide, /docker compose -f compose\.suite\.yaml up -d --build/u);
+  assert.match(guide, /http:\/\/127\.0\.0\.1:7345/u);
+  assert.match(guide, /does not yet containerize Codex or\s+Copilot worker execution/su);
+  assert.match(rfc, /^# RFC-0026 — Local suite Compose preview$/mu);
+  assert.match(rfc, /SDK-based workers running inside containers/u);
+  assert.match(rfc, /host runner bridge/u);
+});


### PR DESCRIPTION
## Summary
- add compose.suite.yaml to start NATS JetStream, Coordination preview, gateway and Control Plane UI together
- add a container-native Control Plane runtime check
- document the one-command local suite flow and record RFC-0026 boundaries

## Tests
- npm run typecheck
- npm run format:check
- node --test test/runtime/local-suite-compose.test.mjs
- node --import tsx --test test/runtime/control-plane-preview.test.ts --test-name-pattern 'runtime topology|bounded text'
- npm run build
- git diff --check
- docker compose -f compose.suite.yaml config

## Note
Docker build could not be executed on rufy-worker because this runner cannot access /var/run/docker.sock. The compose file itself validates with docker compose config.